### PR TITLE
Add battle log for Ancient Soul Sacred Flame sanctuary boost

### DIFF
--- a/card/logic.js
+++ b/card/logic.js
@@ -180,6 +180,7 @@ const Logic = {
                          mult *= eff.mult;
                          if(source.id === 'behemoth' && skill.name === '대지분쇄') logFn("대지의 축복으로 인해 대지분쇄의 위력이 증가합니다!");
                          if(skill.name === '윈터하울링') logFn("윈터하울링: 달의 축복 조건 만족! 대미지 증가!");
+                         if(skill.name === '성염') logFn("성염: 성역 조건 만족! 대미지 2배!");
                      }
                 }
                 else if(eff.type === 'consume_burn_1_dmg') {


### PR DESCRIPTION
Added a battle log message when Ancient Soul's 'Sacred Flame' skill triggers the 2x damage multiplier under the 'Sanctuary' field buff condition. This ensures visibility of the damage boost effect in the battle log.

---
*PR created automatically by Jules for task [10904714854013891054](https://jules.google.com/task/10904714854013891054) started by @romarin0325-cell*