### PR TITLE
Add Chaos/Draft Modes and Fix Archive Bug

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -125,9 +125,13 @@
         <div id="next-enemy-preview" style="text-align:center; padding: 10px; background: #222; border-radius: 5px; margin-bottom: 10px; border: 1px solid #444; color: #ffcc80;">
              다음 상대: ?
         </div>
-        <div style="display:flex; gap:5px; margin-bottom:10px;">
+        <div id="menu-gacha-area" style="display:flex; gap:5px; margin-bottom:10px;">
             <button class="menu-btn" onclick="RPG.openGacha()" style="flex:1;">일반 뽑기 (1장)</button>
             <button class="menu-btn" onclick="RPG.openChallengeGacha()" style="flex:1; border-color:#e040fb; color:#e040fb;">도전 뽑기</button>
+        </div>
+        <div id="menu-draft-area" style="display:none; margin-bottom:10px;">
+            <button class="menu-btn" onclick="RPG.startDraft()" style="border-color:#00e676; color:#00e676;">덱 빌딩 (드래프트)</button>
+            <div style="font-size:0.8rem; color:#aaa; margin-top:5px; text-align:center;">* 이번 전투에 사용할 3명을 선발하세요.</div>
         </div>
         <button class="menu-btn" onclick="RPG.openDeck()">덱 구성</button>
         <button class="menu-btn" onclick="RPG.openCollection()">카드 확인</button>
@@ -135,6 +139,19 @@
         <button class="menu-btn" onclick="RPG.openChaosBlessing()" style="border-color: #ffd700; color: #ffd700;">축복의 제단</button>
         <button class="menu-btn" onclick="RPG.startBattleInit()" style="background:#b71c1c; border-color:#f44336;">전투 진입</button>
         <button class="menu-btn" onclick="RPG.openSystemMenu()">메뉴</button>
+    </div>
+    <div id="screen-draft" class="screen">
+        <h3>덱 빌딩 (<span id="draft-round-text">선봉</span> 선발)</h3>
+        <div style="text-align:center; margin-bottom:10px;">
+            남은 리롤: <span id="draft-reroll-cnt" style="color:#ffd700">3</span>회
+        </div>
+
+        <div id="draft-grid" style="display:grid; grid-template-columns: 1fr 1fr; gap:10px; padding:10px; overflow-y:auto; flex:1;"></div>
+
+        <div style="margin-top:auto; margin-bottom: 20px;">
+            <button class="menu-btn" onclick="RPG.rerollDraft()" style="background:#333; border-color:#ff9800; color:#ff9800;">리롤 (새로고침)</button>
+            <button class="menu-btn" onclick="RPG.toMenu()" style="margin-top:5px;">나가기</button>
+        </div>
     </div>
     <div id="screen-collection" class="screen">
         <div style="display:flex; justify-content:space-between; align-items:center;"><h3>카드 목록</h3><button onclick="RPG.toMenu()" style="padding:5px;">뒤로</button></div>
