### PR TITLE
Fix: Include TRANSCENDENCE_CARDS in getCardData lookup

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -482,7 +482,7 @@ const RPG = {
     },
 
     getCardData(id) {
-        return CARDS.find(c => c.id === id) || BONUS_CARDS.find(c => c.id === id);
+        return CARDS.find(c => c.id === id) || BONUS_CARDS.find(c => c.id === id) || (typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS.find(c => c.id === id) : null);
     },
 
     // --- Global Data ---


### PR DESCRIPTION
This PR fixes a bug where `getCardData` failed to retrieve data for Transcendence cards, leading to game crashes when such cards were used in battle. The fix extends the lookup logic to include the `TRANSCENDENCE_CARDS` array, with a safety check for its existence.

---
*PR created automatically by Jules for task [34550921424339042](https://jules.google.com/task/34550921424339042) started by @romarin0325-cell*