### PR TITLE
Update Quiz Rewards for Archive, Chaos, and Draft Modes

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -2158,6 +2158,7 @@ const RPG = {
                 () => { // Success
                     this.state.quiz_stats.correct++;
                     this.state.quiz_stats.total++;
+                    this.state.tickets++; // Reward Ticket
                     setTimeout(() => this.finishWinBattle(deadMsg, gameClear, true), 200);
                 },
                 () => { // Fail
@@ -2226,7 +2227,7 @@ const RPG = {
         }
 
         this.openInfoModal("전투 결과", msg, () => {
-             if (this.state.mode !== 'archive' && this.state.mode !== 'chaos' && this.state.mode !== 'draft') {
+             if (this.state.mode !== 'archive') {
                  if (this.battle.enemy.id === 'creator_god') {
                      this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 뽑기권 3장 획득)",
                         () => { // Yes


### PR DESCRIPTION
This patch updates the reward logic for Archive, Chaos, and Draft modes:
1.  **Archive Mode:** Successfully answering the mandatory grammar quiz at the end of a battle now grants +1 Draw Ticket.
2.  **Chaos & Draft Modes:** The post-battle optional Word Quiz (previously only available in Origin and other standard modes) is now enabled for Chaos and Draft modes. Answering correctly grants +1 Draw Ticket.

Verified using Playwright scripts to ensure ticket count increments correctly and modal flows appear as expected.

---
*PR created automatically by Jules for task [14140858342871016794](https://jules.google.com/task/14140858342871016794) started by @romarin0325-cell*