### PR TITLE
Fix callback execution order bug in modal closing functions

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1260,9 +1260,10 @@ const RPG = {
     },
     closeLectureView() {
         document.getElementById('modal-lecture-view').classList.remove('active');
-        if(this.tempLectureClose) {
-            this.tempLectureClose();
-            this.tempLectureClose = null;
+        const cb = this.tempLectureClose;
+        this.tempLectureClose = null;
+        if(cb) {
+            cb();
         }
     },
 
@@ -2654,9 +2655,10 @@ const RPG = {
     },
     closeInfoModal() {
         document.getElementById('modal-info').classList.remove('active');
-        if (this.tempOnClose) {
-            this.tempOnClose();
-            this.tempOnClose = null;
+        const cb = this.tempOnClose;
+        this.tempOnClose = null;
+        if (cb) {
+            cb();
         }
     },
 


### PR DESCRIPTION
Modified `closeInfoModal` and `closeLectureView` in `card/index.html` to ensure that callbacks are executed after the property is cleared, preventing race conditions when callbacks set new callbacks. Confirmed with reproduction script.

---
*PR created automatically by Jules for task [16170069672820124630](https://jules.google.com/task/16170069672820124630) started by @romarin0325-cell*