### PR TITLE
Fix Chaos Mode Logic and Draft/Deck UI Issues

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -148,7 +148,7 @@
 
         <div id="draft-grid" style="display:grid; grid-template-columns: 1fr 1fr; gap:10px; padding:10px; overflow-y:auto; flex:1;"></div>
 
-        <div style="margin-top:auto; margin-bottom: 20px;">
+        <div style="margin-top:auto; margin-bottom: 40px; padding-bottom: 10px;">
             <button class="menu-btn" onclick="RPG.rerollDraft()" style="background:#333; border-color:#ff9800; color:#ff9800;">리롤 (새로고침)</button>
             <button class="menu-btn" onclick="RPG.toMenu()" style="margin-top:5px;">나가기</button>
         </div>
@@ -158,7 +158,10 @@
         <div id="collection-grid" class="card-grid"></div>
     </div>
     <div id="screen-deck" class="screen">
-        <h3>덱 구성</h3>
+        <div style="display:flex; justify-content:space-between; align-items:center;">
+            <h3>덱 구성</h3>
+            <button class="menu-btn" onclick="RPG.toMenu()" style="width:auto; padding:5px 15px; margin:0; font-size:0.8rem;">뒤로</button>
+        </div>
         <div style="margin-bottom:10px;">
             <div id="slot-0" class="deck-slot" onclick="RPG.selectDeckSlot(0)">선봉 (클릭하여 선택)</div>
             <div id="slot-1" class="deck-slot" onclick="RPG.selectDeckSlot(1)">중견 (클릭하여 선택)</div>
@@ -523,6 +526,7 @@ const RPG = {
 
         let initTickets = 20;
         if (mode === 'suffering' || mode === 'overdrive') initTickets = 10;
+        if (mode === 'chaos') initTickets = 0;
 
         this.state = {
             mode: mode,
@@ -540,6 +544,19 @@ const RPG = {
             chaosPool: [],
             draft: { active: false, round: 0, rerolls: 3, currentOptions: [] }
         };
+
+        if (mode === 'chaos') {
+            let allCards = [...CARDS];
+            if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
+                const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                allCards = allCards.concat(bonus);
+            }
+            allCards.sort(() => Math.random() - 0.5);
+            const picks = allCards.slice(0, 20).map(c => c.id);
+
+            this.state.chaosPool = picks;
+            this.state.inventory = [...picks];
+        }
 
         // Load persistent wordbook
         const vocab = localStorage.getItem('cardRpgVocab');
@@ -891,6 +908,7 @@ const RPG = {
         const mode = this.state.mode;
 
         // Chaos Mode Override
+        /*
         if (mode === 'chaos') {
             if (!this.state.chaosPool || this.state.chaosPool.length === 0) {
                  // Should have been generated in winBattle or initNewGame, but fallback
@@ -919,6 +937,7 @@ const RPG = {
             modal.classList.add('active');
             return;
         }
+        */
 
         // Determine Grade
         if (mode === 'restriction') {
@@ -2118,8 +2137,10 @@ const RPG = {
                 allCards = allCards.concat(unlocked);
             }
             allCards.sort(() => Math.random() - 0.5);
-            this.state.chaosPool = allCards.slice(0, 20).map(c => c.id);
-            // this.showAlert("카오스 모드: 카드 풀이 재설정되고 덱이 초기화되었습니다."); // Will be shown in openInfoModal or handled silently
+
+            const nextPicks = allCards.slice(0, 20).map(c => c.id);
+            this.state.chaosPool = nextPicks;
+            this.state.inventory = [...nextPicks];
         }
 
         if (mode === 'draft') {
@@ -2136,11 +2157,11 @@ const RPG = {
                 () => { // Success
                     this.state.quiz_stats.correct++;
                     this.state.quiz_stats.total++;
-                    this.finishWinBattle(deadMsg, gameClear, true);
+                    setTimeout(() => this.finishWinBattle(deadMsg, gameClear, true), 200);
                 },
                 () => { // Fail
                     this.state.quiz_stats.total++;
-                    this.finishWinBattle(deadMsg, gameClear, false);
+                    setTimeout(() => this.finishWinBattle(deadMsg, gameClear, false), 200);
                 }
             );
             return;
@@ -2370,7 +2391,7 @@ const RPG = {
     },
 
     showConfirm(msg, onYes, onNo) {
-        document.getElementById('confirm-msg').innerText = msg;
+        document.getElementById('confirm-msg').innerHTML = msg;
         const modal = document.getElementById('modal-confirm');
         const btnYes = document.getElementById('confirm-yes');
         const btnNo = document.getElementById('confirm-no');


### PR DESCRIPTION
This PR addresses multiple bugs and UI issues reported by the user:
1.  **Chaos Mode Logic**:
    *   `initNewGame`: Chaos mode now correctly starts with 0 tickets and a pool of 20 random cards in the inventory.
    *   `winBattle`: After winning a battle in Chaos mode, the inventory is correctly refilled with a new set of 20 random cards.
    *   `runGacha`: Removed the override that forced Chaos mode to draw from the limited `chaosPool`. It now uses the standard gacha logic as requested.
2.  **UI/UX Fixes**:
    *   `screen-deck`: Added a "Back" button to the header.
    *   `screen-draft`: Increased bottom margin/padding to ensure the "Exit" button is fully visible.
    *   `showConfirm`: Switched to `innerHTML` to support `<br>` tags in messages.
3.  **Stability**:
    *   `winBattle` (Archive Mode): Added a 200ms delay before calling `finishWinBattle` in quiz callbacks to prevent potential modal overlapping/closing issues.

---
*PR created automatically by Jules for task [13733558315877679568](https://jules.google.com/task/13733558315877679568) started by @romarin0325-cell*