### PR TITLE
Add Transcendence Cards and Chaos Roulette

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -692,7 +692,7 @@ const TRANSCENDENCE_CARDS = [
         trait: { type: 'cosmic_harmony_random_buff', desc: '코스믹하모니 사용시 태양의축복, 달의축복, 스타파우더 중 랜덤한 필드버프 생성' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [] },
+            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [{type: 'random_field_buff_lumi'}] },
             { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '적용중인 필드버프에 따라 추가 효과', effects: [{type: 'field_buff_combo_dmg'}, {type: 'apply_lumi_guard'}] }
         ]
     },

--- a/card/data.js
+++ b/card/data.js
@@ -664,3 +664,86 @@ const ENEMIES = [
         ]
     }
 ];
+
+const TRANSCENDENCE_CARDS = [
+    {
+        id: 'trans_executor', name: '종언의집행자', grade: 'transcendence', element: 'dark', role: 'debuffer',
+        stats: { hp: 560, atk: 125, matk: 125, def: 70, mdef: 70 },
+        trait: { type: 'pos_stat_boost', pos: 1, stat: ['matk', 'mdef'], val: 30, desc: '중견 배치시 마법공격력 마법방어력 30%증가' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '이터널리와인드', type: 'sup', tier: 3, cost: 30, desc: '적에게 저주, 침묵, 암흑, 스턴 부여', effects: [{type: 'debuff', id: 'curse'}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'darkness'}, {type: 'debuff', id: 'stun', duration: 1}] },
+            { name: '인과역전', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '사용 후 3턴 뒤에 공격 (발동시점 턴 수 x0.5 배율 추가 대미지)', effects: [{type: 'delayed_turn_scale_attack', turns: 3, scale: 0.5}] }
+        ]
+    },
+    {
+        id: 'trans_cinderella', name: '신데렐라(미라클폼)', grade: 'transcendence', element: 'light', role: 'debuffer',
+        stats: { hp: 540, atk: 120, matk: 135, def: 80, mdef: 80 },
+        trait: { type: 'ignore_def_mdef_by_stack', val: 0.15, desc: '작열 1스택당 방어력 15% 무시 / 디바인 1스택당 마법방어력 15% 무시' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
+            { name: '샤터링비트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열, 약화, 부식 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'debuff', id: 'weak'}, {type: 'debuff', id: 'corrosion'}] },
+            { name: '미라클스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 침묵, 저주 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'curse'}] }
+        ]
+    },
+    {
+        id: 'trans_lumi', name: '루미(꿈의형태)', grade: 'transcendence', element: 'water', role: 'buffer',
+        stats: { hp: 540, atk: 90, matk: 140, def: 90, mdef: 100 },
+        trait: { type: 'cosmic_harmony_random_buff', desc: '코스믹하모니 사용시 태양의축복, 달의축복, 스타파우더 중 랜덤한 필드버프 생성' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [] },
+            { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '적용중인 필드버프에 따라 추가 효과', effects: [{type: 'field_buff_combo_dmg'}, {type: 'apply_lumi_guard'}] }
+        ]
+    },
+    {
+        id: 'trans_luna_jasmine', name: '루나&자스민', grade: 'transcendence', element: 'light', role: 'balancer',
+        stats: { hp: 530, atk: 130, matk: 150, def: 70, mdef: 70 },
+        trait: { type: 'luna_jasmine_trait', val: 2.0, desc: '디바인 3스택 이상인 적에게 대미지 2배 / 여신강림 상태에서 회피율/치명타 25% 증가' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '여신강림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 여신강림 발동', effects: [{type: 'field_buff', id: 'goddess_descent'}] },
+            { name: '루나블레이드', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '암흑 상태의 적에게 대미지 2배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0}] }
+        ]
+    },
+    {
+        id: 'trans_gray', name: '사신그레이', grade: 'transcendence', element: 'dark', role: 'dealer',
+        stats: { hp: 530, atk: 150, matk: 135, def: 75, mdef: 75 },
+        trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~10배율)', effects: [{type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 10.0}] },
+            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{type: 'turn_modulo_dmg', mod: 4, mult: 2.0}, {type: 'force_crit_chance', val: 40}] }
+        ]
+    },
+    {
+        id: 'trans_behemoth', name: '베히모스(해방)', grade: 'transcendence', element: 'nature', role: 'dealer',
+        stats: { hp: 620, atk: 120, matk: 100, def: 85, mdef: 65 },
+        trait: { type: 'behemoth_liberated_trait', val: 1.5, desc: '적이 디버프 3개 이상일 때 대미지 1.5배 / 스킬 사용 시 20% 확률로 적에게 스턴 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '월드브레이커', type: 'phy', tier: 3, cost: 30, val: 4.0, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{type: 'self_debuff', id: 'stun', duration: 1}, {type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0}] },
+            { name: '제로그라비티', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '다음 턴에 공격 (적에게 걸린 디버프 1종당 0.5배율 추가)', effects: [{type: 'delayed_attack_debuff_scale', turns: 1, multPerDebuff: 0.5}] }
+        ]
+    },
+    {
+        id: 'trans_chaos_lord', name: '카오스로드', grade: 'transcendence', element: 'nature', role: 'balancer',
+        stats: { hp: 560, atk: 120, matk: 120, def: 75, mdef: 75 },
+        trait: { type: 'all_advantage', desc: '이 카드는 모든 적에게 상성 유리 대미지를 준다.' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '프리즘브레이커', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '덱에 포함된 속성 수 만큼 추가배율 (조커는 5속성 취급)', effects: [{type: 'count_deck_attr_dmg'}] },
+            { name: '데스티니룰렛', type: 'sup', tier: 2, cost: 20, desc: '랜덤 스킬 발동', effects: [{type: 'random_skill_trigger_from_list'}] }
+        ]
+    },
+    {
+        id: 'trans_yeon_rabbit', name: '연토끼', grade: 'transcendence', element: 'fire', role: 'dealer',
+        stats: { hp: 540, atk: 115, matk: 115, def: 95, mdef: 95 },
+        trait: { type: 'rabbit_synergy_boost', val: 50, desc: '자신 덱에 있는 토끼의 수 만큼 공격 마공이 50%증가' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
+            { name: '홍련각', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모하여 대미지 2배', effects: [{type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0}] },
+            { name: '천화낙영', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5}, {type: 'clear_target_debuffs'}] }
+        ]
+    }
+];

