### PR TITLE
Update Collocation Quiz and Archangel Trait

### DIFF
--- a/card/collocation_data.js
+++ b/card/collocation_data.js
@@ -11,7 +11,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The marketing team plans to _______ a survey to gather feedback from customers about the new product line.",
         "answer": "conduct",
-        "translation": "마케팅 팀은 신제품 라인에 대한 고객들의 피드백을 수집하기 위해 설문조사를 실시할 계획이다."
+        "translation": "마케팅 팀은 신제품 라인에 대한 고객들의 피드백을 수집하기 위해 설문조사를 실시할 계획이다.",
+        "quizzes": [
+            {
+                "question": "The marketing team plans to _______ a survey to gather feedback from customers about the new product line.",
+                "options": [
+                    "conduct",
+                    "connect",
+                    "commit",
+                    "contain"
+                ],
+                "answer": "conduct",
+                "translation": "마케팅 팀은 신제품 라인에 대한 고객들의 피드백을 수집하기 위해 설문조사를 실시할 계획이다."
+            },
+            {
+                "question": "Researchers will _______ a survey among employees to assess job satisfaction levels in the company.",
+                "options": [
+                    "perform",
+                    "conduct",
+                    "create",
+                    "collect"
+                ],
+                "answer": "conduct",
+                "translation": "연구원들은 회사 내 직원들의 직무 만족도를 평가하기 위해 설문조사를 실시할 예정이다."
+            }
+        ]
     },
     {
         "id": 2,
@@ -25,7 +49,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "All employees worked overtime this week to _______ the deadline for the project proposal.",
         "answer": "meet",
-        "translation": "모든 직원들은 프로젝트 제안서의 마감일을 맞추기 위해 이번 주에 초과 근무를 했다."
+        "translation": "모든 직원들은 프로젝트 제안서의 마감일을 맞추기 위해 이번 주에 초과 근무를 했다.",
+        "quizzes": [
+            {
+                "question": "All employees worked overtime this week to _______ the deadline for the project proposal.",
+                "options": [
+                    "see",
+                    "face",
+                    "meet",
+                    "hit"
+                ],
+                "answer": "meet",
+                "translation": "모든 직원들은 프로젝트 제안서의 마감일을 맞추기 위해 이번 주에 초과 근무를 했다."
+            },
+            {
+                "question": "The design team must _______ the deadline for submitting the final blueprints to avoid delays in production.",
+                "options": [
+                    "achieve",
+                    "meet",
+                    "pass",
+                    "ignore"
+                ],
+                "answer": "meet",
+                "translation": "디자인 팀은 생산 지연을 피하기 위해 최종 청사진 제출 마감일을 맞춰야 한다."
+            }
+        ]
     },
     {
         "id": 3,
@@ -39,7 +87,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "After hours of negotiation, the two companies finally were able to _______ an agreement on the merger terms.",
         "answer": "reach",
-        "translation": "몇 시간의 협상 끝에, 두 회사는 마침내 합병 조건에 대한 합의에 도달할 수 있었다."
+        "translation": "몇 시간의 협상 끝에, 두 회사는 마침내 합병 조건에 대한 합의에 도달할 수 있었다.",
+        "quizzes": [
+            {
+                "question": "After hours of negotiation, the two companies finally were able to _______ an agreement on the merger terms.",
+                "options": [
+                    "arrive",
+                    "reach",
+                    "get",
+                    "touch"
+                ],
+                "answer": "reach",
+                "translation": "몇 시간의 협상 끝에, 두 회사는 마침내 합병 조건에 대한 합의에 도달할 수 있었다."
+            },
+            {
+                "question": "The labor union and management hope to _______ an agreement on wage increases before the end of the month.",
+                "options": [
+                    "attain",
+                    "reach",
+                    "form",
+                    "avoid"
+                ],
+                "answer": "reach",
+                "translation": "노동 조합과 경영진은 월말 전에 임금 인상에 대한 합의에 도달하기를 희망한다."
+            }
+        ]
     },
     {
         "id": 4,
@@ -53,7 +125,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The manager promised to _______ the issue regarding the defective equipment as soon as possible.",
         "answer": "address",
-        "translation": "관리자는 결함이 있는 장비와 관련된 문제를 가능한 한 빨리 해결하겠다고 약속했다."
+        "translation": "관리자는 결함이 있는 장비와 관련된 문제를 가능한 한 빨리 해결하겠다고 약속했다.",
+        "quizzes": [
+            {
+                "question": "The manager promised to _______ the issue regarding the defective equipment as soon as possible.",
+                "options": [
+                    "address",
+                    "speak",
+                    "talk",
+                    "say"
+                ],
+                "answer": "address",
+                "translation": "관리자는 결함이 있는 장비와 관련된 문제를 가능한 한 빨리 해결하겠다고 약속했다."
+            },
+            {
+                "question": "The customer service representative will _______ the issue with the incorrect billing statement right away.",
+                "options": [
+                    "resolve",
+                    "address",
+                    "ignore",
+                    "discuss"
+                ],
+                "answer": "address",
+                "translation": "고객 서비스 담당자는 잘못된 청구서 문제를 즉시 해결할 것이다."
+            }
+        ]
     },
     {
         "id": 5,
@@ -67,7 +163,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Ms. Carter is scheduled to _______ a presentation on the latest market trends at the upcoming conference.",
         "answer": "deliver",
-        "translation": "Carter 씨는 다가오는 컨퍼런스에서 최신 시장 동향에 대해 발표할 예정이다."
+        "translation": "Carter 씨는 다가오는 컨퍼런스에서 최신 시장 동향에 대해 발표할 예정이다.",
+        "quizzes": [
+            {
+                "question": "Ms. Carter is scheduled to _______ a presentation on the latest market trends at the upcoming conference.",
+                "options": [
+                    "tell",
+                    "deliver",
+                    "say",
+                    "announce"
+                ],
+                "answer": "deliver",
+                "translation": "Carter 씨는 다가오는 컨퍼런스에서 최신 시장 동향에 대해 발표할 예정이다."
+            },
+            {
+                "question": "The sales director will _______ a presentation to potential clients about the benefits of our software solutions.",
+                "options": [
+                    "say",
+                    "deliver",
+                    "speak",
+                    "report"
+                ],
+                "answer": "deliver",
+                "translation": "영업 이사는 잠재 고객들에게 우리 소프트웨어 솔루션의 이점에 대해 발표할 것이다."
+            }
+        ]
     },
     {
         "id": 6,
@@ -81,7 +201,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Please remember to _______ your subscription before it expires next month to avoid service interruption.",
         "answer": "renew",
-        "translation": "서비스 중단을 피하기 위해 다음 달에 만료되기 전에 구독을 갱신하는 것을 잊지 마십시오."
+        "translation": "서비스 중단을 피하기 위해 다음 달에 만료되기 전에 구독을 갱신하는 것을 잊지 마십시오.",
+        "quizzes": [
+            {
+                "question": "Please remember to _______ your subscription before it expires next month to avoid service interruption.",
+                "options": [
+                    "renew",
+                    "redo",
+                    "repeat",
+                    "review"
+                ],
+                "answer": "renew",
+                "translation": "서비스 중단을 피하기 위해 다음 달에 만료되기 전에 구독을 갱신하는 것을 잊지 마십시오."
+            },
+            {
+                "question": "Subscribers are advised to _______ their subscription online to continue receiving monthly newsletters without disruption.",
+                "options": [
+                    "update",
+                    "renew",
+                    "cancel",
+                    "extend"
+                ],
+                "answer": "renew",
+                "translation": "구독자들은 중단 없이 월간 뉴스레터를 계속 받기 위해 온라인으로 구독을 갱신하는 것이 좋다."
+            }
+        ]
     },
     {
         "id": 7,
@@ -95,7 +239,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Social media platforms _______ a significant role in modern advertising strategies.",
         "answer": "play",
-        "translation": "소셜 미디어 플랫폼들은 현대 광고 전략에서 중요한 역할을 한다."
+        "translation": "소셜 미디어 플랫폼들은 현대 광고 전략에서 중요한 역할을 한다.",
+        "quizzes": [
+            {
+                "question": "Social media platforms _______ a significant role in modern advertising strategies.",
+                "options": [
+                    "do",
+                    "make",
+                    "play",
+                    "take"
+                ],
+                "answer": "play",
+                "translation": "소셜 미디어 플랫폼들은 현대 광고 전략에서 중요한 역할을 한다."
+            },
+            {
+                "question": "Innovation and technology _______ a significant role in driving economic growth for many countries.",
+                "options": [
+                    "perform",
+                    "play",
+                    "assume",
+                    "create"
+                ],
+                "answer": "play",
+                "translation": "혁신과 기술은 많은 국가들의 경제 성장을 이끄는 데 중요한 역할을 한다."
+            }
+        ]
     },
     {
         "id": 8,
@@ -109,7 +277,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The factory was expanded to _______ the increasing demand for electric vehicles.",
         "answer": "accommodate",
-        "translation": "그 공장은 전기차에 대한 증가하는 수요를 감당하기 위해 확장되었다."
+        "translation": "그 공장은 전기차에 대한 증가하는 수요를 감당하기 위해 확장되었다.",
+        "quizzes": [
+            {
+                "question": "The factory was expanded to _______ the increasing demand for electric vehicles.",
+                "options": [
+                    "accommodate",
+                    "accumulate",
+                    "account",
+                    "access"
+                ],
+                "answer": "accommodate",
+                "translation": "그 공장은 전기차에 대한 증가하는 수요를 감당하기 위해 확장되었다."
+            },
+            {
+                "question": "The hotel chain plans to add more rooms to _______ the growing demand from international tourists.",
+                "options": [
+                    "meet",
+                    "accommodate",
+                    "increase",
+                    "reduce"
+                ],
+                "answer": "accommodate",
+                "translation": "호텔 체인은 국제 관광객들의 증가하는 수요를 맞추기 위해 더 많은 객실을 추가할 계획이다."
+            }
+        ]
     },
     {
         "id": 9,
@@ -123,7 +315,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Startups often _______ many challenges when trying to enter a competitive market.",
         "answer": "face",
-        "translation": "스타트업들은 경쟁이 치열한 시장에 진입하려고 할 때 종종 많은 도전에 직면한다."
+        "translation": "스타트업들은 경쟁이 치열한 시장에 진입하려고 할 때 종종 많은 도전에 직면한다.",
+        "quizzes": [
+            {
+                "question": "Startups often _______ many challenges when trying to enter a competitive market.",
+                "options": [
+                    "face",
+                    "look",
+                    "view",
+                    "head"
+                ],
+                "answer": "face",
+                "translation": "스타트업들은 경쟁이 치열한 시장에 진입하려고 할 때 종종 많은 도전에 직면한다."
+            },
+            {
+                "question": "The project manager expects the team to _______ a challenge with supply chain disruptions this quarter.",
+                "options": [
+                    "encounter",
+                    "face",
+                    "avoid",
+                    "solve"
+                ],
+                "answer": "face",
+                "translation": "프로젝트 관리자는 이번 분기에 공급망 중단으로 인해 팀이 도전에 직면할 것으로 예상한다."
+            }
+        ]
     },
     {
         "id": 10,
@@ -137,7 +353,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The quarterly profits _______ all expectations, surprising both analysts and investors.",
         "answer": "exceeded",
-        "translation": "분기 수익이 모든 기대를 뛰어넘어 분석가들과 투자자들을 놀라게 했다."
+        "translation": "분기 수익이 모든 기대를 뛰어넘어 분석가들과 투자자들을 놀라게 했다.",
+        "quizzes": [
+            {
+                "question": "The quarterly profits _______ all expectations, surprising both analysts and investors.",
+                "options": [
+                    "excelled",
+                    "exceeded",
+                    "accepted",
+                    "accessed"
+                ],
+                "answer": "exceeded",
+                "translation": "분기 수익이 모든 기대를 뛰어넘어 분석가들과 투자자들을 놀라게 했다."
+            },
+            {
+                "question": "The new product launch _______ expectations, leading to record-breaking sales in the first month.",
+                "options": [
+                    "surpassed",
+                    "exceeded",
+                    "met",
+                    "fell"
+                ],
+                "answer": "exceeded",
+                "translation": "신제품 출시가 기대를 뛰어넘어 첫 달에 기록적인 매출을 이끌었다."
+            }
+        ]
     },
     {
         "id": 11,
@@ -151,7 +391,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The new software is _______ recommended by IT experts for its advanced security features.",
         "answer": "highly",
-        "translation": "그 새 소프트웨어는 향상된 보안 기능 덕분에 IT 전문가들에 의해 강력히 추천된다."
+        "translation": "그 새 소프트웨어는 향상된 보안 기능 덕분에 IT 전문가들에 의해 강력히 추천된다.",
+        "quizzes": [
+            {
+                "question": "The new software is _______ recommended by IT experts for its advanced security features.",
+                "options": [
+                    "highly",
+                    "heavy",
+                    "hugely",
+                    "hardly"
+                ],
+                "answer": "highly",
+                "translation": "그 새 소프트웨어는 향상된 보안 기능 덕분에 IT 전문가들에 의해 강력히 추천된다."
+            },
+            {
+                "question": "This training program is _______ recommended for employees seeking career advancement opportunities.",
+                "options": [
+                    "strongly",
+                    "highly",
+                    "barely",
+                    "slightly"
+                ],
+                "answer": "highly",
+                "translation": "이 교육 프로그램은 경력 발전 기회를 추구하는 직원들에게 강력히 추천된다."
+            }
+        ]
     },
     {
         "id": 12,
@@ -165,7 +429,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Our hotel is _______ located just a five-minute walk from the central train station.",
         "answer": "conveniently",
-        "translation": "우리 호텔은 중앙 기차역에서 도보로 단 5분 거리에 편리하게 위치해 있다."
+        "translation": "우리 호텔은 중앙 기차역에서 도보로 단 5분 거리에 편리하게 위치해 있다.",
+        "quizzes": [
+            {
+                "question": "Our hotel is _______ located just a five-minute walk from the central train station.",
+                "options": [
+                    "completely",
+                    "conveniently",
+                    "confidently",
+                    "considerably"
+                ],
+                "answer": "conveniently",
+                "translation": "우리 호텔은 중앙 기차역에서 도보로 단 5분 거리에 편리하게 위치해 있다."
+            },
+            {
+                "question": "The office building is _______ located near major highways, making it easy for commuters.",
+                "options": [
+                    "ideally",
+                    "conveniently",
+                    "remotely",
+                    "awkwardly"
+                ],
+                "answer": "conveniently",
+                "translation": "그 사무실 건물은 주요 고속도로 근처에 편리하게 위치해 있어 출퇴근자들에게 편리하다."
+            }
+        ]
     },
     {
         "id": 13,
@@ -179,7 +467,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Winter clothing is often _______ discounted during the spring clearance sales.",
         "answer": "heavily",
-        "translation": "겨울 의류는 봄맞이 재고 정리 세일 기간 동안 종종 대폭 할인된다."
+        "translation": "겨울 의류는 봄맞이 재고 정리 세일 기간 동안 종종 대폭 할인된다.",
+        "quizzes": [
+            {
+                "question": "Winter clothing is often _______ discounted during the spring clearance sales.",
+                "options": [
+                    "heavily",
+                    "tightly",
+                    "strictly",
+                    "busily"
+                ],
+                "answer": "heavily",
+                "translation": "겨울 의류는 봄맞이 재고 정리 세일 기간 동안 종종 대폭 할인된다."
+            },
+            {
+                "question": "Electronics are _______ discounted during the annual Black Friday promotions to attract shoppers.",
+                "options": [
+                    "deeply",
+                    "heavily",
+                    "lightly",
+                    "minimally"
+                ],
+                "answer": "heavily",
+                "translation": "전자제품들은 쇼핑객들을 유치하기 위해 연례 블랙 프라이데이 프로모션 기간 동안 대폭 할인된다."
+            }
+        ]
     },
     {
         "id": 14,
@@ -193,7 +505,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Taking photographs is _______ prohibited inside the art gallery to protect the exhibits.",
         "answer": "strictly",
-        "translation": "전시품 보호를 위해 미술관 내부에서의 사진 촬영은 엄격히 금지된다."
+        "translation": "전시품 보호를 위해 미술관 내부에서의 사진 촬영은 엄격히 금지된다.",
+        "quizzes": [
+            {
+                "question": "Taking photographs is _______ prohibited inside the art gallery to protect the exhibits.",
+                "options": [
+                    "strictly",
+                    "strongly",
+                    "straightly",
+                    "securely"
+                ],
+                "answer": "strictly",
+                "translation": "전시품 보호를 위해 미술관 내부에서의 사진 촬영은 엄격히 금지된다."
+            },
+            {
+                "question": "Smoking is _______ prohibited in all areas of the hospital to ensure patient safety.",
+                "options": [
+                    "absolutely",
+                    "strictly",
+                    "loosely",
+                    "optionally"
+                ],
+                "answer": "strictly",
+                "translation": "환자 안전을 보장하기 위해 병원 모든 구역에서 흡연이 엄격히 금지된다."
+            }
+        ]
     },
     {
         "id": 15,
@@ -207,7 +543,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "We hope to establish a _______ beneficial partnership that will help both companies grow.",
         "answer": "mutually",
-        "translation": "우리는 두 회사가 모두 성장하는 데 도움이 될 상호 이익이 되는 파트너십을 구축하기를 희망한다."
+        "translation": "우리는 두 회사가 모두 성장하는 데 도움이 될 상호 이익이 되는 파트너십을 구축하기를 희망한다.",
+        "quizzes": [
+            {
+                "question": "We hope to establish a _______ beneficial partnership that will help both companies grow.",
+                "options": [
+                    "mutually",
+                    "mostly",
+                    "merely",
+                    "manually"
+                ],
+                "answer": "mutually",
+                "translation": "우리는 두 회사가 모두 성장하는 데 도움이 될 상호 이익이 되는 파트너십을 구축하기를 희망한다."
+            },
+            {
+                "question": "The trade agreement is designed to be _______ beneficial for both exporting and importing countries.",
+                "options": [
+                    "equally",
+                    "mutually",
+                    "singly",
+                    "partially"
+                ],
+                "answer": "mutually",
+                "translation": "그 무역 협정은 수출국과 수입국 모두에게 상호 이익이 되도록 설계되었다."
+            }
+        ]
     },
     {
         "id": 16,
@@ -221,7 +581,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The customer service team is trained to _______ respond to all inquiries within 24 hours.",
         "answer": "promptly",
-        "translation": "고객 서비스 팀은 24시간 이내에 모든 문의에 즉시 응답하도록 교육받는다."
+        "translation": "고객 서비스 팀은 24시간 이내에 모든 문의에 즉시 응답하도록 교육받는다.",
+        "quizzes": [
+            {
+                "question": "The customer service team is trained to _______ respond to all inquiries within 24 hours.",
+                "options": [
+                    "promptly",
+                    "presently",
+                    "previously",
+                    "primarily"
+                ],
+                "answer": "promptly",
+                "translation": "고객 서비스 팀은 24시간 이내에 모든 문의에 즉시 응답하도록 교육받는다."
+            },
+            {
+                "question": "Managers are expected to _______ respond to employee concerns to maintain a positive work environment.",
+                "options": [
+                    "quickly",
+                    "promptly",
+                    "slowly",
+                    "eventually"
+                ],
+                "answer": "promptly",
+                "translation": "관리자들은 긍정적인 작업 환경을 유지하기 위해 직원들의 우려에 즉시 응답할 것으로 기대된다."
+            }
+        ]
     },
     {
         "id": 17,
@@ -235,7 +619,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Online education platforms have become _______ popular among working professionals.",
         "answer": "increasingly",
-        "translation": "온라인 교육 플랫폼들은 직장인들 사이에서 점점 더 인기를 얻고 있다."
+        "translation": "온라인 교육 플랫폼들은 직장인들 사이에서 점점 더 인기를 얻고 있다.",
+        "quizzes": [
+            {
+                "question": "Online education platforms have become _______ popular among working professionals.",
+                "options": [
+                    "increasingly",
+                    "intentionally",
+                    "importantly",
+                    "inadvertently"
+                ],
+                "answer": "increasingly",
+                "translation": "온라인 교육 플랫폼들은 직장인들 사이에서 점점 더 인기를 얻고 있다."
+            },
+            {
+                "question": "Electric cars are becoming _______ popular due to rising environmental awareness.",
+                "options": [
+                    "gradually",
+                    "increasingly",
+                    "decreasingly",
+                    "steadily"
+                ],
+                "answer": "increasingly",
+                "translation": "전기 자동차는 증가하는 환경 인식으로 인해 점점 더 인기를 얻고 있다."
+            }
+        ]
     },
     {
         "id": 18,
@@ -249,7 +657,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The item you requested is _______ unavailable, but we expect a new shipment next week.",
         "answer": "currently",
-        "translation": "귀하가 요청하신 물품은 현재 구매하실 수 없으나, 다음 주에 새 입고가 예정되어 있습니다."
+        "translation": "귀하가 요청하신 물품은 현재 구매하실 수 없으나, 다음 주에 새 입고가 예정되어 있습니다.",
+        "quizzes": [
+            {
+                "question": "The item you requested is _______ unavailable, but we expect a new shipment next week.",
+                "options": [
+                    "currently",
+                    "commonly",
+                    "clearly",
+                    "closely"
+                ],
+                "answer": "currently",
+                "translation": "귀하가 요청하신 물품은 현재 구매하실 수 없으나, 다음 주에 새 입고가 예정되어 있습니다."
+            },
+            {
+                "question": "The conference room is _______ unavailable because of ongoing maintenance work.",
+                "options": [
+                    "temporarily",
+                    "currently",
+                    "permanently",
+                    "always"
+                ],
+                "answer": "currently",
+                "translation": "회의실은 진행 중인 유지보수 작업으로 인해 현재 이용 불가하다."
+            }
+        ]
     },
     {
         "id": 19,
@@ -263,7 +695,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The restaurant is known for serving delicious meals that are _______ priced.",
         "answer": "reasonably",
-        "translation": "그 식당은 합리적인 가격의 맛있는 식사를 제공하는 것으로 알려져 있다."
+        "translation": "그 식당은 합리적인 가격의 맛있는 식사를 제공하는 것으로 알려져 있다.",
+        "quizzes": [
+            {
+                "question": "The restaurant is known for serving delicious meals that are _______ priced.",
+                "options": [
+                    "reasonably",
+                    "recently",
+                    "rapidly",
+                    "regularly"
+                ],
+                "answer": "reasonably",
+                "translation": "그 식당은 합리적인 가격의 맛있는 식사를 제공하는 것으로 알려져 있다."
+            },
+            {
+                "question": "The apartments in this neighborhood are _______ priced, attracting many first-time buyers.",
+                "options": [
+                    "affordably",
+                    "reasonably",
+                    "expensively",
+                    "overly"
+                ],
+                "answer": "reasonably",
+                "translation": "이 동네의 아파트들은 합리적인 가격으로 책정되어 많은 첫 구매자들을 끌어들인다."
+            }
+        ]
     },
     {
         "id": 20,
@@ -277,7 +733,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Technicians must _______ inspect the machinery before the factory begins operation each day.",
         "answer": "thoroughly",
-        "translation": "기술자들은 매일 공장 가동이 시작되기 전에 기계를 철저하게 검사해야 한다."
+        "translation": "기술자들은 매일 공장 가동이 시작되기 전에 기계를 철저하게 검사해야 한다.",
+        "quizzes": [
+            {
+                "question": "Technicians must _______ inspect the machinery before the factory begins operation each day.",
+                "options": [
+                    "thoroughly",
+                    "thoughtfully",
+                    "through",
+                    "totally"
+                ],
+                "answer": "thoroughly",
+                "translation": "기술자들은 매일 공장 가동이 시작되기 전에 기계를 철저하게 검사해야 한다."
+            },
+            {
+                "question": "Quality control staff should _______ inspect each product before it leaves the assembly line.",
+                "options": [
+                    "carefully",
+                    "thoroughly",
+                    "quickly",
+                    "superficially"
+                ],
+                "answer": "thoroughly",
+                "translation": "품질 관리 직원들은 각 제품이 조립 라인을 떠나기 전에 철저하게 검사해야 한다."
+            }
+        ]
     },
     {
         "id": 21,
@@ -291,7 +771,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "We look _______ to hearing from you regarding the partnership proposal.",
         "answer": "forward",
-        "translation": "우리는 파트너십 제안과 관련하여 귀하의 연락을 받기를 고대하고 있습니다."
+        "translation": "우리는 파트너십 제안과 관련하여 귀하의 연락을 받기를 고대하고 있습니다.",
+        "quizzes": [
+            {
+                "question": "We look _______ to hearing from you regarding the partnership proposal.",
+                "options": [
+                    "forward",
+                    "up",
+                    "after",
+                    "out"
+                ],
+                "answer": "forward",
+                "translation": "우리는 파트너십 제안과 관련하여 귀하의 연락을 받기를 고대하고 있습니다."
+            },
+            {
+                "question": "The team looks _______ to collaborating with your company on future projects.",
+                "options": [
+                    "ahead",
+                    "forward",
+                    "back",
+                    "up"
+                ],
+                "answer": "forward",
+                "translation": "팀은 귀사와 미래 프로젝트에서 협력하기를 고대하고 있습니다."
+            }
+        ]
     },
     {
         "id": 22,
@@ -305,7 +809,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "All visitors must _______ with the safety regulations while inside the factory.",
         "answer": "comply",
-        "translation": "모든 방문객은 공장 내부에 있는 동안 안전 규정을 준수해야 한다."
+        "translation": "모든 방문객은 공장 내부에 있는 동안 안전 규정을 준수해야 한다.",
+        "quizzes": [
+            {
+                "question": "All visitors must _______ with the safety regulations while inside the factory.",
+                "options": [
+                    "comply",
+                    "compete",
+                    "compare",
+                    "complain"
+                ],
+                "answer": "comply",
+                "translation": "모든 방문객은 공장 내부에 있는 동안 안전 규정을 준수해야 한다."
+            },
+            {
+                "question": "Companies must _______ with international trade regulations to avoid penalties.",
+                "options": [
+                    "follow",
+                    "comply",
+                    "compete",
+                    "compare"
+                ],
+                "answer": "comply",
+                "translation": "회사들은 벌금을 피하기 위해 국제 무역 규정을 준수해야 한다."
+            }
+        ]
     },
     {
         "id": 23,
@@ -319,7 +847,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Electronic products _______ for nearly 40% of the company's total sales.",
         "answer": "account",
-        "translation": "전자 제품은 회사 전체 매출의 거의 40%를 차지한다."
+        "translation": "전자 제품은 회사 전체 매출의 거의 40%를 차지한다.",
+        "quizzes": [
+            {
+                "question": "Electronic products _______ for nearly 40% of the company's total sales.",
+                "options": [
+                    "account",
+                    "apply",
+                    "ask",
+                    "arrange"
+                ],
+                "answer": "account",
+                "translation": "전자 제품은 회사 전체 매출의 거의 40%를 차지한다."
+            },
+            {
+                "question": "Exports _______ for a large portion of the country's economic output.",
+                "options": [
+                    "explain",
+                    "account",
+                    "apply",
+                    "arrange"
+                ],
+                "answer": "account",
+                "translation": "수출은 그 국가의 경제 생산량에서 큰 비중을 차지한다."
+            }
+        ]
     },
     {
         "id": 24,
@@ -333,7 +885,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Please _______ out this application form and return it to the front desk.",
         "answer": "fill",
-        "translation": "이 신청서를 작성해서 안내 데스크에 반납해 주십시오."
+        "translation": "이 신청서를 작성해서 안내 데스크에 반납해 주십시오.",
+        "quizzes": [
+            {
+                "question": "Please _______ out this application form and return it to the front desk.",
+                "options": [
+                    "fill",
+                    "find",
+                    "figure",
+                    "fall"
+                ],
+                "answer": "fill",
+                "translation": "이 신청서를 작성해서 안내 데스크에 반납해 주십시오."
+            },
+            {
+                "question": "Applicants need to _______ out the registration form before attending the seminar.",
+                "options": [
+                    "complete",
+                    "fill",
+                    "find",
+                    "figure"
+                ],
+                "answer": "fill",
+                "translation": "신청자들은 세미나에 참석하기 전에 등록 양식을 작성해야 한다."
+            }
+        ]
     },
     {
         "id": 25,
@@ -347,7 +923,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The outdoor event was _______ off due to the unexpected heavy rain.",
         "answer": "called",
-        "translation": "예기치 못한 폭우로 인해 야외 행사가 취소되었다."
+        "translation": "예기치 못한 폭우로 인해 야외 행사가 취소되었다.",
+        "quizzes": [
+            {
+                "question": "The outdoor event was _______ off due to the unexpected heavy rain.",
+                "options": [
+                    "called",
+                    "taken",
+                    "turned",
+                    "put"
+                ],
+                "answer": "called",
+                "translation": "예기치 못한 폭우로 인해 야외 행사가 취소되었다."
+            },
+            {
+                "question": "The conference was _______ off because of the severe weather forecast.",
+                "options": [
+                    "postponed",
+                    "called",
+                    "canceled",
+                    "taken"
+                ],
+                "answer": "called",
+                "translation": "심각한 날씨 예보로 인해 컨퍼런스가 취소되었다."
+            }
+        ]
     },
     {
         "id": 26,
@@ -361,7 +961,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "We decided to _______ off the meeting until the CEO returns from her business trip.",
         "answer": "put",
-        "translation": "우리는 CEO가 출장에서 돌아올 때까지 회의를 연기하기로 결정했다."
+        "translation": "우리는 CEO가 출장에서 돌아올 때까지 회의를 연기하기로 결정했다.",
+        "quizzes": [
+            {
+                "question": "We decided to _______ off the meeting until the CEO returns from her business trip.",
+                "options": [
+                    "put",
+                    "set",
+                    "keep",
+                    "take"
+                ],
+                "answer": "put",
+                "translation": "우리는 CEO가 출장에서 돌아올 때까지 회의를 연기하기로 결정했다."
+            },
+            {
+                "question": "Due to technical issues, we have to _______ off the product launch until next week.",
+                "options": [
+                    "delay",
+                    "put",
+                    "cancel",
+                    "set"
+                ],
+                "answer": "put",
+                "translation": "기술 문제로 인해 제품 출시를 다음 주로 연기해야 한다."
+            }
+        ]
     },
     {
         "id": 27,
@@ -375,7 +999,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Mr. Kim had to _______ down the job offer because he was not willing to relocate.",
         "answer": "turn",
-        "translation": "Kim 씨는 이사할 의향이 없었기 때문에 그 일자리 제안을 거절해야 했다."
+        "translation": "Kim 씨는 이사할 의향이 없었기 때문에 그 일자리 제안을 거절해야 했다.",
+        "quizzes": [
+            {
+                "question": "Mr. Kim had to _______ down the job offer because he was not willing to relocate.",
+                "options": [
+                    "turn",
+                    "look",
+                    "break",
+                    "settle"
+                ],
+                "answer": "turn",
+                "translation": "Kim 씨는 이사할 의향이 없었기 때문에 그 일자리 제안을 거절해야 했다."
+            },
+            {
+                "question": "She decided to _______ down the promotion offer to focus on her family.",
+                "options": [
+                    "reject",
+                    "turn",
+                    "accept",
+                    "look"
+                ],
+                "answer": "turn",
+                "translation": "그녀는 가족에 집중하기 위해 승진 제안을 거절하기로 결정했다."
+            }
+        ]
     },
     {
         "id": 28,
@@ -389,7 +1037,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The IT department will _______ up the new computer network over the weekend.",
         "answer": "set",
-        "translation": "IT 부서는 주말 동안 새로운 컴퓨터 네트워크를 설치할 것이다."
+        "translation": "IT 부서는 주말 동안 새로운 컴퓨터 네트워크를 설치할 것이다.",
+        "quizzes": [
+            {
+                "question": "The IT department will _______ up the new computer network over the weekend.",
+                "options": [
+                    "set",
+                    "give",
+                    "make",
+                    "bring"
+                ],
+                "answer": "set",
+                "translation": "IT 부서는 주말 동안 새로운 컴퓨터 네트워크를 설치할 것이다."
+            },
+            {
+                "question": "We need to _______ up a meeting with the clients to discuss the contract.",
+                "options": [
+                    "arrange",
+                    "set",
+                    "organize",
+                    "give"
+                ],
+                "answer": "set",
+                "translation": "계약을 논의하기 위해 고객들과 회의를 잡아야 한다."
+            }
+        ]
     },
     {
         "id": 29,
@@ -403,7 +1075,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Let's _______ over the contract details one more time before signing.",
         "answer": "go",
-        "translation": "서명하기 전에 계약서 세부 사항을 한 번 더 검토합시다."
+        "translation": "서명하기 전에 계약서 세부 사항을 한 번 더 검토합시다.",
+        "quizzes": [
+            {
+                "question": "Let's _______ over the contract details one more time before signing.",
+                "options": [
+                    "go",
+                    "come",
+                    "watch",
+                    "take"
+                ],
+                "answer": "go",
+                "translation": "서명하기 전에 계약서 세부 사항을 한 번 더 검토합시다."
+            },
+            {
+                "question": "Please _______ over the report and let me know if there are any errors.",
+                "options": [
+                    "review",
+                    "go",
+                    "check",
+                    "come"
+                ],
+                "answer": "go",
+                "translation": "보고서를 검토하고 오류가 있으면 알려주세요."
+            }
+        ]
     },
     {
         "id": 30,
@@ -417,7 +1113,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The company is trying to cut _______ on travel expenses to improve profitability.",
         "answer": "back",
-        "translation": "그 회사는 수익성을 개선하기 위해 출장 비용을 줄이려 노력하고 있다."
+        "translation": "그 회사는 수익성을 개선하기 위해 출장 비용을 줄이려 노력하고 있다.",
+        "quizzes": [
+            {
+                "question": "The company is trying to cut _______ on travel expenses to improve profitability.",
+                "options": [
+                    "back",
+                    "away",
+                    "out",
+                    "off"
+                ],
+                "answer": "back",
+                "translation": "그 회사는 수익성을 개선하기 위해 출장 비용을 줄이려 노력하고 있다."
+            },
+            {
+                "question": "To save costs, the firm plans to cut _______ on unnecessary office supplies.",
+                "options": [
+                    "down",
+                    "back",
+                    "out",
+                    "off"
+                ],
+                "answer": "back",
+                "translation": "비용을 절감하기 위해 회사는 불필요한 사무용품을 줄일 계획이다."
+            }
+        ]
     },
     {
         "id": 31,
@@ -431,7 +1151,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Please make sure to _______ of chemical waste in the designated containers.",
         "answer": "dispose",
-        "translation": "화학 폐기물은 반드시 지정된 용기에 담아 처분해 주십시오."
+        "translation": "화학 폐기물은 반드시 지정된 용기에 담아 처분해 주십시오.",
+        "quizzes": [
+            {
+                "question": "Please make sure to _______ of chemical waste in the designated containers.",
+                "options": [
+                    "dispose",
+                    "disperse",
+                    "dissolve",
+                    "display"
+                ],
+                "answer": "dispose",
+                "translation": "화학 폐기물은 반드시 지정된 용기에 담아 처분해 주십시오."
+            },
+            {
+                "question": "Employees should properly _______ of confidential documents after use.",
+                "options": [
+                    "discard",
+                    "dispose",
+                    "destroy",
+                    "disperse"
+                ],
+                "answer": "dispose",
+                "translation": "직원들은 사용 후 기밀 문서를 적절히 처분해야 한다."
+            }
+        ]
     },
     {
         "id": 32,
@@ -445,7 +1189,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Small businesses often _______ heavily on word-of-mouth marketing to attract customers.",
         "answer": "rely",
-        "translation": "소규모 기업들은 고객을 유치하기 위해 입소문 마케팅에 크게 의존하는 경우가 많다."
+        "translation": "소규모 기업들은 고객을 유치하기 위해 입소문 마케팅에 크게 의존하는 경우가 많다.",
+        "quizzes": [
+            {
+                "question": "Small businesses often _______ heavily on word-of-mouth marketing to attract customers.",
+                "options": [
+                    "rely",
+                    "reply",
+                    "relay",
+                    "release"
+                ],
+                "answer": "rely",
+                "translation": "소규모 기업들은 고객을 유치하기 위해 입소문 마케팅에 크게 의존하는 경우가 많다."
+            },
+            {
+                "question": "Many industries _______ on imported raw materials for production.",
+                "options": [
+                    "depend",
+                    "rely",
+                    "trust",
+                    "reply"
+                ],
+                "answer": "rely",
+                "translation": "많은 산업들이 생산을 위해 수입 원자재에 의존한다."
+            }
+        ]
     },
     {
         "id": 33,
@@ -459,7 +1227,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Employees who wish to _______ in the advanced training course must sign up by Friday.",
         "answer": "enroll",
-        "translation": "심화 교육 과정에 등록하고자 하는 직원은 금요일까지 신청해야 한다."
+        "translation": "심화 교육 과정에 등록하고자 하는 직원은 금요일까지 신청해야 한다.",
+        "quizzes": [
+            {
+                "question": "Employees who wish to _______ in the advanced training course must sign up by Friday.",
+                "options": [
+                    "enroll",
+                    "enter",
+                    "enlist",
+                    "entail"
+                ],
+                "answer": "enroll",
+                "translation": "심화 교육 과정에 등록하고자 하는 직원은 금요일까지 신청해야 한다."
+            },
+            {
+                "question": "Students can _______ in online courses to improve their skills.",
+                "options": [
+                    "register",
+                    "enroll",
+                    "join",
+                    "enter"
+                ],
+                "answer": "enroll",
+                "translation": "학생들은 기술 향상을 위해 온라인 코스에 등록할 수 있다."
+            }
+        ]
     },
     {
         "id": 34,
@@ -473,7 +1265,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The customer service department is trained to _______ with complaints professionally.",
         "answer": "deal",
-        "translation": "고객 서비스 부서는 불만 사항을 전문적으로 처리하도록 훈련받는다."
+        "translation": "고객 서비스 부서는 불만 사항을 전문적으로 처리하도록 훈련받는다.",
+        "quizzes": [
+            {
+                "question": "The customer service department is trained to _______ with complaints professionally.",
+                "options": [
+                    "deal",
+                    "dial",
+                    "draw",
+                    "dwell"
+                ],
+                "answer": "deal",
+                "translation": "고객 서비스 부서는 불만 사항을 전문적으로 처리하도록 훈련받는다."
+            },
+            {
+                "question": "The support team is equipped to _______ with technical problems efficiently.",
+                "options": [
+                    "handle",
+                    "deal",
+                    "manage",
+                    "dial"
+                ],
+                "answer": "deal",
+                "translation": "지원 팀은 기술 문제를 효율적으로 처리할 수 있도록 갖춰져 있다."
+            }
+        ]
     },
     {
         "id": 35,
@@ -487,7 +1303,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "He decided to _______ up the issue of salary negotiation during the meeting.",
         "answer": "bring",
-        "translation": "그는 회의 중에 연봉 협상 문제를 꺼내기로 결정했다."
+        "translation": "그는 회의 중에 연봉 협상 문제를 꺼내기로 결정했다.",
+        "quizzes": [
+            {
+                "question": "He decided to _______ up the issue of salary negotiation during the meeting.",
+                "options": [
+                    "bring",
+                    "take",
+                    "come",
+                    "make"
+                ],
+                "answer": "bring",
+                "translation": "그는 회의 중에 연봉 협상 문제를 꺼내기로 결정했다."
+            },
+            {
+                "question": "During the interview, he chose to _______ up his previous experience in sales.",
+                "options": [
+                    "mention",
+                    "bring",
+                    "raise",
+                    "take"
+                ],
+                "answer": "bring",
+                "translation": "면접 중에 그는 이전 영업 경험을 꺼내기로 했다."
+            }
+        ]
     },
     {
         "id": 36,
@@ -501,7 +1341,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Ms. Lee is in _______ of overseeing the entire construction project.",
         "answer": "charge",
-        "translation": "Lee 씨는 전체 건설 프로젝트 감독을 담당하고 있다."
+        "translation": "Lee 씨는 전체 건설 프로젝트 감독을 담당하고 있다.",
+        "quizzes": [
+            {
+                "question": "Ms. Lee is in _______ of overseeing the entire construction project.",
+                "options": [
+                    "charge",
+                    "change",
+                    "check",
+                    "case"
+                ],
+                "answer": "charge",
+                "translation": "Lee 씨는 전체 건설 프로젝트 감독을 담당하고 있다."
+            },
+            {
+                "question": "Who is in _______ of managing the budget for this department?",
+                "options": [
+                    "control",
+                    "charge",
+                    "command",
+                    "check"
+                ],
+                "answer": "charge",
+                "translation": "이 부서의 예산 관리를 담당하는 사람은 누구인가?"
+            }
+        ]
     },
     {
         "id": 37,
@@ -515,7 +1379,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The event is open to everyone, _______ of age or occupation.",
         "answer": "regardless",
-        "translation": "이 행사는 나이나 직업에 상관없이 모든 사람에게 열려 있다."
+        "translation": "이 행사는 나이나 직업에 상관없이 모든 사람에게 열려 있다.",
+        "quizzes": [
+            {
+                "question": "The event is open to everyone, _______ of age or occupation.",
+                "options": [
+                    "regardless",
+                    "regarding",
+                    "regards",
+                    "regard"
+                ],
+                "answer": "regardless",
+                "translation": "이 행사는 나이나 직업에 상관없이 모든 사람에게 열려 있다."
+            },
+            {
+                "question": "The policy applies to all employees, _______ of their position.",
+                "options": [
+                    "regardless",
+                    "considering",
+                    "regarding",
+                    "respecting"
+                ],
+                "answer": "regardless",
+                "translation": "그 정책은 직급에 상관없이 모든 직원에게 적용된다."
+            }
+        ]
     },
     {
         "id": 38,
@@ -529,7 +1417,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Passengers should arrive at the airport at least two hours _______ to departure.",
         "answer": "prior",
-        "translation": "승객들은 출발 최소 2시간 전에 공항에 도착해야 한다."
+        "translation": "승객들은 출발 최소 2시간 전에 공항에 도착해야 한다.",
+        "quizzes": [
+            {
+                "question": "Passengers should arrive at the airport at least two hours _______ to departure.",
+                "options": [
+                    "prior",
+                    "primary",
+                    "previous",
+                    "present"
+                ],
+                "answer": "prior",
+                "translation": "승객들은 출발 최소 2시간 전에 공항에 도착해야 한다."
+            },
+            {
+                "question": "Please submit your resume _______ to the interview date.",
+                "options": [
+                    "before",
+                    "prior",
+                    "previous",
+                    "primary"
+                ],
+                "answer": "prior",
+                "translation": "면접 날짜 이전에 이력서를 제출해 주세요."
+            }
+        ]
     },
     {
         "id": 39,
@@ -543,7 +1455,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The schedule is _______ to change depending on weather conditions.",
         "answer": "subject",
-        "translation": "일정은 기상 조건에 따라 변경될 수 있습니다."
+        "translation": "일정은 기상 조건에 따라 변경될 수 있습니다.",
+        "quizzes": [
+            {
+                "question": "The schedule is _______ to change depending on weather conditions.",
+                "options": [
+                    "subject",
+                    "object",
+                    "project",
+                    "inject"
+                ],
+                "answer": "subject",
+                "translation": "일정은 기상 조건에 따라 변경될 수 있습니다."
+            },
+            {
+                "question": "Prices are _______ to change without prior notice.",
+                "options": [
+                    "liable",
+                    "subject",
+                    "prone",
+                    "object"
+                ],
+                "answer": "subject",
+                "translation": "가격은 사전 통보 없이 변경될 수 있습니다."
+            }
+        ]
     },
     {
         "id": 40,
@@ -557,7 +1493,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "I would like to accept this award on _______ of my entire team.",
         "answer": "behalf",
-        "translation": "저는 저희 팀 전체를 대표하여 이 상을 받고 싶습니다."
+        "translation": "저는 저희 팀 전체를 대표하여 이 상을 받고 싶습니다.",
+        "quizzes": [
+            {
+                "question": "I would like to accept this award on _______ of my entire team.",
+                "options": [
+                    "behalf",
+                    "belief",
+                    "behave",
+                    "behind"
+                ],
+                "answer": "behalf",
+                "translation": "저는 저희 팀 전체를 대표하여 이 상을 받고 싶습니다."
+            },
+            {
+                "question": "The lawyer spoke on _______ of the defendant in court.",
+                "options": [
+                    "part",
+                    "behalf",
+                    "side",
+                    "believe"
+                ],
+                "answer": "behalf",
+                "translation": "변호사는 법정에서 피고를 대표하여 발언했다."
+            }
+        ]
     },
     {
         "id": 41,
@@ -571,7 +1531,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "All travel expenses must be filed in _______ with the company's reimbursement policy.",
         "answer": "accordance",
-        "translation": "모든 출장 경비는 회사의 환급 규정에 따라서 청구되어야 한다."
+        "translation": "모든 출장 경비는 회사의 환급 규정에 따라서 청구되어야 한다.",
+        "quizzes": [
+            {
+                "question": "All travel expenses must be filed in _______ with the company's reimbursement policy.",
+                "options": [
+                    "accordance",
+                    "account",
+                    "access",
+                    "accord"
+                ],
+                "answer": "accordance",
+                "translation": "모든 출장 경비는 회사의 환급 규정에 따라서 청구되어야 한다."
+            },
+            {
+                "question": "The report must be prepared in _______ with the guidelines provided by the regulatory authority.",
+                "options": [
+                    "agreement",
+                    "accordance",
+                    "line",
+                    "compliance"
+                ],
+                "answer": "accordance",
+                "translation": "보고서는 규제 기관이 제공한 지침에 따라서 준비되어야 한다."
+            }
+        ]
     },
     {
         "id": 42,
@@ -585,7 +1569,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The elevator in the main lobby is currently out of _______ and will be repaired by noon.",
         "answer": "order",
-        "translation": "메인 로비에 있는 엘리베이터는 현재 고장 난 상태이며 정오까지 수리될 예정이다."
+        "translation": "메인 로비에 있는 엘리베이터는 현재 고장 난 상태이며 정오까지 수리될 예정이다.",
+        "quizzes": [
+            {
+                "question": "The elevator in the main lobby is currently out of _______ and will be repaired by noon.",
+                "options": [
+                    "order",
+                    "place",
+                    "stock",
+                    "duty"
+                ],
+                "answer": "order",
+                "translation": "메인 로비에 있는 엘리베이터는 현재 고장 난 상태이며 정오까지 수리될 예정이다."
+            },
+            {
+                "question": "The vending machine is out of _______ , so please use the one on the next floor.",
+                "options": [
+                    "service",
+                    "order",
+                    "stock",
+                    "place"
+                ],
+                "answer": "order",
+                "translation": "자판기가 고장 나서, 다음 층에 있는 것을 이용해 주세요."
+            }
+        ]
     },
     {
         "id": 43,
@@ -599,7 +1607,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Further details regarding the project are available upon _______ from the headquarters.",
         "answer": "request",
-        "translation": "프로젝트에 관한 추가 세부 사항은 본사에 요청 시 제공됩니다."
+        "translation": "프로젝트에 관한 추가 세부 사항은 본사에 요청 시 제공됩니다.",
+        "quizzes": [
+            {
+                "question": "Further details regarding the project are available upon _______ from the headquarters.",
+                "options": [
+                    "request",
+                    "question",
+                    "require",
+                    "demand"
+                ],
+                "answer": "request",
+                "translation": "프로젝트에 관한 추가 세부 사항은 본사에 요청 시 제공됩니다."
+            },
+            {
+                "question": "Additional training materials are available upon _______ from the human resources department.",
+                "options": [
+                    "demand",
+                    "request",
+                    "order",
+                    "question"
+                ],
+                "answer": "request",
+                "translation": "추가 교육 자료는 인사 부서에 요청 시 제공됩니다."
+            }
+        ]
     },
     {
         "id": 44,
@@ -613,7 +1645,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "All formal complaints must be submitted in _______ to the legal department.",
         "answer": "writing",
-        "translation": "모든 공식적인 불만 사항은 서면으로 법무 부서에 제출되어야 한다."
+        "translation": "모든 공식적인 불만 사항은 서면으로 법무 부서에 제출되어야 한다.",
+        "quizzes": [
+            {
+                "question": "All formal complaints must be submitted in _______ to the legal department.",
+                "options": [
+                    "writing",
+                    "written",
+                    "write",
+                    "writer"
+                ],
+                "answer": "writing",
+                "translation": "모든 공식적인 불만 사항은 서면으로 법무 부서에 제출되어야 한다."
+            },
+            {
+                "question": "Any changes to the contract must be confirmed in _______ to be legally binding.",
+                "options": [
+                    "print",
+                    "writing",
+                    "words",
+                    "text"
+                ],
+                "answer": "writing",
+                "translation": "계약 변경 사항은 법적 구속력을 가지기 위해 서면으로 확인되어야 한다."
+            }
+        ]
     },
     {
         "id": 45,
@@ -627,7 +1683,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Employees are required to wear their identification badges at all _______ while in the building.",
         "answer": "times",
-        "translation": "직원들은 건물 내에 있는 동안 항상 신분증을 착용해야 한다."
+        "translation": "직원들은 건물 내에 있는 동안 항상 신분증을 착용해야 한다.",
+        "quizzes": [
+            {
+                "question": "Employees are required to wear their identification badges at all _______ while in the building.",
+                "options": [
+                    "times",
+                    "days",
+                    "hours",
+                    "periods"
+                ],
+                "answer": "times",
+                "translation": "직원들은 건물 내에 있는 동안 항상 신분증을 착용해야 한다."
+            },
+            {
+                "question": "Safety helmets must be worn at all _______ in the construction area.",
+                "options": [
+                    "moments",
+                    "times",
+                    "hours",
+                    "periods"
+                ],
+                "answer": "times",
+                "translation": "건설 현장에서는 항상 안전 헬멧을 착용해야 한다."
+            }
+        ]
     },
     {
         "id": 46,
@@ -641,7 +1721,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The new model is superior to the old one in _______ of fuel efficiency and safety.",
         "answer": "terms",
-        "translation": "새 모델은 연료 효율성과 안전성 면에서 구형 모델보다 우수하다."
+        "translation": "새 모델은 연료 효율성과 안전성 면에서 구형 모델보다 우수하다.",
+        "quizzes": [
+            {
+                "question": "The new model is superior to the old one in _______ of fuel efficiency and safety.",
+                "options": [
+                    "terms",
+                    "teams",
+                    "turns",
+                    "times"
+                ],
+                "answer": "terms",
+                "translation": "새 모델은 연료 효율성과 안전성 면에서 구형 모델보다 우수하다."
+            },
+            {
+                "question": "The new policy is beneficial in _______ of cost savings and efficiency.",
+                "options": [
+                    "ways",
+                    "terms",
+                    "aspects",
+                    "regards"
+                ],
+                "answer": "terms",
+                "translation": "새 정책은 비용 절감과 효율성 면에서 유익하다."
+            }
+        ]
     },
     {
         "id": 47,
@@ -655,7 +1759,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "Customers are encouraged to _______ advantage of the special holiday discounts.",
         "answer": "take",
-        "translation": "고객 여러분은 특별 휴일 할인 혜택을 이용하시기를 권장합니다."
+        "translation": "고객 여러분은 특별 휴일 할인 혜택을 이용하시기를 권장합니다.",
+        "quizzes": [
+            {
+                "question": "Customers are encouraged to _______ advantage of the special holiday discounts.",
+                "options": [
+                    "take",
+                    "make",
+                    "get",
+                    "have"
+                ],
+                "answer": "take",
+                "translation": "고객 여러분은 특별 휴일 할인 혜택을 이용하시기를 권장합니다."
+            },
+            {
+                "question": "Employees should _______ advantage of the company's wellness programs for better health.",
+                "options": [
+                    "get",
+                    "take",
+                    "make",
+                    "have"
+                ],
+                "answer": "take",
+                "translation": "직원들은 더 나은 건강을 위해 회사의 웰니스 프로그램을 이용해야 한다."
+            }
+        ]
     },
     {
         "id": 48,
@@ -669,7 +1797,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "It is difficult to _______ track of all the inventory changes without an automated system.",
         "answer": "keep",
-        "translation": "자동화된 시스템 없이는 모든 재고 변경 사항을 파악하는 것이 어렵다."
+        "translation": "자동화된 시스템 없이는 모든 재고 변경 사항을 파악하는 것이 어렵다.",
+        "quizzes": [
+            {
+                "question": "It is difficult to _______ track of all the inventory changes without an automated system.",
+                "options": [
+                    "keep",
+                    "hold",
+                    "stay",
+                    "put"
+                ],
+                "answer": "keep",
+                "translation": "자동화된 시스템 없이는 모든 재고 변경 사항을 파악하는 것이 어렵다."
+            },
+            {
+                "question": "The software helps managers _______ track of employee performance metrics.",
+                "options": [
+                    "maintain",
+                    "keep",
+                    "hold",
+                    "follow"
+                ],
+                "answer": "keep",
+                "translation": "그 소프트웨어는 관리자들이 직원 성과 지표를 파악하는 데 도움이 된다."
+            }
+        ]
     },
     {
         "id": 49,
@@ -683,7 +1835,31 @@ const COLLOCATION_DATA = [
         ],
         "question": "The bridge is currently under _______, so traffic is being diverted to a nearby route.",
         "answer": "construction",
-        "translation": "그 다리는 현재 공사 중이어서, 교통이 인근 경로로 우회되고 있다."
+        "translation": "그 다리는 현재 공사 중이어서, 교통이 인근 경로로 우회되고 있다.",
+        "quizzes": [
+            {
+                "question": "The bridge is currently under _______, so traffic is being diverted to a nearby route.",
+                "options": [
+                    "construction",
+                    "connection",
+                    "contraction",
+                    "contribution"
+                ],
+                "answer": "construction",
+                "translation": "그 다리는 현재 공사 중이어서, 교통이 인근 경로로 우회되고 있다."
+            },
+            {
+                "question": "The new highway is under _______ , causing temporary road closures.",
+                "options": [
+                    "repair",
+                    "construction",
+                    "development",
+                    "building"
+                ],
+                "answer": "construction",
+                "translation": "새 고속도로가 공사 중이어서 일시적인 도로 폐쇄가 발생하고 있다."
+            }
+        ]
     },
     {
         "id": 50,
@@ -697,6 +1873,30 @@ const COLLOCATION_DATA = [
         ],
         "question": "The library is open every day with the _______ of public holidays.",
         "answer": "exception",
-        "translation": "도서관은 공휴일을 제외하고 매일 개방한다."
+        "translation": "도서관은 공휴일을 제외하고 매일 개방한다.",
+        "quizzes": [
+            {
+                "question": "The library is open every day with the _______ of public holidays.",
+                "options": [
+                    "exception",
+                    "expectation",
+                    "reception",
+                    "inception"
+                ],
+                "answer": "exception",
+                "translation": "도서관은 공휴일을 제외하고 매일 개방한다."
+            },
+            {
+                "question": "All departments met their targets with the _______ of the marketing team.",
+                "options": [
+                    "exclusion",
+                    "exception",
+                    "omission",
+                    "removal"
+                ],
+                "answer": "exception",
+                "translation": "마케팅 팀을 제외하고 모든 부서가 목표를 달성했다."
+            }
+        ]
     }
 ];