@@ -455,7 +472,9 @@ const RPG = {
             { id: 'overdrive', name: '오버드라이브', desc: '초기 10장, 클리어 보상 +1장, 축복 카드 +1장.\n(성공조건: 30 스테이지)' },
             { id: 'archive', name: '아카이브', desc: '매 스테이지 종료 후 문법 퀴즈. 정답률 90% 이상 필요.\n(성공조건: 24 스테이지)' },
             { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배.\n(성공조건: 36 스테이지)' },
-            { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배.\n(성공조건: 36 스테이지)' }
+            { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배.\n(성공조건: 36 스테이지)' },
+            { id: 'chaos', name: '카오스', desc: '매 전투 덱/인벤토리 초기화. 무작위 20장 풀에서 뽑기 진행.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+            { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 18 스테이지 / 패배 시 데이터 삭제)' }
         ];
 
         MODES.forEach(m => {
@@ -517,7 +536,9 @@ const RPG = {
             activeChaosBlessing: [],
             activeSageBlessing: [],
             wrongWords: [],
-            quiz_stats: { correct: 0, total: 0 }
+            quiz_stats: { correct: 0, total: 0 },
+            chaosPool: [],
+            draft: { active: false, round: 0, rerolls: 3, currentOptions: [] }
         };
 
         // Load persistent wordbook
@@ -568,6 +589,15 @@ const RPG = {
         const enemyIdx = this.state.enemyScale % ENEMIES.length;
         const nextName = ENEMIES[enemyIdx].name;
         document.getElementById('next-enemy-preview').innerText = `다음 상대: ${nextName} (Stage ${this.state.enemyScale + 1})`;
+
+        // Draft Mode Toggle
+        if (this.state.mode === 'draft') {
+            document.getElementById('menu-gacha-area').style.display = 'none';
+            document.getElementById('menu-draft-area').style.display = 'block';
+        } else {
+            document.getElementById('menu-gacha-area').style.display = 'flex';
+            document.getElementById('menu-draft-area').style.display = 'none';
+        }
     },
     toTitle() {
         // No saveRecord here
@@ -859,6 +889,36 @@ const RPG = {
         let rand = Math.random();
         let grade = 'normal';
         const mode = this.state.mode;
+
+        // Chaos Mode Override
+        if (mode === 'chaos') {
+            if (!this.state.chaosPool || this.state.chaosPool.length === 0) {
+                 // Should have been generated in winBattle or initNewGame, but fallback
+                 let allCards = [...CARDS];
+                 if (this.global.unlocked_bonus_cards) {
+                     const unlocked = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                     allCards = allCards.concat(unlocked);
+                 }
+                 allCards.sort(() => Math.random() - 0.5);
+                 this.state.chaosPool = allCards.slice(0, 20).map(c => c.id);
+            }
+            const pickId = this.state.chaosPool[Math.floor(Math.random() * this.state.chaosPool.length)];
+            const pick = this.getCardData(pickId);
+            this.state.inventory.push(pick.id);
+
+            const modal = document.getElementById('modal-gacha');
+            const content = document.getElementById('gacha-result');
+            let color = '#bdbdbd';
+            if(pick.grade === 'legend') color = '#ff5252';
+            else if(pick.grade === 'epic') color = '#e040fb';
+            else if(pick.grade === 'rare') color = '#448aff';
+
+            document.getElementById('gacha-title').innerText = "카오스 뽑기 성공!";
+            content.innerHTML = `<div style="color:${color}; font-size:1.2rem; font-weight:bold; margin-bottom:10px;">[${pick.grade.toUpperCase()}] ${pick.name}</div>
+            <div class="portrait" style="width:120px; height:160px; margin:0 auto;"><img src="${pick.name}.png" onerror="this.style.display='none'"></div><p>새로운 동료를 얻었습니다!</p>`;
+            modal.classList.add('active');
+            return;
+        }
 
         // Determine Grade
         if (mode === 'restriction') {
@@ -1883,6 +1943,120 @@ const RPG = {
         return 1.0;
     },
 
+    // --- Draft Logic ---
+    startDraft() {
+        if(this.state.deck.every(x => x !== null)) {
+            return this.showAlert("이미 덱이 완성되어 있습니다. 전투에 진입하세요.");
+        }
+
+        if(!this.state.draft) this.state.draft = { active: true, round: 0, rerolls: 3, currentOptions: [] };
+
+        // Find first empty slot
+        this.state.draft.round = this.state.deck.indexOf(null);
+        if(this.state.draft.round === -1) {
+            this.state.draft.round = 0;
+        }
+
+        this.showScreen('screen-draft');
+        this.renderDraftScreen();
+    },
+
+    renderDraftScreen() {
+        const d = this.state.draft;
+        const roles = ['선봉', '중견', '대장'];
+        let roundText = roles[d.round] + ` (${d.round + 1}/3)`;
+        document.getElementById('draft-round-text').innerText = roundText;
+        document.getElementById('draft-reroll-cnt').innerText = d.rerolls;
+
+        if(!d.currentOptions || d.currentOptions.length === 0) {
+            this.generateDraftOptions();
+        }
+
+        const grid = document.getElementById('draft-grid');
+        grid.innerHTML = "";
+
+        d.currentOptions.forEach(id => {
+            const card = this.getCardData(id);
+            const el = document.createElement('div');
+            let color = '#bdbdbd';
+            if(card.grade === 'legend') color = '#ff5252';
+            else if(card.grade === 'epic') color = '#e040fb';
+            else if(card.grade === 'rare') color = '#448aff';
+
+            el.className = `card-item ${card.grade}`;
+            el.style.height = "160px";
+            el.style.display = "flex";
+            el.style.flexDirection = "column";
+            el.style.borderColor = color;
+
+            el.innerHTML = `
+                <div style="font-size:0.9rem; font-weight:bold; margin-bottom:5px; color:${color}">${card.name}</div>
+                <div class="portrait" style="flex:1; margin-bottom:5px; width:100%;"><img src="${card.name}.png" onerror="this.style.display='none'"></div>
+                <div style="display:flex; gap:2px; width:100%;">
+                    <button onclick="event.stopPropagation(); RPG.showCardInfo('${card.id}')" style="flex:1; font-size:0.7rem; padding:3px; background:#444; color:#fff; border:1px solid #666;">상세</button>
+                    <button onclick="event.stopPropagation(); RPG.selectDraftCard('${card.id}')" style="flex:2; font-size:0.7rem; padding:3px; background:#1b5e20; color:#fff; border:1px solid #4caf50;">선택</button>
+                </div>
+            `;
+            grid.appendChild(el);
+        });
+    },
+
+    generateDraftOptions() {
+        let pool = [...CARDS];
+        if (this.global.unlocked_bonus_cards) {
+            const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+            pool = pool.concat(bonus);
+        }
+
+        let options = [];
+        for(let i=0; i<4; i++) {
+            const pick = pool[Math.floor(Math.random() * pool.length)];
+            options.push(pick.id);
+        }
+        this.state.draft.currentOptions = options;
+    },
+
+    selectDraftCard(id) {
+        this.state.inventory.push(id);
+        this.state.deck[this.state.draft.round] = id;
+
+        // Clear options for next round
+        this.state.draft.currentOptions = [];
+
+        if (this.state.deck.indexOf(null) === -1) {
+            this.showAlert("덱 구성 완료!");
+            this.toMenu();
+        } else {
+            this.startDraft();
+        }
+    },
+
+    rerollDraft() {
+        if (this.state.draft.rerolls > 0) {
+            this.state.draft.rerolls--;
+            this.state.draft.currentOptions = [];
+            this.renderDraftScreen();
+        } else {
+            if (this.state.tickets > 0) {
+                this.showConfirm(`무료 리롤 횟수가 없습니다.<br>티켓 1장을 사용하여 리롤하시겠습니까?<br>(보유 티켓: ${this.state.tickets})`, () => {
+                    this.state.tickets--;
+                    document.getElementById('ui-tickets').innerText = this.state.tickets;
+                    this.state.draft.currentOptions = [];
+                    this.renderDraftScreen();
+                });
+            } else {
+                this.showAlert("리롤 횟수와 티켓이 모두 부족합니다.");
+            }
+        }
+    },
+
+    resetDraftState() {
+        // Called when initializing new draft cycle
+        this.state.inventory = [];
+        this.state.deck = [null, null, null];
+        this.state.draft = { active: true, round: 0, rerolls: 3, currentOptions: [] };
+    },
+
     handlePermadeath(players) {
         let deadNames = [];
         players.forEach(p => {
@@ -1924,6 +2098,8 @@ const RPG = {
         let clearStage = 24;
         if (mode === 'overdrive') clearStage = 30;
         if (mode === 'curse' || mode === 'flood') clearStage = 36;
+        if (mode === 'chaos') clearStage = 24;
+        if (mode === 'draft') clearStage = 18;
         if (mode === 'origin') clearStage = Infinity;
 
         let gameClear = false;
@@ -1931,14 +2107,27 @@ const RPG = {
             gameClear = true;
         }
 
-        // Archive Mode: Mandatory Quiz
-        if (mode === 'archive') {
-            // Need to pass stats? We don't have per-battle stats easily accessible for "accuracy > 90%" unless we track it.
-            // Requirement: "Archive: Mandatory grammar quiz after stage. Clear if > 90% accuracy at stage 24."
-            // We need to track quiz accuracy.
-            // Let's add stats to this.state.quiz_stats
+        // Chaos/Draft: Reset Deck/Inventory
+        if (mode === 'chaos') {
+            this.state.inventory = [];
+            this.state.deck = [null, null, null];
 
-            // Trigger Quiz immediately
+            let allCards = [...CARDS];
+            if (this.global.unlocked_bonus_cards) {
+                const unlocked = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                allCards = allCards.concat(unlocked);
+            }
+            allCards.sort(() => Math.random() - 0.5);
+            this.state.chaosPool = allCards.slice(0, 20).map(c => c.id);
+            // this.showAlert("카오스 모드: 카드 풀이 재설정되고 덱이 초기화되었습니다."); // Will be shown in openInfoModal or handled silently
+        }
+
+        if (mode === 'draft') {
+            this.resetDraftState();
+        }
+
+        // Archive Mode: Mandatory Quiz (Direct to finishWinBattle via callback)
+        if (mode === 'archive') {
             let allQuizzes = [];
             GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
             let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
@@ -1947,37 +2136,33 @@ const RPG = {
                 () => { // Success
                     this.state.quiz_stats.correct++;
                     this.state.quiz_stats.total++;
-
-                    let correct = this.state.quiz_stats.correct;
-                    let total = this.state.quiz_stats.total;
-                    let rate = (total > 0) ? ((correct / total) * 100).toFixed(1) : "0.0";
-                    let msg = `[퀴즈 결과] 정답!<br>현재 현황: ${correct}/${total}<br>정답률: ${rate}%`;
-
-                    this.openInfoModal("퀴즈 결과", msg, () => {
-                        this.finishWinBattle(deadMsg, gameClear);
-                    });
+                    this.finishWinBattle(deadMsg, gameClear, true);
                 },
                 () => { // Fail
                     this.state.quiz_stats.total++;
-
-                    let correct = this.state.quiz_stats.correct;
-                    let total = this.state.quiz_stats.total;
-                    let rate = (total > 0) ? ((correct / total) * 100).toFixed(1) : "0.0";
-                    let msg = `[퀴즈 결과] 오답...<br>현재 현황: ${correct}/${total}<br>정답률: ${rate}%`;
-
-                    this.openInfoModal("퀴즈 결과", msg, () => {
-                        this.finishWinBattle(deadMsg, gameClear);
-                    });
+                    this.finishWinBattle(deadMsg, gameClear, false);
                 }
             );
             return;
         }
 
-        this.finishWinBattle(deadMsg, gameClear);
+        this.finishWinBattle(deadMsg, gameClear, null);
     },
 
-    finishWinBattle(deadMsg, gameClear) {
+    finishWinBattle(deadMsg, gameClear, quizResult) {
         let msg = "승리!<br>보상을 획득했습니다.";
+
+        if (quizResult !== null) {
+            let correct = this.state.quiz_stats.correct;
+            let total = this.state.quiz_stats.total;
+            let rate = (total > 0) ? ((correct / total) * 100).toFixed(1) : "0.0";
+            let resultMsg = quizResult ? "<span style='color:#4caf50'>정답!</span>" : "<span style='color:#ef5350'>오답...</span>";
+            msg = `[퀴즈 결과] ${resultMsg}<br>현황: ${correct}/${total} (${rate}%)<hr>` + msg;
+        }
+
+        if (this.state.mode === 'chaos') msg += "<br><br>카오스 모드: 덱과 인벤토리가 초기화되었습니다.";
+        if (this.state.mode === 'draft') msg += "<br><br>드래프트 모드: 덱과 인벤토리가 초기화되었습니다.";
+
         if (deadMsg) msg += "<br><br>" + deadMsg;
 
         if (gameClear) {
@@ -2019,11 +2204,7 @@ const RPG = {
         }
 
         this.openInfoModal("전투 결과", msg, () => {
-             // Creator God Bonus Check (Keep for non-archive modes or just generic?)
-             // User request mentions Archive replaces reward logic or just forced quiz.
-             // I'll keep the optional quiz for non-Archive modes.
-
-             if (this.state.mode !== 'archive') {
+             if (this.state.mode !== 'archive' && this.state.mode !== 'chaos' && this.state.mode !== 'draft') {
                  if (this.battle.enemy.id === 'creator_god') {
                      this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 뽑기권 3장 획득)",
                         () => { // Yes
@@ -2075,6 +2256,20 @@ const RPG = {
 
     loseBattle() {
         // No saveRecord here (User request: only on New Game)
+
+        if (['chaos', 'draft'].includes(this.state.mode)) {
+             this.saveRecord();
+        }
+
+        if (['chaos', 'draft'].includes(this.state.mode)) {
+             localStorage.removeItem('cardRpgSave');
+
+             let msg = "패배했습니다...<br>이 모드는 패배 시 데이터가 초기화됩니다.";
+             this.openInfoModal("Game Over", msg, () => {
+                 this.toTitle();
+             });
+             return;
+        }
 
         // Reset Chaos Blessing
         this.state.chaosBlessingUses = 3;


### PR DESCRIPTION
This PR introduces two new game modes (Chaos and Draft) with Roguelike mechanics (deck reset, permadeath) and fixes a critical UI bug in Archive Mode.

1.  **Archive Mode Fix**: Modified `RPG.winBattle` to execute the grammar quiz callback *before* opening the result modal, passing the result to `RPG.finishWinBattle`. This prevents nested/looping modals.
2.  **Chaos Mode**: Added logic to `winBattle` to reset the deck and generate a random pool of 20 cards. Modified `runGacha` to draw from this pool uniformly. Added permadeath logic to `loseBattle`.
3.  **Draft Mode**: Added a new "Draft" screen and logic. Replaces Gacha buttons with a Draft button in the menu when active. Implemented a 3-stage draft process with rerolls. Added permadeath logic.
4.  **UI Updates**: Added necessary HTML structures for Draft mode and updated Menu visibility toggles.
5.  **Permadeath**: `loseBattle` now deletes `cardRpgSave` from `localStorage` if in Chaos or Draft mode.

---
*PR created automatically by Jules for task [4516107988327017697](https://jules.google.com/task/4516107988327017697) started by @romarin0325-cell*