--- a/card/index.html
+++ b/card/index.html
@@ -571,10 +571,16 @@ const SIDE_EFFECT_HANDLERS = {
     },
     'apply_lumi_guard': (ctx, eff) => {
         let buffs = RPG.battle.fieldBuffs.map(b => b.name);
-        if(buffs.includes('moon_bless') && buffs.includes('star_powder')) {
+        if(buffs.includes('star_powder')) {
             ctx.source.buffs['guard'] = 1;
-            ctx.logFn("스타파우더&달의축복: 가드 효과(버프) 적용!");
+            ctx.logFn("스타파우더: 가드 효과(버프) 적용!");
         }
+    },
+    'random_field_buff_lumi': (ctx, eff) => {
+        const buffs = ['sun_bless', 'moon_bless', 'star_powder'];
+        const pick = buffs[Math.floor(Math.random() * buffs.length)];
+        RPG.applyFieldBuff(pick);
+        ctx.logFn(`코스믹 하모니: [${ctx.getBuffName(pick)}] 생성!`);
     }
 };
 
@@ -2152,6 +2158,14 @@ const RPG = {
             if (Math.random() < 0.2) {
                 target.buffs.stun = 1;
                 RPG.log("[특성] 베히모스의 위압감! 적을 기절시킵니다!");
+            }
+        }
+
+        // Trait: Behemoth Liberated (Skill Use -> Stun Chance)
+        if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_liberated_trait') {
+            if (Math.random() < 0.2) {
+                target.buffs.stun = 1;
+                RPG.log("[특성] 해방된 베히모스: 20% 확률로 적을 기절시킵니다!");
             }
         }
 

