### PR TITLE
Add Chaos Shuffle Button and Logic for Chaos Mode

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -133,6 +133,14 @@
             <button class="menu-btn" onclick="RPG.startDraft()" style="border-color:#00e676; color:#00e676;">덱 빌딩 (드래프트)</button>
             <div style="font-size:0.8rem; color:#aaa; margin-top:5px; text-align:center;">* 이번 전투에 사용할 3명을 선발하세요.</div>
         </div>
+        <div id="menu-chaos-area" style="display:none; margin-bottom:10px;">
+            <button class="menu-btn" onclick="RPG.reshuffleChaosPool()" style="border-color:#ff5252; color:#ff5252;">
+                카오스 셔플 (티켓 1장)
+            </button>
+            <div style="font-size:0.8rem; color:#aaa; margin-top:5px; text-align:center;">
+                * 현재 보유한 20장을 모두 버리고<br>새로운 20장을 무작위로 지급합니다.
+            </div>
+        </div>
         <button class="menu-btn" onclick="RPG.openDeck()">덱 구성</button>
         <button class="menu-btn" onclick="RPG.openCollection()">카드 확인</button>
         <button class="menu-btn" onclick="RPG.openLibrary()">도서관</button>
@@ -615,13 +623,24 @@ const RPG = {
         const nextName = ENEMIES[enemyIdx].name;
         document.getElementById('next-enemy-preview').innerText = `다음 상대: ${nextName} (Stage ${this.state.enemyScale + 1})`;
 
-        // Draft Mode Toggle
+        // Mode Specific Menu Areas
+        const gachaArea = document.getElementById('menu-gacha-area');
+        const draftArea = document.getElementById('menu-draft-area');
+        const chaosArea = document.getElementById('menu-chaos-area');
+
+        // Hide all first
+        gachaArea.style.display = 'none';
+        draftArea.style.display = 'none';
+        if (chaosArea) chaosArea.style.display = 'none';
+
         if (this.state.mode === 'draft') {
-            document.getElementById('menu-gacha-area').style.display = 'none';
-            document.getElementById('menu-draft-area').style.display = 'block';
-        } else {
-            document.getElementById('menu-gacha-area').style.display = 'flex';
-            document.getElementById('menu-draft-area').style.display = 'none';
+            draftArea.style.display = 'block';
+        }
+        else if (this.state.mode === 'chaos') {
+            if (chaosArea) chaosArea.style.display = 'block';
+        }
+        else {
+            gachaArea.style.display = 'flex';
         }
     },
     toTitle() {
@@ -887,6 +906,51 @@ const RPG = {
     },
 
     // --- Gacha & Deck UI ---
+    reshuffleChaosPool() {
+        if (this.state.tickets < 1) {
+            return this.showAlert("셔플할 티켓이 부족합니다.");
+        }
+
+        this.showConfirm(
+            `현재 보유한 모든 카드와 덱 구성이 사라집니다.<br>
+            티켓 1장을 사용하여 새로운 20장을 받으시겠습니까?`,
+            () => {
+                this.state.tickets--;
+                document.getElementById('ui-tickets').innerText = this.state.tickets;
+
+                let allCards = [...CARDS];
+
+                if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
+                    const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                    allCards = allCards.concat(bonus);
+                }
+
+                allCards.sort(() => Math.random() - 0.5);
+                const newPicks = allCards.slice(0, 20).map(c => c.id);
+
+                this.state.chaosPool = newPicks;
+                this.state.inventory = [...newPicks];
+                this.state.deck = [null, null, null];
+
+                this.saveGame();
+
+                let legendCnt = 0, epicCnt = 0;
+                newPicks.forEach(id => {
+                    const c = this.getCardData(id);
+                    if(c.grade === 'legend') legendCnt++;
+                    if(c.grade === 'epic') epicCnt++;
+                });
+
+                this.showAlert(
+                    `<b>카오스 셔플 완료!</b><br><br>
+                    새로운 20장이 지급되었습니다.<br>
+                    (전설: ${legendCnt}, 에픽: ${epicCnt})<br><br>
+                    * 덱이 초기화되었으니 다시 구성해주세요.`
+                );
+            }
+        );
+    },
+
     openGacha() {
         if(this.state.tickets < 1) return this.showAlert("티켓이 부족합니다.");
         this.state.tickets--;


### PR DESCRIPTION
Implemented the Chaos Shuffle feature for Chaos Mode. This involves a new UI section in the menu that replaces the standard Gacha buttons when in Chaos Mode. The shuffle logic consumes 1 ticket to generate a new pool of 20 random cards (including unlocked bonus cards), resets the inventory and deck, and saves the game state to prevent errors. Checked for `deck` reset to `[null, null, null]` to avoid referencing missing cards.

---
*PR created automatically by Jules for task [8914619068313275514](https://jules.google.com/task/8914619068313275514) started by @romarin0325-cell*