--- a/card/data.js
+++ b/card/data.js
@@ -205,7 +205,7 @@ const CARDS = [
     {
         id: 'archangel', name: '대천사', grade: 'epic', element: 'light', role: 'balancer',
         stats: { hp: 400, atk: 70, matk: 95, def: 65, mdef: 80 },
-        trait: { type: 'syn_water_light_matk_mdef', val: 30, desc: '덱에 물, 빛이 있을 경우 마법공격력, 마법방어력 30%증가' },
+        trait: { type: 'syn_light_dark_matk_mdef', val: 30, desc: '덱에 빛, 어둠이 있을 경우 마법공격력, 마법방어력 30%증가' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
             { name: '성역전개', type: 'sup', tier: 2, cost: 20, desc: '필드버프 성역 발동 및 적에게 디바인 1스택 부여', effects: [{type: 'field_buff', id: 'sanctuary'}, {type: 'debuff', id: 'divine', stack: 1}] },

--- a/card/index.html
+++ b/card/index.html
@@ -1353,7 +1353,18 @@ const RPG = {
     startCollocationQuiz(callback) {
         document.getElementById('quiz-desc').style.display = 'block';
 
-        const q = COLLOCATION_DATA[Math.floor(Math.random() * COLLOCATION_DATA.length)];
+        let allQuizzes = [];
+        COLLOCATION_DATA.forEach(item => {
+            if (item.quizzes) {
+                item.quizzes.forEach(q => {
+                    allQuizzes.push({ ...q, parentId: item.id });
+                });
+            } else {
+                 allQuizzes.push({ ...item, parentId: item.id });
+            }
+        });
+
+        const q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
 
         let opts = [...q.options];
         opts.sort(() => Math.random() - 0.5);
@@ -1389,8 +1400,8 @@ const RPG = {
                     btn.classList.add('wrong');
 
                     if(!this.state.wrongCollocations) this.state.wrongCollocations = [];
-                    if(!this.state.wrongCollocations.includes(q.id)) {
-                        this.state.wrongCollocations.push(q.id);
+                    if(!this.state.wrongCollocations.includes(q.parentId)) {
+                        this.state.wrongCollocations.push(q.parentId);
                         localStorage.setItem('cardRpgCollocation', JSON.stringify(this.state.wrongCollocations));
                     }
 

--- a/card/logic.js
+++ b/card/logic.js
@@ -391,7 +391,7 @@ const Logic = {
              else if(t.type === 'syn_fire_3_crit' && countEl('fire') >= 3) active = true;
              else if(t.type === 'syn_dark_3_matk' && countEl('dark') >= 3) active = true;
              else if(t.type === 'syn_light_fire_atk' && hasEl('light') && hasEl('fire')) active = true;
-             else if(t.type === 'syn_water_light_matk_mdef' && hasEl('water') && hasEl('light')) active = true;
+             else if(t.type === 'syn_light_dark_matk_mdef' && hasEl('light') && hasEl('dark')) active = true;
              else if(t.type === 'syn_water_nature' && hasEl('water') && hasEl('nature')) active = true;
              else if(t.type === 'syn_nature_3_matk' && countEl('nature') >= 3) active = true;
              else if(t.type === 'syn_night_rabbit' && (deck.includes('night_rabbit') || deck.includes('silver_rabbit') || jokerInDeck)) active = true;
@@ -409,7 +409,7 @@ const Logic = {
                 if(t.type === 'syn_fire_3_crit') p.baseCrit += 30;
                 if(t.type === 'syn_dark_3_matk') p.matk *= 1.5;
                 if(t.type === 'syn_light_fire_atk') p.atk *= 1.3;
-                if(t.type === 'syn_water_light_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
+                if(t.type === 'syn_light_dark_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
                 if(t.type === 'syn_night_rabbit') { p.matk *= 1.5; p.mdef *= 1.5; }
                 if(t.type === 'syn_snow_rabbit') { p.atk *= 1.5; p.def *= 1.5; }
                 if(t.type === 'syn_silver_rabbit') { p.atk *= 1.5; p.matk *= 1.5; }
@@ -596,7 +596,7 @@ Logic.calculateInitialStats = function(playerProto, deck, allCards, idx) {
          else if(t.type === 'syn_fire_3_crit' && countEl('fire') >= 3) active = true;
          else if(t.type === 'syn_dark_3_matk' && countEl('dark') >= 3) active = true;
          else if(t.type === 'syn_light_fire_atk' && hasEl('light') && hasEl('fire')) active = true;
-         else if(t.type === 'syn_water_light_matk_mdef' && hasEl('water') && hasEl('light')) active = true;
+         else if(t.type === 'syn_light_dark_matk_mdef' && hasEl('light') && hasEl('dark')) active = true;
          else if(t.type === 'syn_water_nature' && hasEl('water') && hasEl('nature')) active = true;
          else if(t.type === 'syn_nature_3_matk' && countEl('nature') >= 3) active = true;
          else if(t.type === 'syn_night_rabbit' && (deck.includes('night_rabbit') || deck.includes('silver_rabbit') || jokerInDeck)) active = true;
@@ -614,7 +614,7 @@ Logic.calculateInitialStats = function(playerProto, deck, allCards, idx) {
             if(t.type === 'syn_fire_3_crit') p.baseCrit += 30;
             if(t.type === 'syn_dark_3_matk') p.matk *= 1.5;
             if(t.type === 'syn_light_fire_atk') p.atk *= 1.3;
-            if(t.type === 'syn_water_light_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
+            if(t.type === 'syn_light_dark_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
             if(t.type === 'syn_night_rabbit') { p.matk *= 1.5; p.mdef *= 1.5; }
             if(t.type === 'syn_snow_rabbit') { p.atk *= 1.5; p.def *= 1.5; }
             if(t.type === 'syn_silver_rabbit') { p.atk *= 1.5; p.matk *= 1.5; }


### PR DESCRIPTION
This patch adds 50 new questions to the collocation quiz pool, ensuring 2 questions per word. It updates the quiz selection logic to handle the expanded pool while maintaining correct wrong-answer tracking. It also modifies the Archangel card's synergy trait to activate with Light and Dark elements instead of Light and Water.

---
*PR created automatically by Jules for task [15003465011601464628](https://jules.google.com/task/15003465011601464628) started by @romarin0325-cell*