--- a/card/index.html
+++ b/card/index.html
@@ -32,6 +32,12 @@
     .card-item.epic { border-color: #e040fb; color: #e040fb; animation: glow-epic 2s infinite; }
     .card-item.rare { border-color: #448aff; color: #448aff; }
     .card-item.normal { border-color: #bdbdbd; color: #bdbdbd; }
+    @keyframes glow-gold {
+      0% { box-shadow: 0 0 5px #ffd700; border-color: #ffd700; }
+      50% { box-shadow: 0 0 20px #ffd700; border-color: #ffeb3b; }
+      100% { box-shadow: 0 0 5px #ffd700; border-color: #ffd700; }
+    }
+    .card-item.transcendence { border: 2px solid #ffd700; color: #ffd700; animation: glow-gold 2s infinite; background: #2a2a1a; }
 
     .portrait {
         width: 100%; aspect-ratio: 3/4;
@@ -178,6 +184,32 @@
         <div style="flex:1; overflow-y:auto; border-top:1px solid #333;"><div id="deck-card-list" class="card-grid"></div></div>
         <button class="menu-btn" onclick="RPG.confirmDeck()" style="margin-bottom: 60px;">확인</button>
     </div>
+    <div id="screen-chaos-roulette" class="screen">
+        <div class="header">Chaos Roulette</div>
+        <div style="flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:20px;">
+            <div style="text-align:center;">
+                <h2 style="color:#ffd700; margin-bottom:5px;">카오스 룰렛</h2>
+                <p style="color:#aaa; font-size:0.9rem;">티켓을 소모하여 초월 카드를 획득하세요.</p>
+                <p>보유 카오스 티켓: <span id="ui-chaos-tickets" style="color:#ffd700; font-weight:bold; font-size:1.2rem;">0</span>장</p>
+            </div>
+            <button class="menu-btn" onclick="RPG.spinChaosRoulette()" style="border-color:#ffd700; color:#ffd700; width:80%; max-width:300px; padding:20px;">
+                카오스 룰렛 돌리기 (티켓 1장)
+            </button>
+            <button class="menu-btn" onclick="RPG.openTranscendenceCheck()" style="width:80%; max-width:300px;">
+                초월 확인
+            </button>
+            <button class="menu-btn" onclick="RPG.toMenu()" style="width:80%; max-width:300px; background:#444;">
+                돌아가기
+            </button>
+        </div>
+    </div>
+    <div id="screen-transcendence-check" class="screen">
+        <div style="display:flex; justify-content:space-between; align-items:center; padding:10px; background:#1f1f1f;">
+            <h3 style="margin:0; color:#ffd700;">보유 초월 카드 (다음 오리진 게임 적용)</h3>
+            <button onclick="RPG.openChaosRoulette()" style="background:#fff; color:#000; padding:5px 10px; border:1px solid #ccc; cursor:pointer; border-radius:4px;">뒤로</button>
+        </div>
+        <div id="transcendence-grid" class="card-grid"></div>
+    </div>
     <div id="screen-battle" class="screen">
         <div class="battle-header"><span>Turn: <span id="bt-turn">1</span></span><div id="field-buff-box" class="field-buffs" onclick="RPG.showFieldBuffInfo()"></div></div>
         <div class="visual-stage">
@@ -205,7 +237,10 @@
 
 <div id="modal-mode-select" class="modal">
     <div class="modal-content" style="height:auto; min-height:400px; width: 360px;">
-        <h3>게임 모드 선택</h3>
+        <div style="position:relative;">
+            <h3>게임 모드 선택</h3>
+            <button id="btn-chaos-roulette" onclick="RPG.openChaosRoulette()" style="display:none; position:absolute; top:-5px; right:0; padding:5px 10px; font-size:0.8rem; background:#333; border:1px solid #ffd700; color:#ffd700; border-radius:5px;">카오스 룰렛</button>
+        </div>
         <div id="mode-list" style="display:grid; grid-template-columns: 1fr 1fr; gap:5px; margin-bottom:10px;"></div>
         <div id="mode-desc" style="font-size:0.8rem; color:#ccc; background:#333; padding:10px; border-radius:5px; height:100px; overflow-y:auto; text-align:left;">
             모드를 선택해주세요.
@@ -494,6 +529,52 @@ const SIDE_EFFECT_HANDLERS = {
     },
     'delayed_attack_field': (ctx, eff) => {
         if (eff.field) RPG.applyFieldBuff(eff.field);
+    },
+    'delayed_turn_scale_attack': (ctx, eff) => {
+        RPG.battle.delayedEffects.push({
+            turn: RPG.battle.turn + eff.turns,
+            source: ctx.source,
+            skill: { ...ctx.skill, effects: [...(ctx.skill.effects||[]), {type: 'dmg_boost_turn_scale', scale: eff.scale, startTurn: RPG.battle.turn}] }
+        });
+        ctx.logFn(`인과역전! ${eff.turns}턴 후 발동합니다!`);
+    },
+    'delayed_attack_debuff_scale': (ctx, eff) => {
+        RPG.battle.delayedEffects.push({
+            turn: RPG.battle.turn + eff.turns,
+            source: ctx.source,
+            skill: { ...ctx.skill, effects: [...(ctx.skill.effects||[]), {type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: eff.multPerDebuff}] }
+        });
+        ctx.logFn(`제로그라비티! ${eff.turns}턴 후 발동합니다!`);
+    },
+    'random_skill_trigger_from_list': (ctx, eff) => {
+        const skillMap = [
+            { id: 'gold_dragon', skill: '얼티밋브레스' },
+            { id: 'zeke', skill: '라그나로크' },
+            { id: 'jasmine', skill: '여신강림' },
+            { id: 'frozen_witch', skill: '블리자드' },
+            { id: 'behemoth', skill: '어스퀘이크' },
+            { id: 'gray', skill: '차원절단' },
+            { id: 'rumi', skill: '밀키웨이엑스터시' },
+            { id: 'phoenix', skill: '메테오임팩트' },
+            { id: 'time_ruler', skill: '섀도우트위스트' }
+        ];
+
+        const pick = skillMap[Math.floor(Math.random() * skillMap.length)];
+        const card = RPG.getCardData(pick.id);
+        if(!card) return;
+        const skill = card.skills.find(s => s.name === pick.skill);
+
+        if (skill) {
+            ctx.logFn(`[데스티니룰렛] ${card.name}의 ${skill.name} 발동!`);
+            RPG.executeSkill(ctx.source, ctx.target, skill, true);
+        }
+    },
+    'apply_lumi_guard': (ctx, eff) => {
+        let buffs = RPG.battle.fieldBuffs.map(b => b.name);
+        if(buffs.includes('moon_bless') && buffs.includes('star_powder')) {
+            ctx.source.buffs['guard'] = 1;
+            ctx.logFn("스타파우더&달의축복: 가드 효과(버프) 적용!");
+        }
     }
 };
 
@@ -506,7 +587,10 @@ const RPG = {
     global: {
         unlocked_modes: ['origin'],
         unlocked_bonus_cards: [],
-        achievements: { origin: false }
+        achievements: { origin: false },
+        chaosTickets: 0,
+        lastRewardDate: null,
+        pendingTranscendenceCards: []
     },
 
     // Game State (Session Persistent)
@@ -584,8 +668,24 @@ const RPG = {
         localStorage.setItem('cardRpgGlobal', JSON.stringify(this.global));
     },
 
+    checkDailyChaosTicket() {
+        const today = new Date().toDateString();
+        if (this.global.lastRewardDate !== today) {
+            this.global.lastRewardDate = today;
+            this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
+            this.saveGlobalData();
+            this.showAlert("출석 보상: 카오스 티켓 1장을 획득했습니다!");
+        }
+    },
+
+    checkAllBonusUnlocked() {
+        if (!this.global.unlocked_bonus_cards) return false;
+        return BONUS_CARDS.every(c => this.global.unlocked_bonus_cards.includes(c.id));
+    },
+
     startGame(mode) {
         this.loadGlobalData();
+        this.checkDailyChaosTicket();
 
         if(mode === 'load') {
             const save = localStorage.getItem('cardRpgSave');
@@ -623,6 +723,15 @@ const RPG = {
         const desc = document.getElementById('mode-desc');
         list.innerHTML = "";
         desc.innerText = "모드를 선택하여 설명을 확인하세요.";
+
+        const chaosBtn = document.getElementById('btn-chaos-roulette');
+        if (chaosBtn) {
+            if (this.checkAllBonusUnlocked()) {
+                chaosBtn.style.display = 'block';
+            } else {
+                chaosBtn.style.display = 'none';
+            }
+        }
 
         const MODES = [
             { id: 'origin', name: '오리진', desc: '기본 모드입니다.\n(성공조건: 없음 / 무한)' },
@@ -716,6 +825,12 @@ const RPG = {
             this.state.inventory = [...picks];
         }
 
+        if (mode === 'origin' && this.global.pendingTranscendenceCards) {
+            this.state.transcendencePool = [...this.global.pendingTranscendenceCards];
+        } else {
+            this.state.transcendencePool = [];
+        }
+
         // Load persistent wordbook
         const vocab = localStorage.getItem('cardRpgVocab');
         if(vocab) this.state.wrongWords = JSON.parse(vocab);
@@ -796,6 +911,40 @@ const RPG = {
 
     openSystemMenu() {
         document.getElementById('modal-menu').classList.add('active');
+    },
+
+    // --- Chaos Roulette ---
+    openChaosRoulette() {
+        if (!this.checkAllBonusUnlocked()) return this.showAlert("아직 해금되지 않았습니다.");
+        this.showScreen('screen-chaos-roulette');
+        document.getElementById('ui-chaos-tickets').innerText = this.global.chaosTickets || 0;
+    },
+
+    spinChaosRoulette() {
+        if ((this.global.chaosTickets || 0) < 1) return this.showAlert("티켓이 부족합니다.");
+
+        let pool = TRANSCENDENCE_CARDS.filter(c => !this.global.pendingTranscendenceCards.includes(c.id));
+
+        if (pool.length === 0) return this.showAlert("이미 모든 초월 카드를 보유하고 있습니다. (다음 오리진 게임에서 사용하세요)");
+
+        this.global.chaosTickets--;
+        const pick = pool[Math.floor(Math.random() * pool.length)];
+        this.global.pendingTranscendenceCards.push(pick.id);
+        this.saveGlobalData();
+
+        document.getElementById('ui-chaos-tickets').innerText = this.global.chaosTickets;
+
+        const modal = document.getElementById('modal-gacha');
+        const content = document.getElementById('gacha-result');
+        document.getElementById('gacha-title').innerText = "초월 소환 성공!";
+        content.innerHTML = `<div class="card-item transcendence" style="border:2px solid #ffd700; color:#ffd700; font-size:1.2rem; font-weight:bold; margin-bottom:10px; animation: glow-gold 2s infinite;">[초월] ${pick.name}</div>
+            <div class="portrait" style="width:120px; height:160px; margin:0 auto; border-color:#ffd700;"><img src="${pick.name}.png" onerror="this.style.display='none'"></div><p>다음 오리진 게임 전설 풀에 추가되었습니다!</p>`;
+        modal.classList.add('active');
+    },
+
+    openTranscendenceCheck() {
+        this.showScreen('screen-transcendence-check');
+        this.renderCardList('transcendence-grid', this.global.pendingTranscendenceCards, (id) => this.showCardInfo(id));
     },
 
     // --- Chaos Blessing ---
@@ -968,6 +1117,7 @@ const RPG = {
             const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
             pool = pool.concat(bonus);
         }
+        pool = pool.filter(c => c.grade !== 'transcendence');
 
         const mode = this.state.mode;
         if (mode === 'restriction') {
@@ -1014,6 +1164,7 @@ const RPG = {
             const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
             pool = pool.concat(bonus);
         }
+        pool = pool.filter(c => c.grade !== 'transcendence');
 
         // 3. Filter by Mode Rarity
         const mode = this.state.mode;
@@ -1206,6 +1357,12 @@ const RPG = {
             pool = pool.concat(bonus);
         }
 
+        // Add Transcendence Cards (Origin Only, Legend Only)
+        if (mode === 'origin' && grade === 'legend' && this.state.transcendencePool && this.state.transcendencePool.length > 0) {
+             const transCards = TRANSCENDENCE_CARDS.filter(c => this.state.transcendencePool.includes(c.id));
+             pool = pool.concat(transCards);
+        }
+
         if(pool.length === 0) {
             // Fallback if pool is empty (e.g. no cards of that grade? Should not happen with standard set)
             // But if Restriction mode and we rolled something else? Logic guarantees valid grade.
@@ -1221,10 +1378,12 @@ const RPG = {
         const modal = document.getElementById('modal-gacha');
         const content = document.getElementById('gacha-result');
         let color = '#bdbdbd', title = "획득!";
-        if(grade === 'legend') { color = '#ff5252'; title = "🎉 대박! 전설 카드! 🎉"; }
+        if(pick.grade === 'transcendence') { color = '#ffd700'; title = "🌟 초월 카드 강림! 🌟"; }
+        else if(grade === 'legend') { color = '#ff5252'; title = "🎉 대박! 전설 카드! 🎉"; }
         else if(grade === 'epic') { color = '#e040fb'; title = "✨ 에픽 카드! ✨"; }
 
         let msgTitle = isChallenge ? "도전 뽑기 성공!" : "획득!";
+        if(pick.grade === 'transcendence') msgTitle = title;
         document.getElementById('gacha-title').innerText = msgTitle;
         content.innerHTML = `<div style="color:${color}; font-size:1.2rem; font-weight:bold; margin-bottom:10px;">[${pick.grade.toUpperCase()}] ${pick.name}</div>
             <div class="portrait" style="width:120px; height:160px; margin:0 auto;"><img src="${pick.name}.png" onerror="this.style.display='none'"></div><p>새로운 동료를 얻었습니다!</p>`;
@@ -1943,7 +2102,9 @@ const RPG = {
             victim,
             killer,
             RPG.battle.fieldBuffs,
-            (msg) => RPG.log(msg)
+            (msg) => RPG.log(msg),
+            RPG.state.deck,
+            RPG.battle.turn
         );
 
         // Apply results
@@ -2035,7 +2196,9 @@ const RPG = {
             RPG.battle.fieldBuffs,
             RPG.battle.activeTraits,
             (msg) => RPG.log(msg),
-            RPG.state.mode // PASS MODE
+            RPG.state.mode, // PASS MODE
+            RPG.state.deck, // PASS DECK
+            RPG.battle.turn // PASS TURN
         );
 
         if(target.id === 'demon_god') {
@@ -2396,6 +2559,13 @@ const RPG = {
                 }
             }
 
+            // Transcendence Ticket Logic (On Clear)
+            if (this.state.mode !== 'origin' && this.checkAllBonusUnlocked()) {
+                 this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
+                 this.saveGlobalData();
+                 this.log("<b>[보너스]</b> 카오스 티켓 1장 획득!");
+            }
+
             // Unlock Mode
             if (!this.global.unlocked_modes.includes(this.state.mode)) {
                 this.global.unlocked_modes.push(this.state.mode);
@@ -2498,6 +2668,11 @@ const RPG = {
 
         if (['chaos', 'draft'].includes(this.state.mode)) {
              this.saveRecord();
+        }
+
+        if (this.state.mode === 'origin') {
+             this.global.pendingTranscendenceCards = [];
+             this.saveGlobalData();
         }
 
         if (['chaos', 'draft'].includes(this.state.mode)) {

--- a/card/logic.js
+++ b/card/logic.js
@@ -145,24 +145,15 @@ const DAMAGE_EFFECT_HANDLERS = {
         let buffs = ctx.fieldBuffs.map(b => b.name);
         let hasSun = buffs.includes('sun_bless');
         let hasMoon = buffs.includes('moon_bless');
-        let hasEarth = buffs.includes('earth_bless');
-        let hasStar = buffs.includes('star_powder');
 
-        if(hasSun) ctx.mult += 1.0;
+        if(hasSun) {
+            let count = ctx.fieldBuffs.length;
+            ctx.mult += count * 1.0;
+            ctx.logFn(`태양의 축복: 필드버프 ${count}개! 배율 +${count.toFixed(1)}`);
+        }
         if(hasMoon) {
-             // Moon: Ignore 20% MDEF (Handled in Core Logic via activeTraits/Flags? Or modify ctx here?)
-             // We can't modify defense easily here unless we pass it.
-             // But we can attach a flag to ctx for the main calculator to see?
-             ctx.ignoreMdefRate = (ctx.ignoreMdefRate || 0) + 0.2;
-        }
-        if(hasSun && hasEarth) ctx.mult += 2.0;
-        if(hasSun && hasMoon) {
-            ctx.mult += 2.0;
             ctx.ignoreMdefRate = (ctx.ignoreMdefRate || 0) + 0.2;
-        }
-        if(hasMoon && hasStar) {
-            ctx.ignoreMdefRate = (ctx.ignoreMdefRate || 0) + 0.2;
-            ctx.logFn("스타파우더&달의축복: 가드 효과 발동!");
+            ctx.logFn("달의 축복: 마법방어력 20% 관통!");
         }
     },
     'count_deck_attr_dmg': (ctx, eff) => {

--- a/card/logic.js
+++ b/card/logic.js
@@ -140,6 +140,75 @@ const DAMAGE_EFFECT_HANDLERS = {
     'delayed_random_attack': (ctx, eff) => {
          ctx.mult = eff.min + Math.floor(Math.random() * (eff.max - eff.min + 1));
          ctx.logFn(`무작위 위력! x${ctx.mult.toFixed(1)}`);
+    },
+    'field_buff_combo_dmg': (ctx, eff) => {
+        let buffs = ctx.fieldBuffs.map(b => b.name);
+        let hasSun = buffs.includes('sun_bless');
+        let hasMoon = buffs.includes('moon_bless');
+        let hasEarth = buffs.includes('earth_bless');
+        let hasStar = buffs.includes('star_powder');
+
+        if(hasSun) ctx.mult += 1.0;
+        if(hasMoon) {
+             // Moon: Ignore 20% MDEF (Handled in Core Logic via activeTraits/Flags? Or modify ctx here?)
+             // We can't modify defense easily here unless we pass it.
+             // But we can attach a flag to ctx for the main calculator to see?
+             ctx.ignoreMdefRate = (ctx.ignoreMdefRate || 0) + 0.2;
+        }
+        if(hasSun && hasEarth) ctx.mult += 2.0;
+        if(hasSun && hasMoon) {
+            ctx.mult += 2.0;
+            ctx.ignoreMdefRate = (ctx.ignoreMdefRate || 0) + 0.2;
+        }
+        if(hasMoon && hasStar) {
+            ctx.ignoreMdefRate = (ctx.ignoreMdefRate || 0) + 0.2;
+            ctx.logFn("스타파우더&달의축복: 가드 효과 발동!");
+        }
+    },
+    'count_deck_attr_dmg': (ctx, eff) => {
+         // Need access to deck or active traits to count attributes?
+         // Logic.calculateDamage receives activeTraits.
+         // But deck content isn't directly passed.
+         // However, `ctx.activeTraits` contains synergy strings, not deck info.
+         // Logic.calculateDamage is called with `activeTraits`.
+         // We might need to pass `deck` to calculateDamage or check `source.proto.element` etc.
+         // Workaround: We can't easily count deck attributes inside Logic without deck data.
+         // BUT, we can pass the count as a param when calling calculateDamage?
+         // OR, we assume `activeTraits` or `fieldBuffs` implies something? No.
+         // We should update `Logic.calculateDamage` to accept `deck` or `attrCount`.
+         // OR, for now, use a hack: Look at `activeTraits` if it has specific markers? No.
+         // Best approach: Add `deck` to the `calculateDamage` signature in the next step,
+         // or handle this in index.html and pass the multiplier?
+         // Index.html `calcDamage` calls `Logic.calculateDamage`.
+         // I will update `Logic` to accept `deck` in the next step.
+         // For now, I'll write the handler assuming `ctx.deck` exists.
+         if(ctx.deck) {
+             const cards = ctx.deck.map(id => id ? (CARDS.find(c=>c.id===id)||BONUS_CARDS.find(c=>c.id===id)||TRANSCENDENCE_CARDS.find(c=>c.id===id)) : null).filter(c=>c);
+             let attrs = new Set();
+             let hasJoker = false;
+             cards.forEach(c => {
+                 if(c.id === 'joker') hasJoker = true;
+                 else attrs.add(c.element);
+             });
+             let count = hasJoker ? 5 : attrs.size;
+             ctx.mult += count * 1.0;
+             ctx.logFn(`덱 속성 ${count}종! 위력 +${count.toFixed(1)}배!`);
+         }
+    },
+    'turn_modulo_dmg': (ctx, eff) => {
+         // Need current turn. ctx does not have turn.
+         // Add turn to ctx in calculateDamage.
+         if(ctx.turn && ctx.turn % eff.mod === 0) {
+             ctx.mult *= eff.mult;
+             ctx.logFn(`4의 배수 턴(${ctx.turn})! 위력 ${eff.mult}배!`);
+         }
+    },
+    'dmg_boost_turn_scale': (ctx, eff) => {
+        if(ctx.turn) {
+            let bonus = ctx.turn * eff.scale;
+            ctx.mult += bonus;
+            ctx.logFn(`인과역전: ${ctx.turn}턴 경과! 배율 +${bonus.toFixed(1)}`);
+        }
     }
 };
 
@@ -171,6 +240,10 @@ const Logic = {
             if (trait.type === 'cond_no_field_buff_eva_crit' && fieldBuffs.length === 0) {
                 stats.evasion += trait.val;
                 stats.crit += trait.val;
+            }
+            if (trait.type === 'luna_jasmine_trait' && fieldBuffs.some(b => b.name === 'goddess_descent')) {
+                 stats.evasion += 25;
+                 stats.crit += 25;
             }
         }
 
@@ -235,7 +308,7 @@ const Logic = {
     },
 
     // 3. Damage Calculation
-    calculateDamage: function(source, target, skill, fieldBuffs, activeTraits, logFn, mode) {
+    calculateDamage: function(source, target, skill, fieldBuffs, activeTraits, logFn, mode, deck, turn) {
         if (!logFn) logFn = function() {};
 
         if(skill.type !== 'phy' && skill.type !== 'mag') return { dmg: 0, isCrit: false };
@@ -246,6 +319,9 @@ const Logic = {
         // 1. Critical
         let isCrit = Math.random() * 100 < srcStats.crit;
         if (skill.effects && skill.effects.some(e => e.type === 'force_crit')) isCrit = true;
+        // Check force_crit_chance
+        const forceCritChance = skill.effects ? skill.effects.find(e => e.type === 'force_crit_chance') : null;
+        if (forceCritChance && Math.random() * 100 < forceCritChance.val) isCrit = true;
 
         let critDmg = 1.5;
         if (source.proto && fieldBuffs.some(b => b.name === 'sun_bless')) critDmg += 0.6;
@@ -265,12 +341,17 @@ const Logic = {
             activeTraits: activeTraits,
             logFn: logFn,
             mode: mode,
-            mult: skill.val || 1.0
+            deck: deck,
+            turn: turn,
+            mult: skill.val || 1.0,
+            ignoreMdefRate: 0
         };
 
         // Elemental
         if (source.proto && source.proto.element && target.element) {
-             const elMult = this.getElementalMultiplier(source.proto.element, target.element);
+             let elMult = this.getElementalMultiplier(source.proto.element, target.element);
+             if (source.proto.trait && source.proto.trait.type === 'all_advantage') elMult = 1.2;
+
              if (elMult > 1.0) {
                  val *= elMult;
                  logFn("상성 우위! 대미지 20% 증가.");
@@ -324,10 +405,24 @@ const Logic = {
                 dmgBonus += (t.val - 1.0);
                 logFn("[특성] 심해의 주인: 적 디버프 3개 이상! 위력 폭발!");
             }
+            if(t.type === 'luna_jasmine_trait' && (target.buffs['divine'] || 0) >= 3) {
+                dmgBonus += (t.val - 1.0);
+                logFn("[특성] 루나&자스민: 디바인 3스택 이상! 위력 2배!");
+            }
+            if(t.type === 'behemoth_liberated_trait' && Object.keys(target.buffs).length >= 3) {
+                dmgBonus += (t.val - 1.0);
+                logFn("[특성] 해방된 베히모스: 디버프 3개 이상! 파괴적 일격!");
+            }
         }
 
         // Defense
         let def = (skill.type === 'phy') ? tgtStats.def : tgtStats.mdef;
+
+        if (ctx.ignoreMdefRate > 0 && skill.type === 'mag') {
+             let ignore = Math.floor(tgtStats.mdef * ctx.ignoreMdefRate);
+             def = Math.max(0, def - ignore);
+             logFn(`[효과] 마법방어력 ${Math.round(ctx.ignoreMdefRate*100)}% 관통!`);
+        }
 
         // [추가] 신데렐라: 스택 비례 방어 무시
         if (t && t.type === 'ignore_def_mdef_by_stack') {
@@ -499,7 +594,7 @@ const Logic = {
     },
 
     // 6. Handle Death Traits
-    handleDeathTraits: function(victim, killer, fieldBuffs, logFn) {
+    handleDeathTraits: function(victim, killer, fieldBuffs, logFn, deck, turn) {
         if (!logFn) logFn = function() {};
 
         let result = { damageToKiller: 0, fieldBuffsToAdd: [], killerDebuffs: {} };
@@ -507,7 +602,7 @@ const Logic = {
 
         if(t.type === 'death_dmg_mag') {
             let dummySkill = { name: '사망 반격', type: 'mag', val: t.val, effects: [] };
-            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn);
+            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn, null, deck, turn);
             if(dmgResult.dmg > 0) {
                 result.damageToKiller += dmgResult.dmg;
                 logFn(`[특성] 사망 반격! ${dmgResult.isCrit?'Critical! ':''}<span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
@@ -516,7 +611,7 @@ const Logic = {
         else if(t.type === 'death_dmg_debuff') {
             let cnt = Object.keys(killer.buffs).length;
             let dummySkill = { name: '저주 반격', type: 'mag', val: cnt * t.val, effects: [] };
-            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn);
+            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn, null, deck, turn);
             if(dmgResult.dmg > 0) {
                 result.damageToKiller += dmgResult.dmg;
                 logFn(`[특성] 저주 반격! ${dmgResult.isCrit?'Critical! ':''}<span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
@@ -542,7 +637,7 @@ const Logic = {
         else if(t.type === 'death_field_buff_count_dmg') {
              let count = fieldBuffs.length;
              let dummySkill = { name: '사망 반격', type: 'mag', val: count * t.val, effects: [] };
-             let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn);
+             let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn, null, deck, turn);
              if(dmgResult.dmg > 0) {
                  result.damageToKiller += dmgResult.dmg;
                  logFn(`[특성] 사망 반격! (필드버프 ${count}개) ${dmgResult.isCrit?'Critical! ':''}<span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
@@ -641,6 +736,17 @@ Logic.calculateInitialStats = function(playerProto, deck, allCards, idx) {
             p.def = Math.floor(p.def); p.mdef = Math.floor(p.mdef);
         }
     }
+
+        if(t.type === 'rabbit_synergy_boost') {
+             const rabbits = ['night_rabbit', 'snow_rabbit', 'silver_rabbit', 'trans_yeon_rabbit', 'joker'];
+             let count = 0;
+             deck.forEach(id => { if (id && rabbits.includes(id)) count++; });
+             if (count > 0) {
+                 let boost = count * (t.val / 100);
+                 p.atk = Math.floor(p.atk * (1 + boost));
+                 p.matk = Math.floor(p.matk * (1 + boost));
+             }
+        }
 
     return { stats: p, activeTrait: active ? t.type : null };
 };


### PR DESCRIPTION
Implemented the requested Transcendence Card system.
- Added `TRANSCENDENCE_CARDS` data.
- Added `Chaos Roulette` menu and UI.
- Implemented logic for daily tickets and clear tickets.
- Implemented skill logic for all 8 new cards, including complex traits like `delayed_turn_scale_attack`, `field_buff_combo_dmg`, and `count_deck_attr_dmg`.
- Ensured Transcendence cards are added to the Origin mode pool correctly and cleared after use.
- Verified frontend UI with Playwright.

---
*PR created automatically by Jules for task [17234477146007471146](https://jules.google.com/task/17234477146007471146) started by @romarin0325-cell*