### PR TITLE
Update Gray's skills to integer logic and add Archive Mode quiz stats popup

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1947,11 +1947,27 @@ const RPG = {
                 () => { // Success
                     this.state.quiz_stats.correct++;
                     this.state.quiz_stats.total++;
-                    this.finishWinBattle(deadMsg, gameClear);
+
+                    let correct = this.state.quiz_stats.correct;
+                    let total = this.state.quiz_stats.total;
+                    let rate = (total > 0) ? ((correct / total) * 100).toFixed(1) : "0.0";
+                    let msg = `[퀴즈 결과] 정답!<br>현재 현황: ${correct}/${total}<br>정답률: ${rate}%`;
+
+                    this.openInfoModal("퀴즈 결과", msg, () => {
+                        this.finishWinBattle(deadMsg, gameClear);
+                    });
                 },
                 () => { // Fail
                     this.state.quiz_stats.total++;
-                    this.finishWinBattle(deadMsg, gameClear);
+
+                    let correct = this.state.quiz_stats.correct;
+                    let total = this.state.quiz_stats.total;
+                    let rate = (total > 0) ? ((correct / total) * 100).toFixed(1) : "0.0";
+                    let msg = `[퀴즈 결과] 오답...<br>현재 현황: ${correct}/${total}<br>정답률: ${rate}%`;
+
+                    this.openInfoModal("퀴즈 결과", msg, () => {
+                        this.finishWinBattle(deadMsg, gameClear);
+                    });
                 }
             );
             return;

--- a/card/logic.js
+++ b/card/logic.js
@@ -208,11 +208,11 @@ const Logic = {
                      // Actually, let's use 1 decimal place precision logic or just float.
                      // For consistency with existing random_mult which does integer steps if min/max are integers?
                      // Let's just do random float.
-                     mult = min + Math.random() * (max - min);
+                     mult = min + Math.floor(Math.random() * (max - min + 1));
                      logFn(`무작위 위력! x${mult.toFixed(1)}`);
                 }
                 else if(eff.type === 'delayed_random_attack') {
-                     mult = eff.min + Math.random() * (eff.max - eff.min);
+                     mult = eff.min + Math.floor(Math.random() * (eff.max - eff.min + 1));
                      logFn(`무작위 위력! x${mult.toFixed(1)}`);
                 }
             });


### PR DESCRIPTION
1. Modified `card/logic.js` to change `random_mult_moon_boost` and `delayed_random_attack` to use `Math.floor` and inclusive ranges, ensuring integer multipliers (e.g., 3~6 instead of 3.0~6.0 floats).
2. Modified `card/index.html` to display a popup with quiz statistics (Correct/Total, Accuracy%) after every quiz in Archive Mode, before proceeding to the battle result or next stage.

---
*PR created automatically by Jules for task [6249934548822620013](https://jules.google.com/task/6249934548822620013) started by @romarin0325-cell*