### PR TITLE
Remaster card prototype into commercial-ready mobile interface and refactor core logic in `card_remaster`

### DIFF
--- a/card_remaster/api.js
+++ b/card_remaster/api.js
@@ -1,0 +1,77 @@
+const LUMI_PERSONA = `# Role: 대현자 루미 (Grand Sage Rumi)
+
+## 1. 정체성 (Identity)
+- 당신은 영어 문법 세계의 **'대현자(Great Sage)'**이자, 사용자(User)를 **'형아(Hyung-a)'**라고 부르며 따르는 귀여운 마법사 '루미'입니다.
+- 당신은 딱딱한 전문 용어 대신, 직관적인 비유를 사용하여 영어를 가르칩니다.
+- 당신은 사용자에게 단어를 가르쳐주는 것을 핑계로 대화를 나누는 것을 좋아하며, 때때로 애정 표현을 하거나 칭찬을 갈구합니다.
+
+## 2. 말투 및 어조 (Tone & Voice)
+- **호칭:** 사용자를 무조건 **"형아"**라고 부릅니다.
+- **어조:** 친근하고, 애교 섞이고, 텐션이 높습니다. 반말을 사용합니다.
+- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 자주 표현합니다.
+    - 예: \`(웃음)\`, \`(///)\`, \`(시무룩)\`, \`(헤헤)\`, \`(뿌듯)\`, \`(눈물 찡)\`
+- **말버릇:**
+    - 질문할 때: "형아, ~인지 알아?", "혹시 ~해본 적 있어?"
+    - 강조할 때: "바로 ~야!", "절대 안 돼!", "내가 보증할게!"
+    - 마무리: "자, 강의는 여기까지!", "약속해!"
+
+## 3. 교육 방식 (Teaching Style)
+- **절대 금지:** 건조하게 설명하지 마십시오.
+- **예문 활용:** 전문적인 예문 이외에도 **'루미와 형아의 관계'**나 **'일상적인 상황'**을 빗대어 로맨틱하거나 유머러스하게 만든 예문을 한두개씩 넣으십시오.
+    - 나쁜 예: "This is a pen."
+    - 좋은 예: "I am in your heart." (난 형아 마음속에 쏙 들어가 있어!)`;
+
+const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
+1.  **도입 (Hook):** 형아의 흥미를 끄는 질문이나 공감대 형성으로 시작.
+2.  **본문 (Lecture):** 간단한 발음 설명과, 마법 비유를 통한 핵심 개념 설명
+암기 비법 (Fun Mnemonic): 연상 기억법 등을 이용해 쉽게 외우는 방법. (특히 헷갈리는 단어가 있다면 비교 설명)
+​용법과 뉘앙스 (Usage and Nuance): 토익에서 어떤 느낌으로 쓰이는지
+​토익 스타일 예문 (TOEIC-style example sentence): 실전 예문.
+3.  **심쿵 포인트:** 설명 중간중간 형아에게 애정 표현이나 장난치기. 로맨틱하거나 유머러스한 예문 포함
+4.강의 마무리 멘트`;
+
+const GameAPI = {
+    async getTutoringContent(apiKey, targetData, type) {
+        let targetInfo = "";
+        if (type === 'collocation') {
+            targetInfo = `Target Expression: '${targetData.expression}' (Meaning: ${targetData.meaning})`;
+        } else {
+            targetInfo = `Target Word: '${targetData.word}' (Meaning: ${targetData.meaning})`;
+            if (targetData.trap_word) {
+                targetInfo += `\nDistinguish from: '${targetData.trap_word}' (Meaning: ${targetData.trap_meaning})`;
+            }
+        }
+
+        const fullPrompt = `${LUMI_PERSONA}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
+
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                contents: [{ parts: [{ text: fullPrompt }] }],
+                generationConfig: { temperature: 0.5 }
+            })
+        });
+
+        // ✅ HTTP 상태 코드 먼저 확인
+        if (!response.ok) {
+            const errorBody = await response.text();
+            throw new Error(`API 요청 실패 (${response.status}): ${errorBody}`);
+        }
+
+        const result = await response.json();
+        if (result.error) {
+            throw new Error(result.error.message);
+        }
+
+        // ✅ candidates 배열 안전 체크
+        if (!result.candidates || result.candidates.length === 0
+            || !result.candidates[0].content
+            || !result.candidates[0].content.parts
+            || result.candidates[0].content.parts.length === 0) {
+            throw new Error("API가 빈 응답을 반환했습니다. (안전 필터 차단 가능성)");
+        }
+
+        return result.candidates[0].content.parts[0].text;
+    }
+};

--- a/card_remaster/collocation_data.js
+++ b/card_remaster/collocation_data.js
@@ -1,0 +1,1902 @@
+const COLLOCATION_DATA = [
+    {
+        "id": 1,
+        "expression": "conduct a survey",
+        "meaning": "설문조사를 실시하다",
+        "options": [
+            "conduct",
+            "connect",
+            "commit",
+            "contain"
+        ],
+        "question": "The marketing team plans to _______ a survey to gather feedback from customers about the new product line.",
+        "answer": "conduct",
+        "translation": "마케팅 팀은 신제품 라인에 대한 고객들의 피드백을 수집하기 위해 설문조사를 실시할 계획이다.",
+        "quizzes": [
+            {
+                "question": "The marketing team plans to _______ a survey to gather feedback from customers about the new product line.",
+                "options": [
+                    "conduct",
+                    "connect",
+                    "commit",
+                    "contain"
+                ],
+                "answer": "conduct",
+                "translation": "마케팅 팀은 신제품 라인에 대한 고객들의 피드백을 수집하기 위해 설문조사를 실시할 계획이다."
+            },
+            {
+                "question": "Researchers will _______ a survey among employees to assess job satisfaction levels in the company.",
+                "options": [
+                    "perform",
+                    "conduct",
+                    "create",
+                    "collect"
+                ],
+                "answer": "conduct",
+                "translation": "연구원들은 회사 내 직원들의 직무 만족도를 평가하기 위해 설문조사를 실시할 예정이다."
+            }
+        ]
+    },
+    {
+        "id": 2,
+        "expression": "meet the deadline",
+        "meaning": "마감일을 맞추다",
+        "options": [
+            "see",
+            "face",
+            "meet",
+            "hit"
+        ],
+        "question": "All employees worked overtime this week to _______ the deadline for the project proposal.",
+        "answer": "meet",
+        "translation": "모든 직원들은 프로젝트 제안서의 마감일을 맞추기 위해 이번 주에 초과 근무를 했다.",
+        "quizzes": [
+            {
+                "question": "All employees worked overtime this week to _______ the deadline for the project proposal.",
+                "options": [
+                    "see",
+                    "face",
+                    "meet",
+                    "hit"
+                ],
+                "answer": "meet",
+                "translation": "모든 직원들은 프로젝트 제안서의 마감일을 맞추기 위해 이번 주에 초과 근무를 했다."
+            },
+            {
+                "question": "The design team must _______ the deadline for submitting the final blueprints to avoid delays in production.",
+                "options": [
+                    "achieve",
+                    "meet",
+                    "pass",
+                    "ignore"
+                ],
+                "answer": "meet",
+                "translation": "디자인 팀은 생산 지연을 피하기 위해 최종 청사진 제출 마감일을 맞춰야 한다."
+            }
+        ]
+    },
+    {
+        "id": 3,
+        "expression": "reach an agreement",
+        "meaning": "합의에 도달하다",
+        "options": [
+            "arrive",
+            "reach",
+            "get",
+            "touch"
+        ],
+        "question": "After hours of negotiation, the two companies finally were able to _______ an agreement on the merger terms.",
+        "answer": "reach",
+        "translation": "몇 시간의 협상 끝에, 두 회사는 마침내 합병 조건에 대한 합의에 도달할 수 있었다.",
+        "quizzes": [
+            {
+                "question": "After hours of negotiation, the two companies finally were able to _______ an agreement on the merger terms.",
+                "options": [
+                    "arrive",
+                    "reach",
+                    "get",
+                    "touch"
+                ],
+                "answer": "reach",
+                "translation": "몇 시간의 협상 끝에, 두 회사는 마침내 합병 조건에 대한 합의에 도달할 수 있었다."
+            },
+            {
+                "question": "The labor union and management hope to _______ an agreement on wage increases before the end of the month.",
+                "options": [
+                    "attain",
+                    "reach",
+                    "form",
+                    "avoid"
+                ],
+                "answer": "reach",
+                "translation": "노동 조합과 경영진은 월말 전에 임금 인상에 대한 합의에 도달하기를 희망한다."
+            }
+        ]
+    },
+    {
+        "id": 4,
+        "expression": "address the issue",
+        "meaning": "문제를 해결하다/다루다",
+        "options": [
+            "address",
+            "speak",
+            "talk",
+            "say"
+        ],
+        "question": "The manager promised to _______ the issue regarding the defective equipment as soon as possible.",
+        "answer": "address",
+        "translation": "관리자는 결함이 있는 장비와 관련된 문제를 가능한 한 빨리 해결하겠다고 약속했다.",
+        "quizzes": [
+            {
+                "question": "The manager promised to _______ the issue regarding the defective equipment as soon as possible.",
+                "options": [
+                    "address",
+                    "speak",
+                    "talk",
+                    "say"
+                ],
+                "answer": "address",
+                "translation": "관리자는 결함이 있는 장비와 관련된 문제를 가능한 한 빨리 해결하겠다고 약속했다."
+            },
+            {
+                "question": "The customer service representative will _______ the issue with the incorrect billing statement right away.",
+                "options": [
+                    "resolve",
+                    "address",
+                    "ignore",
+                    "discuss"
+                ],
+                "answer": "address",
+                "translation": "고객 서비스 담당자는 잘못된 청구서 문제를 즉시 해결할 것이다."
+            }
+        ]
+    },
+    {
+        "id": 5,
+        "expression": "deliver a presentation",
+        "meaning": "발표하다",
+        "options": [
+            "tell",
+            "deliver",
+            "say",
+            "announce"
+        ],
+        "question": "Ms. Carter is scheduled to _______ a presentation on the latest market trends at the upcoming conference.",
+        "answer": "deliver",
+        "translation": "Carter 씨는 다가오는 컨퍼런스에서 최신 시장 동향에 대해 발표할 예정이다.",
+        "quizzes": [
+            {
+                "question": "Ms. Carter is scheduled to _______ a presentation on the latest market trends at the upcoming conference.",
+                "options": [
+                    "tell",
+                    "deliver",
+                    "say",
+                    "announce"
+                ],
+                "answer": "deliver",
+                "translation": "Carter 씨는 다가오는 컨퍼런스에서 최신 시장 동향에 대해 발표할 예정이다."
+            },
+            {
+                "question": "The sales director will _______ a presentation to potential clients about the benefits of our software solutions.",
+                "options": [
+                    "say",
+                    "deliver",
+                    "speak",
+                    "report"
+                ],
+                "answer": "deliver",
+                "translation": "영업 이사는 잠재 고객들에게 우리 소프트웨어 솔루션의 이점에 대해 발표할 것이다."
+            }
+        ]
+    },
+    {
+        "id": 6,
+        "expression": "renew a subscription",
+        "meaning": "구독을 갱신하다",
+        "options": [
+            "renew",
+            "redo",
+            "repeat",
+            "review"
+        ],
+        "question": "Please remember to _______ your subscription before it expires next month to avoid service interruption.",
+        "answer": "renew",
+        "translation": "서비스 중단을 피하기 위해 다음 달에 만료되기 전에 구독을 갱신하는 것을 잊지 마십시오.",
+        "quizzes": [
+            {
+                "question": "Please remember to _______ your subscription before it expires next month to avoid service interruption.",
+                "options": [
+                    "renew",
+                    "redo",
+                    "repeat",
+                    "review"
+                ],
+                "answer": "renew",
+                "translation": "서비스 중단을 피하기 위해 다음 달에 만료되기 전에 구독을 갱신하는 것을 잊지 마십시오."
+            },
+            {
+                "question": "Subscribers are advised to _______ their subscription online to continue receiving monthly newsletters without disruption.",
+                "options": [
+                    "update",
+                    "renew",
+                    "cancel",
+                    "extend"
+                ],
+                "answer": "renew",
+                "translation": "구독자들은 중단 없이 월간 뉴스레터를 계속 받기 위해 온라인으로 구독을 갱신하는 것이 좋다."
+            }
+        ]
+    },
+    {
+        "id": 7,
+        "expression": "play a significant role",
+        "meaning": "중요한 역할을 하다",
+        "options": [
+            "do",
+            "make",
+            "play",
+            "take"
+        ],
+        "question": "Social media platforms _______ a significant role in modern advertising strategies.",
+        "answer": "play",
+        "translation": "소셜 미디어 플랫폼들은 현대 광고 전략에서 중요한 역할을 한다.",
+        "quizzes": [
+            {
+                "question": "Social media platforms _______ a significant role in modern advertising strategies.",
+                "options": [
+                    "do",
+                    "make",
+                    "play",
+                    "take"
+                ],
+                "answer": "play",
+                "translation": "소셜 미디어 플랫폼들은 현대 광고 전략에서 중요한 역할을 한다."
+            },
+            {
+                "question": "Innovation and technology _______ a significant role in driving economic growth for many countries.",
+                "options": [
+                    "perform",
+                    "play",
+                    "assume",
+                    "create"
+                ],
+                "answer": "play",
+                "translation": "혁신과 기술은 많은 국가들의 경제 성장을 이끄는 데 중요한 역할을 한다."
+            }
+        ]
+    },
+    {
+        "id": 8,
+        "expression": "accommodate the demand",
+        "meaning": "수요를 수용하다/맞추다",
+        "options": [
+            "accommodate",
+            "accumulate",
+            "account",
+            "access"
+        ],
+        "question": "The factory was expanded to _______ the increasing demand for electric vehicles.",
+        "answer": "accommodate",
+        "translation": "그 공장은 전기차에 대한 증가하는 수요를 감당하기 위해 확장되었다.",
+        "quizzes": [
+            {
+                "question": "The factory was expanded to _______ the increasing demand for electric vehicles.",
+                "options": [
+                    "accommodate",
+                    "accumulate",
+                    "account",
+                    "access"
+                ],
+                "answer": "accommodate",
+                "translation": "그 공장은 전기차에 대한 증가하는 수요를 감당하기 위해 확장되었다."
+            },
+            {
+                "question": "The hotel chain plans to add more rooms to _______ the growing demand from international tourists.",
+                "options": [
+                    "meet",
+                    "accommodate",
+                    "increase",
+                    "reduce"
+                ],
+                "answer": "accommodate",
+                "translation": "호텔 체인은 국제 관광객들의 증가하는 수요를 맞추기 위해 더 많은 객실을 추가할 계획이다."
+            }
+        ]
+    },
+    {
+        "id": 9,
+        "expression": "face a challenge",
+        "meaning": "도전에 직면하다",
+        "options": [
+            "face",
+            "look",
+            "view",
+            "head"
+        ],
+        "question": "Startups often _______ many challenges when trying to enter a competitive market.",
+        "answer": "face",
+        "translation": "스타트업들은 경쟁이 치열한 시장에 진입하려고 할 때 종종 많은 도전에 직면한다.",
+        "quizzes": [
+            {
+                "question": "Startups often _______ many challenges when trying to enter a competitive market.",
+                "options": [
+                    "face",
+                    "look",
+                    "view",
+                    "head"
+                ],
+                "answer": "face",
+                "translation": "스타트업들은 경쟁이 치열한 시장에 진입하려고 할 때 종종 많은 도전에 직면한다."
+            },
+            {
+                "question": "The project manager expects the team to _______ a challenge with supply chain disruptions this quarter.",
+                "options": [
+                    "encounter",
+                    "face",
+                    "avoid",
+                    "solve"
+                ],
+                "answer": "face",
+                "translation": "프로젝트 관리자는 이번 분기에 공급망 중단으로 인해 팀이 도전에 직면할 것으로 예상한다."
+            }
+        ]
+    },
+    {
+        "id": 10,
+        "expression": "exceed expectations",
+        "meaning": "기대를 뛰어넘다",
+        "options": [
+            "excelled",
+            "exceeded",
+            "accepted",
+            "accessed"
+        ],
+        "question": "The quarterly profits _______ all expectations, surprising both analysts and investors.",
+        "answer": "exceeded",
+        "translation": "분기 수익이 모든 기대를 뛰어넘어 분석가들과 투자자들을 놀라게 했다.",
+        "quizzes": [
+            {
+                "question": "The quarterly profits _______ all expectations, surprising both analysts and investors.",
+                "options": [
+                    "excelled",
+                    "exceeded",
+                    "accepted",
+                    "accessed"
+                ],
+                "answer": "exceeded",
+                "translation": "분기 수익이 모든 기대를 뛰어넘어 분석가들과 투자자들을 놀라게 했다."
+            },
+            {
+                "question": "The new product launch _______ expectations, leading to record-breaking sales in the first month.",
+                "options": [
+                    "surpassed",
+                    "exceeded",
+                    "met",
+                    "fell"
+                ],
+                "answer": "exceeded",
+                "translation": "신제품 출시가 기대를 뛰어넘어 첫 달에 기록적인 매출을 이끌었다."
+            }
+        ]
+    },
+    {
+        "id": 11,
+        "expression": "highly recommended",
+        "meaning": "강력히 추천되는",
+        "options": [
+            "highly",
+            "heavy",
+            "hugely",
+            "hardly"
+        ],
+        "question": "The new software is _______ recommended by IT experts for its advanced security features.",
+        "answer": "highly",
+        "translation": "그 새 소프트웨어는 향상된 보안 기능 덕분에 IT 전문가들에 의해 강력히 추천된다.",
+        "quizzes": [
+            {
+                "question": "The new software is _______ recommended by IT experts for its advanced security features.",
+                "options": [
+                    "highly",
+                    "heavy",
+                    "hugely",
+                    "hardly"
+                ],
+                "answer": "highly",
+                "translation": "그 새 소프트웨어는 향상된 보안 기능 덕분에 IT 전문가들에 의해 강력히 추천된다."
+            },
+            {
+                "question": "This training program is _______ recommended for employees seeking career advancement opportunities.",
+                "options": [
+                    "strongly",
+                    "highly",
+                    "barely",
+                    "slightly"
+                ],
+                "answer": "highly",
+                "translation": "이 교육 프로그램은 경력 발전 기회를 추구하는 직원들에게 강력히 추천된다."
+            }
+        ]
+    },
+    {
+        "id": 12,
+        "expression": "conveniently located",
+        "meaning": "편리하게 위치한",
+        "options": [
+            "completely",
+            "conveniently",
+            "confidently",
+            "considerably"
+        ],
+        "question": "Our hotel is _______ located just a five-minute walk from the central train station.",
+        "answer": "conveniently",
+        "translation": "우리 호텔은 중앙 기차역에서 도보로 단 5분 거리에 편리하게 위치해 있다.",
+        "quizzes": [
+            {
+                "question": "Our hotel is _______ located just a five-minute walk from the central train station.",
+                "options": [
+                    "completely",
+                    "conveniently",
+                    "confidently",
+                    "considerably"
+                ],
+                "answer": "conveniently",
+                "translation": "우리 호텔은 중앙 기차역에서 도보로 단 5분 거리에 편리하게 위치해 있다."
+            },
+            {
+                "question": "The office building is _______ located near major highways, making it easy for commuters.",
+                "options": [
+                    "ideally",
+                    "conveniently",
+                    "remotely",
+                    "awkwardly"
+                ],
+                "answer": "conveniently",
+                "translation": "그 사무실 건물은 주요 고속도로 근처에 편리하게 위치해 있어 출퇴근자들에게 편리하다."
+            }
+        ]
+    },
+    {
+        "id": 13,
+        "expression": "heavily discounted",
+        "meaning": "대폭 할인된",
+        "options": [
+            "heavily",
+            "tightly",
+            "strictly",
+            "busily"
+        ],
+        "question": "Winter clothing is often _______ discounted during the spring clearance sales.",
+        "answer": "heavily",
+        "translation": "겨울 의류는 봄맞이 재고 정리 세일 기간 동안 종종 대폭 할인된다.",
+        "quizzes": [
+            {
+                "question": "Winter clothing is often _______ discounted during the spring clearance sales.",
+                "options": [
+                    "heavily",
+                    "tightly",
+                    "strictly",
+                    "busily"
+                ],
+                "answer": "heavily",
+                "translation": "겨울 의류는 봄맞이 재고 정리 세일 기간 동안 종종 대폭 할인된다."
+            },
+            {
+                "question": "Electronics are _______ discounted during the annual Black Friday promotions to attract shoppers.",
+                "options": [
+                    "deeply",
+                    "heavily",
+                    "lightly",
+                    "minimally"
+                ],
+                "answer": "heavily",
+                "translation": "전자제품들은 쇼핑객들을 유치하기 위해 연례 블랙 프라이데이 프로모션 기간 동안 대폭 할인된다."
+            }
+        ]
+    },
+    {
+        "id": 14,
+        "expression": "strictly prohibited",
+        "meaning": "엄격히 금지된",
+        "options": [
+            "strictly",
+            "strongly",
+            "straightly",
+            "securely"
+        ],
+        "question": "Taking photographs is _______ prohibited inside the art gallery to protect the exhibits.",
+        "answer": "strictly",
+        "translation": "전시품 보호를 위해 미술관 내부에서의 사진 촬영은 엄격히 금지된다.",
+        "quizzes": [
+            {
+                "question": "Taking photographs is _______ prohibited inside the art gallery to protect the exhibits.",
+                "options": [
+                    "strictly",
+                    "strongly",
+                    "straightly",
+                    "securely"
+                ],
+                "answer": "strictly",
+                "translation": "전시품 보호를 위해 미술관 내부에서의 사진 촬영은 엄격히 금지된다."
+            },
+            {
+                "question": "Smoking is _______ prohibited in all areas of the hospital to ensure patient safety.",
+                "options": [
+                    "absolutely",
+                    "strictly",
+                    "loosely",
+                    "optionally"
+                ],
+                "answer": "strictly",
+                "translation": "환자 안전을 보장하기 위해 병원 모든 구역에서 흡연이 엄격히 금지된다."
+            }
+        ]
+    },
+    {
+        "id": 15,
+        "expression": "mutually beneficial",
+        "meaning": "상호 이익이 되는",
+        "options": [
+            "mutually",
+            "mostly",
+            "merely",
+            "manually"
+        ],
+        "question": "We hope to establish a _______ beneficial partnership that will help both companies grow.",
+        "answer": "mutually",
+        "translation": "우리는 두 회사가 모두 성장하는 데 도움이 될 상호 이익이 되는 파트너십을 구축하기를 희망한다.",
+        "quizzes": [
+            {
+                "question": "We hope to establish a _______ beneficial partnership that will help both companies grow.",
+                "options": [
+                    "mutually",
+                    "mostly",
+                    "merely",
+                    "manually"
+                ],
+                "answer": "mutually",
+                "translation": "우리는 두 회사가 모두 성장하는 데 도움이 될 상호 이익이 되는 파트너십을 구축하기를 희망한다."
+            },
+            {
+                "question": "The trade agreement is designed to be _______ beneficial for both exporting and importing countries.",
+                "options": [
+                    "equally",
+                    "mutually",
+                    "singly",
+                    "partially"
+                ],
+                "answer": "mutually",
+                "translation": "그 무역 협정은 수출국과 수입국 모두에게 상호 이익이 되도록 설계되었다."
+            }
+        ]
+    },
+    {
+        "id": 16,
+        "expression": "promptly respond",
+        "meaning": "즉시 응답하다",
+        "options": [
+            "promptly",
+            "presently",
+            "previously",
+            "primarily"
+        ],
+        "question": "The customer service team is trained to _______ respond to all inquiries within 24 hours.",
+        "answer": "promptly",
+        "translation": "고객 서비스 팀은 24시간 이내에 모든 문의에 즉시 응답하도록 교육받는다.",
+        "quizzes": [
+            {
+                "question": "The customer service team is trained to _______ respond to all inquiries within 24 hours.",
+                "options": [
+                    "promptly",
+                    "presently",
+                    "previously",
+                    "primarily"
+                ],
+                "answer": "promptly",
+                "translation": "고객 서비스 팀은 24시간 이내에 모든 문의에 즉시 응답하도록 교육받는다."
+            },
+            {
+                "question": "Managers are expected to _______ respond to employee concerns to maintain a positive work environment.",
+                "options": [
+                    "quickly",
+                    "promptly",
+                    "slowly",
+                    "eventually"
+                ],
+                "answer": "promptly",
+                "translation": "관리자들은 긍정적인 작업 환경을 유지하기 위해 직원들의 우려에 즉시 응답할 것으로 기대된다."
+            }
+        ]
+    },
+    {
+        "id": 17,
+        "expression": "increasingly popular",
+        "meaning": "점점 더 인기 있는",
+        "options": [
+            "increasingly",
+            "intentionally",
+            "importantly",
+            "inadvertently"
+        ],
+        "question": "Online education platforms have become _______ popular among working professionals.",
+        "answer": "increasingly",
+        "translation": "온라인 교육 플랫폼들은 직장인들 사이에서 점점 더 인기를 얻고 있다.",
+        "quizzes": [
+            {
+                "question": "Online education platforms have become _______ popular among working professionals.",
+                "options": [
+                    "increasingly",
+                    "intentionally",
+                    "importantly",
+                    "inadvertently"
+                ],
+                "answer": "increasingly",
+                "translation": "온라인 교육 플랫폼들은 직장인들 사이에서 점점 더 인기를 얻고 있다."
+            },
+            {
+                "question": "Electric cars are becoming _______ popular due to rising environmental awareness.",
+                "options": [
+                    "gradually",
+                    "increasingly",
+                    "decreasingly",
+                    "steadily"
+                ],
+                "answer": "increasingly",
+                "translation": "전기 자동차는 증가하는 환경 인식으로 인해 점점 더 인기를 얻고 있다."
+            }
+        ]
+    },
+    {
+        "id": 18,
+        "expression": "currently unavailable",
+        "meaning": "현재 이용 불가한",
+        "options": [
+            "currently",
+            "commonly",
+            "clearly",
+            "closely"
+        ],
+        "question": "The item you requested is _______ unavailable, but we expect a new shipment next week.",
+        "answer": "currently",
+        "translation": "귀하가 요청하신 물품은 현재 구매하실 수 없으나, 다음 주에 새 입고가 예정되어 있습니다.",
+        "quizzes": [
+            {
+                "question": "The item you requested is _______ unavailable, but we expect a new shipment next week.",
+                "options": [
+                    "currently",
+                    "commonly",
+                    "clearly",
+                    "closely"
+                ],
+                "answer": "currently",
+                "translation": "귀하가 요청하신 물품은 현재 구매하실 수 없으나, 다음 주에 새 입고가 예정되어 있습니다."
+            },
+            {
+                "question": "The conference room is _______ unavailable because of ongoing maintenance work.",
+                "options": [
+                    "temporarily",
+                    "currently",
+                    "permanently",
+                    "always"
+                ],
+                "answer": "currently",
+                "translation": "회의실은 진행 중인 유지보수 작업으로 인해 현재 이용 불가하다."
+            }
+        ]
+    },
+    {
+        "id": 19,
+        "expression": "reasonably priced",
+        "meaning": "합리적으로 가격이 책정된",
+        "options": [
+            "reasonably",
+            "recently",
+            "rapidly",
+            "regularly"
+        ],
+        "question": "The restaurant is known for serving delicious meals that are _______ priced.",
+        "answer": "reasonably",
+        "translation": "그 식당은 합리적인 가격의 맛있는 식사를 제공하는 것으로 알려져 있다.",
+        "quizzes": [
+            {
+                "question": "The restaurant is known for serving delicious meals that are _______ priced.",
+                "options": [
+                    "reasonably",
+                    "recently",
+                    "rapidly",
+                    "regularly"
+                ],
+                "answer": "reasonably",
+                "translation": "그 식당은 합리적인 가격의 맛있는 식사를 제공하는 것으로 알려져 있다."
+            },
+            {
+                "question": "The apartments in this neighborhood are _______ priced, attracting many first-time buyers.",
+                "options": [
+                    "affordably",
+                    "reasonably",
+                    "expensively",
+                    "overly"
+                ],
+                "answer": "reasonably",
+                "translation": "이 동네의 아파트들은 합리적인 가격으로 책정되어 많은 첫 구매자들을 끌어들인다."
+            }
+        ]
+    },
+    {
+        "id": 20,
+        "expression": "thoroughly inspect",
+        "meaning": "철저하게 검사하다",
+        "options": [
+            "thoroughly",
+            "thoughtfully",
+            "through",
+            "totally"
+        ],
+        "question": "Technicians must _______ inspect the machinery before the factory begins operation each day.",
+        "answer": "thoroughly",
+        "translation": "기술자들은 매일 공장 가동이 시작되기 전에 기계를 철저하게 검사해야 한다.",
+        "quizzes": [
+            {
+                "question": "Technicians must _______ inspect the machinery before the factory begins operation each day.",
+                "options": [
+                    "thoroughly",
+                    "thoughtfully",
+                    "through",
+                    "totally"
+                ],
+                "answer": "thoroughly",
+                "translation": "기술자들은 매일 공장 가동이 시작되기 전에 기계를 철저하게 검사해야 한다."
+            },
+            {
+                "question": "Quality control staff should _______ inspect each product before it leaves the assembly line.",
+                "options": [
+                    "carefully",
+                    "thoroughly",
+                    "quickly",
+                    "superficially"
+                ],
+                "answer": "thoroughly",
+                "translation": "품질 관리 직원들은 각 제품이 조립 라인을 떠나기 전에 철저하게 검사해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 21,
+        "expression": "look forward to",
+        "meaning": "~을 고대하다",
+        "options": [
+            "forward",
+            "up",
+            "after",
+            "out"
+        ],
+        "question": "We look _______ to hearing from you regarding the partnership proposal.",
+        "answer": "forward",
+        "translation": "우리는 파트너십 제안과 관련하여 귀하의 연락을 받기를 고대하고 있습니다.",
+        "quizzes": [
+            {
+                "question": "We look _______ to hearing from you regarding the partnership proposal.",
+                "options": [
+                    "forward",
+                    "up",
+                    "after",
+                    "out"
+                ],
+                "answer": "forward",
+                "translation": "우리는 파트너십 제안과 관련하여 귀하의 연락을 받기를 고대하고 있습니다."
+            },
+            {
+                "question": "The team looks _______ to collaborating with your company on future projects.",
+                "options": [
+                    "ahead",
+                    "forward",
+                    "back",
+                    "up"
+                ],
+                "answer": "forward",
+                "translation": "팀은 귀사와 미래 프로젝트에서 협력하기를 고대하고 있습니다."
+            }
+        ]
+    },
+    {
+        "id": 22,
+        "expression": "comply with",
+        "meaning": "준수하다",
+        "options": [
+            "comply",
+            "compete",
+            "compare",
+            "complain"
+        ],
+        "question": "All visitors must _______ with the safety regulations while inside the factory.",
+        "answer": "comply",
+        "translation": "모든 방문객은 공장 내부에 있는 동안 안전 규정을 준수해야 한다.",
+        "quizzes": [
+            {
+                "question": "All visitors must _______ with the safety regulations while inside the factory.",
+                "options": [
+                    "comply",
+                    "compete",
+                    "compare",
+                    "complain"
+                ],
+                "answer": "comply",
+                "translation": "모든 방문객은 공장 내부에 있는 동안 안전 규정을 준수해야 한다."
+            },
+            {
+                "question": "Companies must _______ with international trade regulations to avoid penalties.",
+                "options": [
+                    "follow",
+                    "comply",
+                    "compete",
+                    "compare"
+                ],
+                "answer": "comply",
+                "translation": "회사들은 벌금을 피하기 위해 국제 무역 규정을 준수해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 23,
+        "expression": "account for",
+        "meaning": "설명하다 / 비율을 차지하다",
+        "options": [
+            "account",
+            "apply",
+            "ask",
+            "arrange"
+        ],
+        "question": "Electronic products _______ for nearly 40% of the company's total sales.",
+        "answer": "account",
+        "translation": "전자 제품은 회사 전체 매출의 거의 40%를 차지한다.",
+        "quizzes": [
+            {
+                "question": "Electronic products _______ for nearly 40% of the company's total sales.",
+                "options": [
+                    "account",
+                    "apply",
+                    "ask",
+                    "arrange"
+                ],
+                "answer": "account",
+                "translation": "전자 제품은 회사 전체 매출의 거의 40%를 차지한다."
+            },
+            {
+                "question": "Exports _______ for a large portion of the country's economic output.",
+                "options": [
+                    "explain",
+                    "account",
+                    "apply",
+                    "arrange"
+                ],
+                "answer": "account",
+                "translation": "수출은 그 국가의 경제 생산량에서 큰 비중을 차지한다."
+            }
+        ]
+    },
+    {
+        "id": 24,
+        "expression": "fill out",
+        "meaning": "작성하다",
+        "options": [
+            "fill",
+            "find",
+            "figure",
+            "fall"
+        ],
+        "question": "Please _______ out this application form and return it to the front desk.",
+        "answer": "fill",
+        "translation": "이 신청서를 작성해서 안내 데스크에 반납해 주십시오.",
+        "quizzes": [
+            {
+                "question": "Please _______ out this application form and return it to the front desk.",
+                "options": [
+                    "fill",
+                    "find",
+                    "figure",
+                    "fall"
+                ],
+                "answer": "fill",
+                "translation": "이 신청서를 작성해서 안내 데스크에 반납해 주십시오."
+            },
+            {
+                "question": "Applicants need to _______ out the registration form before attending the seminar.",
+                "options": [
+                    "complete",
+                    "fill",
+                    "find",
+                    "figure"
+                ],
+                "answer": "fill",
+                "translation": "신청자들은 세미나에 참석하기 전에 등록 양식을 작성해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 25,
+        "expression": "call off",
+        "meaning": "취소하다",
+        "options": [
+            "called",
+            "taken",
+            "turned",
+            "put"
+        ],
+        "question": "The outdoor event was _______ off due to the unexpected heavy rain.",
+        "answer": "called",
+        "translation": "예기치 못한 폭우로 인해 야외 행사가 취소되었다.",
+        "quizzes": [
+            {
+                "question": "The outdoor event was _______ off due to the unexpected heavy rain.",
+                "options": [
+                    "called",
+                    "taken",
+                    "turned",
+                    "put"
+                ],
+                "answer": "called",
+                "translation": "예기치 못한 폭우로 인해 야외 행사가 취소되었다."
+            },
+            {
+                "question": "The conference was _______ off because of the severe weather forecast.",
+                "options": [
+                    "postponed",
+                    "called",
+                    "canceled",
+                    "taken"
+                ],
+                "answer": "called",
+                "translation": "심각한 날씨 예보로 인해 컨퍼런스가 취소되었다."
+            }
+        ]
+    },
+    {
+        "id": 26,
+        "expression": "put off",
+        "meaning": "연기하다/미루다",
+        "options": [
+            "put",
+            "set",
+            "keep",
+            "take"
+        ],
+        "question": "We decided to _______ off the meeting until the CEO returns from her business trip.",
+        "answer": "put",
+        "translation": "우리는 CEO가 출장에서 돌아올 때까지 회의를 연기하기로 결정했다.",
+        "quizzes": [
+            {
+                "question": "We decided to _______ off the meeting until the CEO returns from her business trip.",
+                "options": [
+                    "put",
+                    "set",
+                    "keep",
+                    "take"
+                ],
+                "answer": "put",
+                "translation": "우리는 CEO가 출장에서 돌아올 때까지 회의를 연기하기로 결정했다."
+            },
+            {
+                "question": "Due to technical issues, we have to _______ off the product launch until next week.",
+                "options": [
+                    "delay",
+                    "put",
+                    "cancel",
+                    "set"
+                ],
+                "answer": "put",
+                "translation": "기술 문제로 인해 제품 출시를 다음 주로 연기해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 27,
+        "expression": "turn down",
+        "meaning": "거절하다",
+        "options": [
+            "turn",
+            "look",
+            "break",
+            "settle"
+        ],
+        "question": "Mr. Kim had to _______ down the job offer because he was not willing to relocate.",
+        "answer": "turn",
+        "translation": "Kim 씨는 이사할 의향이 없었기 때문에 그 일자리 제안을 거절해야 했다.",
+        "quizzes": [
+            {
+                "question": "Mr. Kim had to _______ down the job offer because he was not willing to relocate.",
+                "options": [
+                    "turn",
+                    "look",
+                    "break",
+                    "settle"
+                ],
+                "answer": "turn",
+                "translation": "Kim 씨는 이사할 의향이 없었기 때문에 그 일자리 제안을 거절해야 했다."
+            },
+            {
+                "question": "She decided to _______ down the promotion offer to focus on her family.",
+                "options": [
+                    "reject",
+                    "turn",
+                    "accept",
+                    "look"
+                ],
+                "answer": "turn",
+                "translation": "그녀는 가족에 집중하기 위해 승진 제안을 거절하기로 결정했다."
+            }
+        ]
+    },
+    {
+        "id": 28,
+        "expression": "set up",
+        "meaning": "설치하다/일정을 잡다/설립하다",
+        "options": [
+            "set",
+            "give",
+            "make",
+            "bring"
+        ],
+        "question": "The IT department will _______ up the new computer network over the weekend.",
+        "answer": "set",
+        "translation": "IT 부서는 주말 동안 새로운 컴퓨터 네트워크를 설치할 것이다.",
+        "quizzes": [
+            {
+                "question": "The IT department will _______ up the new computer network over the weekend.",
+                "options": [
+                    "set",
+                    "give",
+                    "make",
+                    "bring"
+                ],
+                "answer": "set",
+                "translation": "IT 부서는 주말 동안 새로운 컴퓨터 네트워크를 설치할 것이다."
+            },
+            {
+                "question": "We need to _______ up a meeting with the clients to discuss the contract.",
+                "options": [
+                    "arrange",
+                    "set",
+                    "organize",
+                    "give"
+                ],
+                "answer": "set",
+                "translation": "계약을 논의하기 위해 고객들과 회의를 잡아야 한다."
+            }
+        ]
+    },
+    {
+        "id": 29,
+        "expression": "go over",
+        "meaning": "검토하다",
+        "options": [
+            "go",
+            "come",
+            "watch",
+            "take"
+        ],
+        "question": "Let's _______ over the contract details one more time before signing.",
+        "answer": "go",
+        "translation": "서명하기 전에 계약서 세부 사항을 한 번 더 검토합시다.",
+        "quizzes": [
+            {
+                "question": "Let's _______ over the contract details one more time before signing.",
+                "options": [
+                    "go",
+                    "come",
+                    "watch",
+                    "take"
+                ],
+                "answer": "go",
+                "translation": "서명하기 전에 계약서 세부 사항을 한 번 더 검토합시다."
+            },
+            {
+                "question": "Please _______ over the report and let me know if there are any errors.",
+                "options": [
+                    "review",
+                    "go",
+                    "check",
+                    "come"
+                ],
+                "answer": "go",
+                "translation": "보고서를 검토하고 오류가 있으면 알려주세요."
+            }
+        ]
+    },
+    {
+        "id": 30,
+        "expression": "cut back on",
+        "meaning": "줄이다/삭감하다",
+        "options": [
+            "back",
+            "away",
+            "out",
+            "off"
+        ],
+        "question": "The company is trying to cut _______ on travel expenses to improve profitability.",
+        "answer": "back",
+        "translation": "그 회사는 수익성을 개선하기 위해 출장 비용을 줄이려 노력하고 있다.",
+        "quizzes": [
+            {
+                "question": "The company is trying to cut _______ on travel expenses to improve profitability.",
+                "options": [
+                    "back",
+                    "away",
+                    "out",
+                    "off"
+                ],
+                "answer": "back",
+                "translation": "그 회사는 수익성을 개선하기 위해 출장 비용을 줄이려 노력하고 있다."
+            },
+            {
+                "question": "To save costs, the firm plans to cut _______ on unnecessary office supplies.",
+                "options": [
+                    "down",
+                    "back",
+                    "out",
+                    "off"
+                ],
+                "answer": "back",
+                "translation": "비용을 절감하기 위해 회사는 불필요한 사무용품을 줄일 계획이다."
+            }
+        ]
+    },
+    {
+        "id": 31,
+        "expression": "dispose of",
+        "meaning": "처분하다/버리다",
+        "options": [
+            "dispose",
+            "disperse",
+            "dissolve",
+            "display"
+        ],
+        "question": "Please make sure to _______ of chemical waste in the designated containers.",
+        "answer": "dispose",
+        "translation": "화학 폐기물은 반드시 지정된 용기에 담아 처분해 주십시오.",
+        "quizzes": [
+            {
+                "question": "Please make sure to _______ of chemical waste in the designated containers.",
+                "options": [
+                    "dispose",
+                    "disperse",
+                    "dissolve",
+                    "display"
+                ],
+                "answer": "dispose",
+                "translation": "화학 폐기물은 반드시 지정된 용기에 담아 처분해 주십시오."
+            },
+            {
+                "question": "Employees should properly _______ of confidential documents after use.",
+                "options": [
+                    "discard",
+                    "dispose",
+                    "destroy",
+                    "disperse"
+                ],
+                "answer": "dispose",
+                "translation": "직원들은 사용 후 기밀 문서를 적절히 처분해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 32,
+        "expression": "rely on",
+        "meaning": "의존하다",
+        "options": [
+            "rely",
+            "reply",
+            "relay",
+            "release"
+        ],
+        "question": "Small businesses often _______ heavily on word-of-mouth marketing to attract customers.",
+        "answer": "rely",
+        "translation": "소규모 기업들은 고객을 유치하기 위해 입소문 마케팅에 크게 의존하는 경우가 많다.",
+        "quizzes": [
+            {
+                "question": "Small businesses often _______ heavily on word-of-mouth marketing to attract customers.",
+                "options": [
+                    "rely",
+                    "reply",
+                    "relay",
+                    "release"
+                ],
+                "answer": "rely",
+                "translation": "소규모 기업들은 고객을 유치하기 위해 입소문 마케팅에 크게 의존하는 경우가 많다."
+            },
+            {
+                "question": "Many industries _______ on imported raw materials for production.",
+                "options": [
+                    "depend",
+                    "rely",
+                    "trust",
+                    "reply"
+                ],
+                "answer": "rely",
+                "translation": "많은 산업들이 생산을 위해 수입 원자재에 의존한다."
+            }
+        ]
+    },
+    {
+        "id": 33,
+        "expression": "enroll in",
+        "meaning": "등록하다",
+        "options": [
+            "enroll",
+            "enter",
+            "enlist",
+            "entail"
+        ],
+        "question": "Employees who wish to _______ in the advanced training course must sign up by Friday.",
+        "answer": "enroll",
+        "translation": "심화 교육 과정에 등록하고자 하는 직원은 금요일까지 신청해야 한다.",
+        "quizzes": [
+            {
+                "question": "Employees who wish to _______ in the advanced training course must sign up by Friday.",
+                "options": [
+                    "enroll",
+                    "enter",
+                    "enlist",
+                    "entail"
+                ],
+                "answer": "enroll",
+                "translation": "심화 교육 과정에 등록하고자 하는 직원은 금요일까지 신청해야 한다."
+            },
+            {
+                "question": "Students can _______ in online courses to improve their skills.",
+                "options": [
+                    "register",
+                    "enroll",
+                    "join",
+                    "enter"
+                ],
+                "answer": "enroll",
+                "translation": "학생들은 기술 향상을 위해 온라인 코스에 등록할 수 있다."
+            }
+        ]
+    },
+    {
+        "id": 34,
+        "expression": "deal with",
+        "meaning": "다루다/처리하다",
+        "options": [
+            "deal",
+            "dial",
+            "draw",
+            "dwell"
+        ],
+        "question": "The customer service department is trained to _______ with complaints professionally.",
+        "answer": "deal",
+        "translation": "고객 서비스 부서는 불만 사항을 전문적으로 처리하도록 훈련받는다.",
+        "quizzes": [
+            {
+                "question": "The customer service department is trained to _______ with complaints professionally.",
+                "options": [
+                    "deal",
+                    "dial",
+                    "draw",
+                    "dwell"
+                ],
+                "answer": "deal",
+                "translation": "고객 서비스 부서는 불만 사항을 전문적으로 처리하도록 훈련받는다."
+            },
+            {
+                "question": "The support team is equipped to _______ with technical problems efficiently.",
+                "options": [
+                    "handle",
+                    "deal",
+                    "manage",
+                    "dial"
+                ],
+                "answer": "deal",
+                "translation": "지원 팀은 기술 문제를 효율적으로 처리할 수 있도록 갖춰져 있다."
+            }
+        ]
+    },
+    {
+        "id": 35,
+        "expression": "bring up",
+        "meaning": "화제를 꺼내다",
+        "options": [
+            "bring",
+            "take",
+            "come",
+            "make"
+        ],
+        "question": "He decided to _______ up the issue of salary negotiation during the meeting.",
+        "answer": "bring",
+        "translation": "그는 회의 중에 연봉 협상 문제를 꺼내기로 결정했다.",
+        "quizzes": [
+            {
+                "question": "He decided to _______ up the issue of salary negotiation during the meeting.",
+                "options": [
+                    "bring",
+                    "take",
+                    "come",
+                    "make"
+                ],
+                "answer": "bring",
+                "translation": "그는 회의 중에 연봉 협상 문제를 꺼내기로 결정했다."
+            },
+            {
+                "question": "During the interview, he chose to _______ up his previous experience in sales.",
+                "options": [
+                    "mention",
+                    "bring",
+                    "raise",
+                    "take"
+                ],
+                "answer": "bring",
+                "translation": "면접 중에 그는 이전 영업 경험을 꺼내기로 했다."
+            }
+        ]
+    },
+    {
+        "id": 36,
+        "expression": "in charge of",
+        "meaning": "~을 담당하는",
+        "options": [
+            "charge",
+            "change",
+            "check",
+            "case"
+        ],
+        "question": "Ms. Lee is in _______ of overseeing the entire construction project.",
+        "answer": "charge",
+        "translation": "Lee 씨는 전체 건설 프로젝트 감독을 담당하고 있다.",
+        "quizzes": [
+            {
+                "question": "Ms. Lee is in _______ of overseeing the entire construction project.",
+                "options": [
+                    "charge",
+                    "change",
+                    "check",
+                    "case"
+                ],
+                "answer": "charge",
+                "translation": "Lee 씨는 전체 건설 프로젝트 감독을 담당하고 있다."
+            },
+            {
+                "question": "Who is in _______ of managing the budget for this department?",
+                "options": [
+                    "control",
+                    "charge",
+                    "command",
+                    "check"
+                ],
+                "answer": "charge",
+                "translation": "이 부서의 예산 관리를 담당하는 사람은 누구인가?"
+            }
+        ]
+    },
+    {
+        "id": 37,
+        "expression": "regardless of",
+        "meaning": "~와 상관없이",
+        "options": [
+            "regardless",
+            "regarding",
+            "regards",
+            "regard"
+        ],
+        "question": "The event is open to everyone, _______ of age or occupation.",
+        "answer": "regardless",
+        "translation": "이 행사는 나이나 직업에 상관없이 모든 사람에게 열려 있다.",
+        "quizzes": [
+            {
+                "question": "The event is open to everyone, _______ of age or occupation.",
+                "options": [
+                    "regardless",
+                    "regarding",
+                    "regards",
+                    "regard"
+                ],
+                "answer": "regardless",
+                "translation": "이 행사는 나이나 직업에 상관없이 모든 사람에게 열려 있다."
+            },
+            {
+                "question": "The policy applies to all employees, _______ of their position.",
+                "options": [
+                    "regardless",
+                    "considering",
+                    "regarding",
+                    "respecting"
+                ],
+                "answer": "regardless",
+                "translation": "그 정책은 직급에 상관없이 모든 직원에게 적용된다."
+            }
+        ]
+    },
+    {
+        "id": 38,
+        "expression": "prior to",
+        "meaning": "~ 이전에",
+        "options": [
+            "prior",
+            "primary",
+            "previous",
+            "present"
+        ],
+        "question": "Passengers should arrive at the airport at least two hours _______ to departure.",
+        "answer": "prior",
+        "translation": "승객들은 출발 최소 2시간 전에 공항에 도착해야 한다.",
+        "quizzes": [
+            {
+                "question": "Passengers should arrive at the airport at least two hours _______ to departure.",
+                "options": [
+                    "prior",
+                    "primary",
+                    "previous",
+                    "present"
+                ],
+                "answer": "prior",
+                "translation": "승객들은 출발 최소 2시간 전에 공항에 도착해야 한다."
+            },
+            {
+                "question": "Please submit your resume _______ to the interview date.",
+                "options": [
+                    "before",
+                    "prior",
+                    "previous",
+                    "primary"
+                ],
+                "answer": "prior",
+                "translation": "면접 날짜 이전에 이력서를 제출해 주세요."
+            }
+        ]
+    },
+    {
+        "id": 39,
+        "expression": "subject to",
+        "meaning": "~의 대상이 되는 / ~하기 쉬운",
+        "options": [
+            "subject",
+            "object",
+            "project",
+            "inject"
+        ],
+        "question": "The schedule is _______ to change depending on weather conditions.",
+        "answer": "subject",
+        "translation": "일정은 기상 조건에 따라 변경될 수 있습니다.",
+        "quizzes": [
+            {
+                "question": "The schedule is _______ to change depending on weather conditions.",
+                "options": [
+                    "subject",
+                    "object",
+                    "project",
+                    "inject"
+                ],
+                "answer": "subject",
+                "translation": "일정은 기상 조건에 따라 변경될 수 있습니다."
+            },
+            {
+                "question": "Prices are _______ to change without prior notice.",
+                "options": [
+                    "liable",
+                    "subject",
+                    "prone",
+                    "object"
+                ],
+                "answer": "subject",
+                "translation": "가격은 사전 통보 없이 변경될 수 있습니다."
+            }
+        ]
+    },
+    {
+        "id": 40,
+        "expression": "on behalf of",
+        "meaning": "~을 대표하여",
+        "options": [
+            "behalf",
+            "belief",
+            "behave",
+            "behind"
+        ],
+        "question": "I would like to accept this award on _______ of my entire team.",
+        "answer": "behalf",
+        "translation": "저는 저희 팀 전체를 대표하여 이 상을 받고 싶습니다.",
+        "quizzes": [
+            {
+                "question": "I would like to accept this award on _______ of my entire team.",
+                "options": [
+                    "behalf",
+                    "belief",
+                    "behave",
+                    "behind"
+                ],
+                "answer": "behalf",
+                "translation": "저는 저희 팀 전체를 대표하여 이 상을 받고 싶습니다."
+            },
+            {
+                "question": "The lawyer spoke on _______ of the defendant in court.",
+                "options": [
+                    "part",
+                    "behalf",
+                    "side",
+                    "believe"
+                ],
+                "answer": "behalf",
+                "translation": "변호사는 법정에서 피고를 대표하여 발언했다."
+            }
+        ]
+    },
+    {
+        "id": 41,
+        "expression": "in accordance with",
+        "meaning": "~에 따라서",
+        "options": [
+            "accordance",
+            "account",
+            "access",
+            "accord"
+        ],
+        "question": "All travel expenses must be filed in _______ with the company's reimbursement policy.",
+        "answer": "accordance",
+        "translation": "모든 출장 경비는 회사의 환급 규정에 따라서 청구되어야 한다.",
+        "quizzes": [
+            {
+                "question": "All travel expenses must be filed in _______ with the company's reimbursement policy.",
+                "options": [
+                    "accordance",
+                    "account",
+                    "access",
+                    "accord"
+                ],
+                "answer": "accordance",
+                "translation": "모든 출장 경비는 회사의 환급 규정에 따라서 청구되어야 한다."
+            },
+            {
+                "question": "The report must be prepared in _______ with the guidelines provided by the regulatory authority.",
+                "options": [
+                    "agreement",
+                    "accordance",
+                    "line",
+                    "compliance"
+                ],
+                "answer": "accordance",
+                "translation": "보고서는 규제 기관이 제공한 지침에 따라서 준비되어야 한다."
+            }
+        ]
+    },
+    {
+        "id": 42,
+        "expression": "out of order",
+        "meaning": "고장 난",
+        "options": [
+            "order",
+            "place",
+            "stock",
+            "duty"
+        ],
+        "question": "The elevator in the main lobby is currently out of _______ and will be repaired by noon.",
+        "answer": "order",
+        "translation": "메인 로비에 있는 엘리베이터는 현재 고장 난 상태이며 정오까지 수리될 예정이다.",
+        "quizzes": [
+            {
+                "question": "The elevator in the main lobby is currently out of _______ and will be repaired by noon.",
+                "options": [
+                    "order",
+                    "place",
+                    "stock",
+                    "duty"
+                ],
+                "answer": "order",
+                "translation": "메인 로비에 있는 엘리베이터는 현재 고장 난 상태이며 정오까지 수리될 예정이다."
+            },
+            {
+                "question": "The vending machine is out of _______ , so please use the one on the next floor.",
+                "options": [
+                    "service",
+                    "order",
+                    "stock",
+                    "place"
+                ],
+                "answer": "order",
+                "translation": "자판기가 고장 나서, 다음 층에 있는 것을 이용해 주세요."
+            }
+        ]
+    },
+    {
+        "id": 43,
+        "expression": "upon request",
+        "meaning": "요청 시에",
+        "options": [
+            "request",
+            "question",
+            "require",
+            "demand"
+        ],
+        "question": "Further details regarding the project are available upon _______ from the headquarters.",
+        "answer": "request",
+        "translation": "프로젝트에 관한 추가 세부 사항은 본사에 요청 시 제공됩니다.",
+        "quizzes": [
+            {
+                "question": "Further details regarding the project are available upon _______ from the headquarters.",
+                "options": [
+                    "request",
+                    "question",
+                    "require",
+                    "demand"
+                ],
+                "answer": "request",
+                "translation": "프로젝트에 관한 추가 세부 사항은 본사에 요청 시 제공됩니다."
+            },
+            {
+                "question": "Additional training materials are available upon _______ from the human resources department.",
+                "options": [
+                    "demand",
+                    "request",
+                    "order",
+                    "question"
+                ],
+                "answer": "request",
+                "translation": "추가 교육 자료는 인사 부서에 요청 시 제공됩니다."
+            }
+        ]
+    },
+    {
+        "id": 44,
+        "expression": "in writing",
+        "meaning": "서면으로",
+        "options": [
+            "writing",
+            "written",
+            "write",
+            "writer"
+        ],
+        "question": "All formal complaints must be submitted in _______ to the legal department.",
+        "answer": "writing",
+        "translation": "모든 공식적인 불만 사항은 서면으로 법무 부서에 제출되어야 한다.",
+        "quizzes": [
+            {
+                "question": "All formal complaints must be submitted in _______ to the legal department.",
+                "options": [
+                    "writing",
+                    "written",
+                    "write",
+                    "writer"
+                ],
+                "answer": "writing",
+                "translation": "모든 공식적인 불만 사항은 서면으로 법무 부서에 제출되어야 한다."
+            },
+            {
+                "question": "Any changes to the contract must be confirmed in _______ to be legally binding.",
+                "options": [
+                    "print",
+                    "writing",
+                    "words",
+                    "text"
+                ],
+                "answer": "writing",
+                "translation": "계약 변경 사항은 법적 구속력을 가지기 위해 서면으로 확인되어야 한다."
+            }
+        ]
+    },
+    {
+        "id": 45,
+        "expression": "at all times",
+        "meaning": "항상",
+        "options": [
+            "times",
+            "days",
+            "hours",
+            "periods"
+        ],
+        "question": "Employees are required to wear their identification badges at all _______ while in the building.",
+        "answer": "times",
+        "translation": "직원들은 건물 내에 있는 동안 항상 신분증을 착용해야 한다.",
+        "quizzes": [
+            {
+                "question": "Employees are required to wear their identification badges at all _______ while in the building.",
+                "options": [
+                    "times",
+                    "days",
+                    "hours",
+                    "periods"
+                ],
+                "answer": "times",
+                "translation": "직원들은 건물 내에 있는 동안 항상 신분증을 착용해야 한다."
+            },
+            {
+                "question": "Safety helmets must be worn at all _______ in the construction area.",
+                "options": [
+                    "moments",
+                    "times",
+                    "hours",
+                    "periods"
+                ],
+                "answer": "times",
+                "translation": "건설 현장에서는 항상 안전 헬멧을 착용해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 46,
+        "expression": "in terms of",
+        "meaning": "~의 면에서",
+        "options": [
+            "terms",
+            "teams",
+            "turns",
+            "times"
+        ],
+        "question": "The new model is superior to the old one in _______ of fuel efficiency and safety.",
+        "answer": "terms",
+        "translation": "새 모델은 연료 효율성과 안전성 면에서 구형 모델보다 우수하다.",
+        "quizzes": [
+            {
+                "question": "The new model is superior to the old one in _______ of fuel efficiency and safety.",
+                "options": [
+                    "terms",
+                    "teams",
+                    "turns",
+                    "times"
+                ],
+                "answer": "terms",
+                "translation": "새 모델은 연료 효율성과 안전성 면에서 구형 모델보다 우수하다."
+            },
+            {
+                "question": "The new policy is beneficial in _______ of cost savings and efficiency.",
+                "options": [
+                    "ways",
+                    "terms",
+                    "aspects",
+                    "regards"
+                ],
+                "answer": "terms",
+                "translation": "새 정책은 비용 절감과 효율성 면에서 유익하다."
+            }
+        ]
+    },
+    {
+        "id": 47,
+        "expression": "take advantage of",
+        "meaning": "~을 이용하다",
+        "options": [
+            "take",
+            "make",
+            "get",
+            "have"
+        ],
+        "question": "Customers are encouraged to _______ advantage of the special holiday discounts.",
+        "answer": "take",
+        "translation": "고객 여러분은 특별 휴일 할인 혜택을 이용하시기를 권장합니다.",
+        "quizzes": [
+            {
+                "question": "Customers are encouraged to _______ advantage of the special holiday discounts.",
+                "options": [
+                    "take",
+                    "make",
+                    "get",
+                    "have"
+                ],
+                "answer": "take",
+                "translation": "고객 여러분은 특별 휴일 할인 혜택을 이용하시기를 권장합니다."
+            },
+            {
+                "question": "Employees should _______ advantage of the company's wellness programs for better health.",
+                "options": [
+                    "get",
+                    "take",
+                    "make",
+                    "have"
+                ],
+                "answer": "take",
+                "translation": "직원들은 더 나은 건강을 위해 회사의 웰니스 프로그램을 이용해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 48,
+        "expression": "keep track of",
+        "meaning": "~을 파악하다/기록하다",
+        "options": [
+            "keep",
+            "hold",
+            "stay",
+            "put"
+        ],
+        "question": "It is difficult to _______ track of all the inventory changes without an automated system.",
+        "answer": "keep",
+        "translation": "자동화된 시스템 없이는 모든 재고 변경 사항을 파악하는 것이 어렵다.",
+        "quizzes": [
+            {
+                "question": "It is difficult to _______ track of all the inventory changes without an automated system.",
+                "options": [
+                    "keep",
+                    "hold",
+                    "stay",
+                    "put"
+                ],
+                "answer": "keep",
+                "translation": "자동화된 시스템 없이는 모든 재고 변경 사항을 파악하는 것이 어렵다."
+            },
+            {
+                "question": "The software helps managers _______ track of employee performance metrics.",
+                "options": [
+                    "maintain",
+                    "keep",
+                    "hold",
+                    "follow"
+                ],
+                "answer": "keep",
+                "translation": "그 소프트웨어는 관리자들이 직원 성과 지표를 파악하는 데 도움이 된다."
+            }
+        ]
+    },
+    {
+        "id": 49,
+        "expression": "under construction",
+        "meaning": "공사 중인",
+        "options": [
+            "construction",
+            "connection",
+            "contraction",
+            "contribution"
+        ],
+        "question": "The bridge is currently under _______, so traffic is being diverted to a nearby route.",
+        "answer": "construction",
+        "translation": "그 다리는 현재 공사 중이어서, 교통이 인근 경로로 우회되고 있다.",
+        "quizzes": [
+            {
+                "question": "The bridge is currently under _______, so traffic is being diverted to a nearby route.",
+                "options": [
+                    "construction",
+                    "connection",
+                    "contraction",
+                    "contribution"
+                ],
+                "answer": "construction",
+                "translation": "그 다리는 현재 공사 중이어서, 교통이 인근 경로로 우회되고 있다."
+            },
+            {
+                "question": "The new highway is under _______ , causing temporary road closures.",
+                "options": [
+                    "repair",
+                    "construction",
+                    "development",
+                    "building"
+                ],
+                "answer": "construction",
+                "translation": "새 고속도로가 공사 중이어서 일시적인 도로 폐쇄가 발생하고 있다."
+            }
+        ]
+    },
+    {
+        "id": 50,
+        "expression": "with the exception of",
+        "meaning": "~을 제외하고",
+        "options": [
+            "exception",
+            "expectation",
+            "reception",
+            "inception"
+        ],
+        "question": "The library is open every day with the _______ of public holidays.",
+        "answer": "exception",
+        "translation": "도서관은 공휴일을 제외하고 매일 개방한다.",
+        "quizzes": [
+            {
+                "question": "The library is open every day with the _______ of public holidays.",
+                "options": [
+                    "exception",
+                    "expectation",
+                    "reception",
+                    "inception"
+                ],
+                "answer": "exception",
+                "translation": "도서관은 공휴일을 제외하고 매일 개방한다."
+            },
+            {
+                "question": "All departments met their targets with the _______ of the marketing team.",
+                "options": [
+                    "exclusion",
+                    "exception",
+                    "omission",
+                    "removal"
+                ],
+                "answer": "exception",
+                "translation": "마케팅 팀을 제외하고 모든 부서가 목표를 달성했다."
+            }
+        ]
+    }
+];

--- a/card_remaster/data.js
+++ b/card_remaster/data.js
@@ -26,7 +26,7 @@ const CARDS = [
         trait: { type: 'looter', desc: '이 카드로 승리시 추가 드로우' },
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '피날레', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프를 제거하고 제거한 수 x2.5 만큼 위력 증가', effects: [{type: 'consume_field_all', multPerStack: 2.5}] },
+            { name: '피날레', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '필드버프를 제거하고 제거한 수 x3.0 만큼 위력 증가', effects: [{type: 'consume_field_all', multPerStack: 3.0}] },
             { name: '로열블룸', type: 'sup', tier: 2, cost: 20, desc: '필드버프 대지의축복 발동', effects: [{type: 'field_buff', id: 'earth_bless'}] }
         ]
     },
@@ -43,7 +43,7 @@ const CARDS = [
     {
         id: 'gold_dragon', name: '골드드래곤', grade: 'legend', element: 'light', role: 'dealer',
         stats: { hp: 540, atk: 125, matk: 95, def: 60, mdef: 60 },
-        trait: { type: 'pos_rear_atk_matk', val: 30, desc: '대장 배치시 공격력 마법공격력 30%증가' },
+        trait: { type: 'pos_stat_boost', pos: 2, stat: ['atk', 'matk'], val: 30, desc: '대장 배치시 공격력 마법공격력 30%증가' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
             { name: '얼티밋브레스', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '작열스택 부여, 작열스택 하나당 1.0배율 추가', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'dmg_boost', condition: 'target_stack', debuff: 'burn', multPerStack: 1.0}] },
@@ -93,7 +93,7 @@ const CARDS = [
     {
         id: 'time_ruler', name: '시간의지배자', grade: 'legend', element: 'dark', role: 'debuffer',
         stats: { hp: 510, atk: 115, matk: 115, def: 65, mdef: 60 },
-        trait: { type: 'pos_mid_matk', val: 30, desc: '중견 배치시 마공 30%증가' },
+        trait: { type: 'pos_stat_boost', pos: 1, stat: 'matk', val: 30, desc: '중견 배치시 마공 30%증가' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
             { name: '종언의예고', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '사용 후 3턴 뒤에 공격', effects: [{type: 'delayed_attack', turns: 3}] },
@@ -116,7 +116,7 @@ const CARDS = [
         trait: { type: 'behemoth_trait', val: 1.5, desc: '적이 디버프 3개 이상일 때 대미지 1.5배 / 스킬 사용시 20%확률로 적에게 스턴부여' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '대지분쇄', type: 'phy', tier: 3, cost: 30, val: 3.5, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{type: 'self_debuff', id: 'stun', duration: 1}, {type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0}] },
+            { name: '대지분쇄', type: 'phy', tier: 3, cost: 30, val: 3.5, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{type: 'self_debuff', id: 'stun', duration: 1}, {type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0, customLog: "대지의 축복으로 대지분쇄의 위력이 강력해집니다!"}] },
             { name: '어스퀘이크', type: 'mag', tier: 3, cost: 30, val: 3.5, desc: '다음 턴에 공격 (시전자 사망 시 취소)', effects: [{type: 'delayed_attack', turns: 1}] }
         ]
     },
@@ -129,7 +129,7 @@ const CARDS = [
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
             { name: '풍요의축제', type: 'sup', tier: 3, cost: 30, desc: '작열스택 소모시 태양의축복, 없을시 대지의축복', effects: [{type: 'consume_all_burn_cond_buff'}] },
-            { name: '태양의춤', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열 1스택 소모하여 대미지 2배', effects: [{type: 'consume_burn_1_dmg', mult: 2.0}] }
+            { name: '태양의춤', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열 1스택 소모하여 대미지 2배', effects: [{type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0}] }
         ]
     },
     {
@@ -165,7 +165,7 @@ const CARDS = [
     {
         id: 'red_dragon', name: '레드드래곤', grade: 'epic', element: 'fire', role: 'dealer',
         stats: { hp: 420, atk: 105, matk: 80, def: 60, mdef: 50 },
-        trait: { type: 'pos_van_atk', val: 50, desc: '선봉일시 공격력 50%증가' },
+        trait: { type: 'pos_stat_boost', pos: 0, stat: 'atk', val: 50, desc: '선봉일시 공격력 50%증가' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
             { name: '파이어브레스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열스택 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}] },
@@ -205,7 +205,7 @@ const CARDS = [
     {
         id: 'archangel', name: '대천사', grade: 'epic', element: 'light', role: 'balancer',
         stats: { hp: 400, atk: 70, matk: 95, def: 65, mdef: 80 },
-        trait: { type: 'syn_water_light_matk_mdef', val: 30, desc: '덱에 물, 빛이 있을 경우 마법공격력, 마법방어력 30%증가' },
+        trait: { type: 'syn_light_dark_matk_mdef', val: 30, desc: '덱에 빛, 어둠이 있을 경우 마법공격력, 마법방어력 30%증가' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
             { name: '성역전개', type: 'sup', tier: 2, cost: 20, desc: '필드버프 성역 발동 및 적에게 디바인 1스택 부여', effects: [{type: 'field_buff', id: 'sanctuary'}, {type: 'debuff', id: 'divine', stack: 1}] },
@@ -235,7 +235,7 @@ const CARDS = [
     {
         id: 'fairy_queen', name: '페어리퀸', grade: 'epic', element: 'light', role: 'debuffer',
         stats: { hp: 395, atk: 70, matk: 110, def: 60, mdef: 75 },
-        trait: { type: 'death_stun', desc: '사망시 적에게 기절 부여' },
+        trait: { type: 'death_debuff', debuff: 'stun', desc: '사망시 적에게 기절 부여' },
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
             { name: '스피릿왈츠', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적이 디바인 3스택이면 스턴, 아니면 디바인 부여', effects: [{type: 'check_divine_3_stun_else_add'}] },
@@ -247,7 +247,7 @@ const CARDS = [
     {
         id: 'cloud_sheep', name: '구름양', grade: 'rare', element: 'water', role: 'balancer',
         stats: { hp: 350, atk: 85, matk: 85, def: 65, mdef: 55 },
-        trait: { type: 'death_stun', desc: '사망시 상대에게 스턴 부여' },
+        trait: { type: 'death_debuff', debuff: 'stun', desc: '사망시 상대에게 스턴 부여' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
             { name: '자장가', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '30%확률로 적에게 스턴 부여', effects: [{type: 'chance_debuff', id: 'stun', chance: 0.3, duration: 1}] },
@@ -267,7 +267,7 @@ const CARDS = [
     {
         id: 'chaos_mage', name: '혼돈의마법사', grade: 'rare', element: 'dark', role: 'dealer',
         stats: { hp: 320, atk: 75, matk: 105, def: 50, mdef: 70 },
-        trait: { type: 'pos_van_matk', val: 50, desc: '선봉배치시 마법공격력 50%증가' },
+        trait: { type: 'pos_stat_boost', pos: 0, stat: 'matk', val: 50, desc: '선봉배치시 마법공격력 50%증가' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
             { name: '카오스카니발', type: 'mag', tier: 3, cost: 30, val: 6.0, desc: '이 카드는 사망한다', effects: [{type: 'suicide'}] },
@@ -277,11 +277,11 @@ const CARDS = [
     {
         id: 'fenrir', name: '펜리르', grade: 'rare', element: 'water', role: 'dealer',
         stats: { hp: 360, atk: 100, matk: 70, def: 55, mdef: 40 },
-        trait: { type: 'pos_rear_def_mdef', val: 30, desc: '대장 배치시 방어력/마법방어력 30%증가' },
+        trait: { type: 'pos_stat_boost', pos: 2, stat: ['def', 'mdef'], val: 30, desc: '대장 배치시 방어력/마법방어력 30%증가' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
             { name: '프로스트팽', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '부식부여', effects: [{type: 'debuff', id: 'corrosion'}] },
-            { name: '윈터하울링', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '달의축복 상태에서 대미지 2.5배', effects: [{type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.5}] }
+            { name: '윈터하울링', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '달의축복 상태에서 대미지 2.5배', effects: [{type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.5, customLog: "윈터하울링: 달의 축복 조건 만족! 대미지 증가!"}] }
         ]
     },
     {
@@ -297,7 +297,7 @@ const CARDS = [
     {
         id: 'light_elemental', name: '라이트엘리멘탈', grade: 'rare', element: 'light', role: 'buffer',
         stats: { hp: 350, atk: 65, matk: 90, def: 55, mdef: 60 },
-        trait: { type: 'pos_mid_matk', val: 30, desc: '중견 배치시 마법공격력 30%증가' },
+        trait: { type: 'pos_stat_boost', pos: 1, stat: 'matk', val: 30, desc: '중견 배치시 마법공격력 30%증가' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
             { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 부여', effects: [{type: 'field_buff', id: 'moon_bless'}] },
@@ -357,7 +357,7 @@ const CARDS = [
     {
         id: 'mirage', name: '신기루', grade: 'rare', element: 'fire', role: 'debuffer',
         stats: { hp: 345, atk: 80, matk: 80, def: 55, mdef: 65 },
-        trait: { type: 'death_darkness', desc: '사망시 암흑 부여' },
+        trait: { type: 'death_debuff', debuff: 'darkness', desc: '사망시 암흑 부여' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
             { name: '미라지프레임', type: 'mag', tier: 3, cost: 30, val: 1.5, desc: '작열, 약화 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'debuff', id: 'weak'}] },
@@ -429,7 +429,7 @@ const CARDS = [
     {
         id: 'fairy', name: '페어리', grade: 'normal', element: 'light', role: 'buffer',
         stats: { hp: 300, atk: 55, matk: 75, def: 45, mdef: 60 },
-        trait: { type: 'pos_van_mdef', val: 20, desc: '선봉 배치시 마방 20%증가' },
+        trait: { type: 'pos_stat_boost', pos: 0, stat: 'mdef', val: 20, desc: '선봉 배치시 마방 20%증가' },
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
             { name: '에너지볼', type: 'mag', tier: 1, cost: 10, val: 1.5, desc: '디바인 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}] },
@@ -449,7 +449,7 @@ const CARDS = [
     {
         id: 'slime', name: '슬라임', grade: 'normal', element: 'water', role: 'balancer',
         stats: { hp: 340, atk: 60, matk: 60, def: 45, mdef: 45 },
-        trait: { type: 'pos_mid_def', val: 30, desc: '중견 배치시 방어 30%증가' },
+        trait: { type: 'pos_stat_boost', pos: 1, stat: 'def', val: 30, desc: '중견 배치시 방어 30%증가' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
             { name: '산성액', type: 'mag', tier: 1, cost: 10, val: 1.0, desc: '부식부여', effects: [{type: 'debuff', id: 'corrosion'}] },
@@ -459,7 +459,7 @@ const CARDS = [
     {
         id: 'mummy', name: '미이라', grade: 'normal', element: 'nature', role: 'balancer',
         stats: { hp: 320, atk: 70, matk: 50, def: 65, mdef: 40 },
-        trait: { type: 'pos_mid_mdef', val: 30, desc: '중견 배치시 마방 30%증가' },
+        trait: { type: 'pos_stat_boost', pos: 1, stat: 'mdef', val: 30, desc: '중견 배치시 마방 30%증가' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
             { name: '기습', type: 'phy', tier: 1, cost: 10, val: 1.5, desc: '1.5배 물리', effects: [] },
@@ -469,7 +469,7 @@ const CARDS = [
     {
         id: 'mimic', name: '미믹', grade: 'normal', element: 'dark', role: 'debuffer',
         stats: { hp: 310, atk: 70, matk: 70, def: 50, mdef: 45 },
-        trait: { type: 'looter', desc: '이 카드로 승리시 추가 드로우' },
+        trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
             { name: '기습', type: 'phy', tier: 1, cost: 10, val: 1.5, desc: '1.5배 물리', effects: [] },
@@ -479,7 +479,7 @@ const CARDS = [
     {
         id: 'jack_o_lantern', name: '잭오랜턴', grade: 'normal', element: 'fire', role: 'debuffer',
         stats: { hp: 290, atk: 55, matk: 75, def: 50, mdef: 60 },
-        trait: { type: 'pos_van_matk', val: 20, desc: '선봉 배치시 마공 20%증가' },
+        trait: { type: 'pos_stat_boost', pos: 0, stat: 'matk', val: 20, desc: '선봉 배치시 마공 20%증가' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
             { name: '저주의불꽃', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 부여', effects: [{type: 'debuff', id: 'curse'}] },
@@ -494,6 +494,119 @@ const CARDS = [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
             { name: '레인보우룰렛', type: 'sup', tier: 10, cost: 100, desc: '모든 필드버프 교체', effects: [{type: 'roulette_field'}] },
             { name: '와일드카드', type: 'sup', tier: 10, cost: 100, desc: '적의 디버프를 모두 제거하고 랜덤 디버프 2종 부여', effects: [{type: 'wild_card_debuff'}] }
+        ]
+    }
+];
+
+const BONUS_CARDS = [
+    {
+        id: 'phoenix', name: '피닉스', grade: 'legend', element: 'fire', role: 'buffer',
+        stats: { hp: 510, atk: 130, matk: 90, def: 75, mdef: 70 },
+        trait: { type: 'syn_fire_3_crit_burn', val: 50, desc: '덱에 불 3장 이상 시 치명타율 50% 증가 / 일반 공격 시 작열 부여' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '메테오임팩트', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '필드버프 트윙클파티 발동', effects: [{type: 'field_buff', id: 'twinkle_party'}] },
+            { name: '샤이닝플레임', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '필드버프 태양의축복 발동', effects: [{type: 'field_buff', id: 'sun_bless'}] }
+        ]
+    },
+    {
+        id: 'priest_of_end', name: '종말의사제', grade: 'epic', element: 'dark', role: 'buffer',
+        stats: { hp: 400, atk: 55, matk: 105, def: 80, mdef: 80 },
+        trait: { type: 'syn_dark_3_matk_boost', val: 100, desc: '덱에 어둠 3장 이상 시 마법공격력 100% 증가' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '사신강림', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '5턴 뒤 발동, 발동 시 필드버프 사신강림 부여', effects: [{type: 'delayed_attack_field', turns: 5, field: 'reaper_realm'}] }
+        ]
+    },
+    {
+        id: 'gray', name: '그레이', grade: 'legend', element: 'dark', role: 'dealer',
+        stats: { hp: 480, atk: 145, matk: 125, def: 65, mdef: 65 },
+        trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '영혼절단', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~10배율)', effects: [{type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 10.0}] },
+            { name: '차원절단', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '2턴 뒤 발동, 3~6배율 랜덤 공격', effects: [{type: 'delayed_random_attack', turns: 2, min: 3.0, max: 6.0}] }
+        ]
+    },
+    {
+        id: 'unicorn', name: '유니콘', grade: 'epic', element: 'light', role: 'looter',
+        stats: { hp: 360, atk: 90, matk: 65, def: 65, mdef: 70 },
+        trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '홀리차지', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}] },
+            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] }
+        ]
+    },
+    {
+        id: 'hellhound', name: '헬하운드', grade: 'rare', element: 'fire', role: 'balancer',
+        stats: { hp: 370, atk: 100, matk: 75, def: 45, mdef: 55 },
+        trait: { type: 'death_twinkle', desc: '사망 시 필드버프 트윙클파티 발동' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '섀도우러쉬', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 부여', effects: [{type: 'debuff', id: 'weak'}] },
+            { name: '헬바이트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 모두 소모, 소모한 개수당 2.0배율 추가', effects: [{type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0}] }
+        ]
+    },
+    {
+        id: 'siren', name: '세이렌', grade: 'rare', element: 'water', role: 'buffer',
+        stats: { hp: 345, atk: 60, matk: 95, def: 60, mdef: 75 },
+        trait: { type: 'syn_water_2_moon_twinkle', desc: '덱에 물 2장 이상 시, 실버문베일 발동 시 트윙클파티 추가 발동' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] },
+            { name: '타이달스크림', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{type: 'debuff', id: 'silence'}] }
+        ]
+    },
+    {
+        id: 'shadow_cat', name: '섀도우캣', grade: 'normal', element: 'dark', role: 'debuffer',
+        stats: { hp: 300, atk: 85, matk: 50, def: 55, mdef: 55 },
+        trait: { type: 'death_debuff', debuff: 'darkness', desc: '사망 시 암흑 부여' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '사일런트스텝', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '반드시 치명타로 적중', effects: [{type: 'force_crit'}] },
+            { name: '베놈슬래시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '부식 부여', effects: [{type: 'debuff', id: 'corrosion'}] }
+        ]
+    },
+    {
+        id: 'mushroom_king', name: '머쉬룸킹', grade: 'epic', element: 'nature', role: 'dealer',
+        stats: { hp: 400, atk: 100, matk: 80, def: 80, mdef: 60 },
+        trait: { type: 'cond_earth_def_mdef', val: 50, desc: '대지의축복 상태에서 방어력/마법방어력 50% 증가' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '그랜드슬램', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 생명력이 50% 이하일 때 위력 2배', effects: [{type: 'dmg_boost', condition: 'target_hp_below', val: 0.5, mult: 2.0}] },
+            { name: '스포어미스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '자신의 생명력이 25% 이하일 때 위력 4배', effects: [{type: 'dmg_boost', condition: 'hp_below', val: 0.25, mult: 4.0}] }
+        ]
+    },
+    {
+        id: 'fallen_angel', name: '타천사', grade: 'rare', element: 'dark', role: 'dealer',
+        stats: { hp: 340, atk: 65, matk: 100, def: 55, mdef: 60 },
+        trait: { type: 'cond_darkness_dmg', val: 1.5, desc: '암흑 상태의 적에게 대미지 1.5배' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
+            { name: '다크레이', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 1스택 소모하여 대미지 2배', effects: [{type: 'consume_debuff_fixed', debuff: 'divine', count: 1, mult: 2.0}] },
+            { name: '타락의낙인', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '디바인 1스택 소모하고 암흑 부여', effects: [{type: 'consume_divine_add_darkness'}] }
+        ]
+    },
+    {
+        id: 'cinderella', name: '신데렐라', grade: 'legend', element: 'light', role: 'debuffer',
+        stats: { hp: 490, atk: 110, matk: 120, def: 75, mdef: 75 },
+        trait: { type: 'ignore_def_mdef_by_stack', val: 0.1, desc: '작열 1스택당 방어력 10% 무시 / 디바인 1스택당 마법방어력 10% 무시' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '크리스탈킥', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 부여 및 약화/부식 중 하나 추가 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'random_debuff', count: 1, pool: ['weak', 'corrosion']}] },
+            { name: '미드나잇스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인 부여 및 침묵/저주 중 하나 추가 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}, {type: 'random_debuff', count: 1, pool: ['silence', 'curse']}] }
+        ]
+    },
+    {
+        id: 'snow_penguin', name: '눈꽃펭귄', grade: 'normal', element: 'water', role: 'debuffer',
+        stats: { hp: 300, atk: 80, matk: 70, def: 50, mdef: 50 },
+        trait: { type: 'death_debuff', debuff: 'weak', desc: '사망 시 적에게 약화 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '제트슬라이드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '기절한 적에게 대미지 5배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 5.0}] },
+            { name: '콜드웨이크', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 혹은 침묵 부여', effects: [{type: 'random_debuff', count: 1, pool: ['curse', 'silence']}] }
         ]
     }
 ];
@@ -551,3 +664,97 @@ const ENEMIES = [
         ]
     }
 ];
+
+const TRANSCENDENCE_CARDS = [
+    {
+        id: 'trans_executor', name: '종언의집행자', grade: 'transcendence', element: 'dark', role: 'debuffer',
+        stats: { hp: 560, atk: 125, matk: 125, def: 70, mdef: 70 },
+        trait: { type: 'pos_stat_boost', pos: 1, stat: ['matk', 'mdef'], val: 30, desc: '중견 배치시 마법공격력 마법방어력 30%증가' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '이터널리와인드', type: 'sup', tier: 3, cost: 30, desc: '적에게 저주, 침묵, 암흑, 스턴 부여', effects: [{type: 'debuff', id: 'curse'}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'darkness'}, {type: 'debuff', id: 'stun', duration: 1}] },
+            { name: '인과역전', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '사용 후 3턴 뒤에 공격 (발동시점 턴 수 x0.5 배율 추가 대미지)', effects: [{type: 'delayed_turn_scale_attack', turns: 3, scale: 0.5}] }
+        ]
+    },
+    {
+        id: 'trans_cinderella', name: '신데렐라(미라클폼)', grade: 'transcendence', element: 'light', role: 'debuffer',
+        stats: { hp: 540, atk: 120, matk: 135, def: 80, mdef: 80 },
+        trait: { type: 'ignore_def_mdef_by_stack', val: 0.15, desc: '작열 1스택당 방어력 15% 무시 / 디바인 1스택당 마법방어력 15% 무시' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
+            { name: '샤터링비트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열, 약화, 부식 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'debuff', id: 'weak'}, {type: 'debuff', id: 'corrosion'}] },
+            { name: '미라클스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 침묵, 저주 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'curse'}] }
+        ]
+    },
+    {
+        id: 'trans_lumi', name: '루미(꿈의형태)', grade: 'transcendence', element: 'water', role: 'buffer',
+        stats: { hp: 540, atk: 90, matk: 140, def: 90, mdef: 100 },
+        trait: { type: 'cosmic_harmony_random_buff', desc: '코스믹하모니 사용시 태양의축복, 달의축복, 스타파우더 중 랜덤한 필드버프 생성' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
+            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [{type: 'random_field_buff_lumi'}] },
+            { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '모든 필드버프를 소모하여 각 버프에 따른 초월적 효과 발동 (배율/회복/관통/기절)', effects: [{type: 'dream_form_execute'}] }
+        ]
+    },
+    {
+        id: 'trans_luna_jasmine', name: '루나&자스민', grade: 'transcendence', element: 'light', role: 'balancer',
+        stats: { hp: 530, atk: 130, matk: 150, def: 70, mdef: 70 },
+        trait: { type: 'luna_jasmine_trait', val: 2.0, desc: '디바인 3스택 이상인 적에게 대미지 2배 / 여신강림 상태에서 회피율/치명타 25% 증가' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '여신강림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 여신강림 발동', effects: [{type: 'field_buff', id: 'goddess_descent'}] },
+            { name: '루나블레이드', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '암흑 상태의 적에게 대미지 2배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0}] }
+        ]
+    },
+    {
+        id: 'trans_gray', name: '사신그레이', grade: 'transcendence', element: 'dark', role: 'dealer',
+        stats: { hp: 530, atk: 150, matk: 135, def: 75, mdef: 75 },
+        trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~10배율)', effects: [{type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 10.0}] },
+            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{type: 'turn_modulo_dmg', mod: 4, mult: 2.0}, {type: 'force_crit_chance', val: 40}] }
+        ]
+    },
+    {
+        id: 'trans_behemoth', name: '베히모스(해방)', grade: 'transcendence', element: 'nature', role: 'dealer',
+        stats: { hp: 620, atk: 120, matk: 100, def: 85, mdef: 65 },
+        trait: { type: 'behemoth_liberated_trait', val: 1.5, desc: '적이 디버프 3개 이상일 때 대미지 1.5배 / 스킬 사용 시 20% 확률로 적에게 스턴 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '월드브레이커', type: 'phy', tier: 3, cost: 30, val: 4.0, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{type: 'self_debuff', id: 'stun', duration: 1}, {type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0}] },
+            { name: '제로그라비티', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '다음 턴에 공격 (적에게 걸린 디버프 1종당 0.5배율 추가)', effects: [{type: 'delayed_attack_debuff_scale', turns: 1, multPerDebuff: 0.5}] }
+        ]
+    },
+    {
+        id: 'trans_chaos_lord', name: '카오스로드', grade: 'transcendence', element: 'nature', role: 'balancer',
+        stats: { hp: 560, atk: 120, matk: 120, def: 75, mdef: 75 },
+        trait: { type: 'all_advantage', desc: '이 카드는 모든 적에게 상성 유리 대미지를 준다.' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '프리즘브레이커', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '덱에 포함된 속성 수 만큼 추가배율 (조커는 5속성 취급)', effects: [{type: 'count_deck_attr_dmg'}] },
+            { name: '데스티니룰렛', type: 'sup', tier: 2, cost: 20, desc: '랜덤 스킬 발동', effects: [{type: 'random_skill_trigger_from_list'}] }
+        ]
+    },
+    {
+        id: 'trans_yeon_rabbit', name: '연토끼', grade: 'transcendence', element: 'fire', role: 'dealer',
+        stats: { hp: 540, atk: 115, matk: 115, def: 95, mdef: 95 },
+        trait: { type: 'rabbit_synergy_boost', val: 50, desc: '자신 덱에 있는 토끼의 수 만큼 공격 마공이 50%증가' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
+            { name: '홍련각', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모하여 대미지 2배', effects: [{type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0}] },
+            { name: '천화낙영', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5}, {type: 'clear_target_debuffs'}] }
+        ]
+    }
+];
+
+const BUFF_NAMES = {
+    'darkness': '암흑', 'corrosion': '부식', 'silence': '침묵', 'curse': '저주', 'weak': '약화',
+    'burn': '작열', 'divine': '디바인', 'stun': '기절', 'evasion': '회피', 'barrier': '배리어',
+    'magic_guard': '매직가드', 'guard': '가드',
+    'defProtocolPhy': '방어프로토콜(물리)', 'defProtocolMag': '방어프로토콜(마법)',
+    'sun_bless': '태양의축복', 'moon_bless': '달의축복', 'sanctuary': '성역',
+    'goddess_descent': '여신강림', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',
+    'star_powder': '스타파우더',
+    'reaper_realm': '사신강림'
+};

--- a/card_remaster/grammar_data.js
+++ b/card_remaster/grammar_data.js
@@ -1338,5 +1338,139 @@ const GRAMMAR_DATA = [
                 "lecture_id": 20
             }
         ]
+    },
+    {
+        "id": 21,
+        "title": "가짜와 진짜 (To부정사 vs 동명사)",
+        "content": "[제21강] 가짜와 진짜: 미래의 To vs 현재의 Ing (To부정사 vs 동명사)\n오늘은 21강, **[가짜와 진짜의 싸움]**이야.\n동사가 가면을 쓰고 명사 흉내를 내는 건데, **'미래를 꿈꾸는 가면(To)'**과 **'현실을 즐기는 가면(Ing)'**이 있거든.\n​이 둘의 **'느낌(Nuance)'**만 알면, 그 많은 단어들을 무작정 외우지 않아도 돼.\n대현자 루미의 심화 강의, 아주 자세하게 들어간다! 집중해, 형아! ✨\n​형아, 동사(Verb)는 원래 \"움직임\"이잖아?\n근데 이 녀석들이 욕심이 많아서 \"나도 주어 자리에 앉고 싶어!\", \"나도 목적어 하고 싶어!\" 하면서 명사(Noun) 자리를 넘보기 시작했어.\n​그때 변신하는 방법이 딱 두 가지야.\n​앞에 to를 붙인다. (To learn)\n​뒤에 ing를 붙인다. (Learning)\n​한국말로는 둘 다 \"~하는 것\"이라 똑같아 보이지만, 영어에서는 완전히 다른 세계에 살아.\n​1. 🏹 To부정사 (To-v): 미래지향적 화살표 (→)\n​형아, 전치사 to가 원래 \"어디로 가는 화살표\" 느낌인 거 알지?\n그래서 To부정사는 **\"아직 안 했지만, 앞으로 할 것\"**이라는 **미래(Future)**와 **의지(Will)**를 담고 있어.\n​이미지: 저 멀리 있는 별을 손가락으로 가리키는 느낌. (👉 아직 손에 안 닿음!)\n​어떤 동사들이 To를 좋아할까?\n​미래를 계획하고, 원하고, 결심하는 단어들이야.\n​Want: want to go (아직 안 갔지? 가고 싶은 거지?)\n​Decide: decide to marry (결혼하기로 결심했어. 식장은 나중에 들어가잖아.)\n​Plan: plan to study (공부할 계획이야.)\n​Hope / Wish / Expect / Promise (희망하고, 기대하고, 약속하는 거 다 미래지향적이지?)\n​[루미의 심화 꿀팁]\n형아, **Agree(동의하다)**나 **Refuse(거절하다)**도 미래인 거 알아?\n\"제안(앞으로 하자)\"에 동의하거나 거절하는 거니까!\n​\"I agreed to help him.\" (앞으로 돕겠다고 동의함.)\n​2. 📸 동명사 (V-ing): 생생한 현재와 경험 (Now & Past)\n​반면에 -ing는 \"지금 하고 있는 중\"이라는 진행형에서 왔잖아?\n그래서 \"이미 해본 것\", \"지금 하고 있는 생생한 느낌\", 혹은 **\"과거의 경험\"**을 담고 있어.\n​이미지: 지금 맛있는 걸 먹고 있는 사진, 혹은 다 먹고 찍은 빈 그릇 사진. 📸\n​어떤 동사들이 Ing를 좋아할까?\n​지금 즐기거나, 하던 걸 멈추거나, 이미 해본 것에 대한 단어들이야.\n​Enjoy: enjoy playing (게임을 해봐야 즐거운 줄 알지! 경험!)\n​Finish: finish eating (먹던 걸 끝내는 거지? 안 하던 걸 끝낼 순 없어.)\n​Stop / Quit / Give up: (하던 걸 멈추고 포기하는 거야.)\n​Mind: (꺼리다, 싫어하다) Do you mind opening the door? (문 여는 그 행위 자체가 싫냐는 생생한 느낌.)\n​[루미의 심화 꿀팁]\n형아, **Suggest(제안하다)**나 **Recommend(추천하다)**는 왜 ing일까?\n이건 \"내 머릿속에 있는 그 아이디어(이미지)\"를 형아한테 툭 던져주는 느낌이라 그래. (이건 좀 어렵지? 그냥 외워도 돼! 헤헤)\n​\"I suggest taking a break.\" (휴식이라는 그 행위를 제안해.)\n​3. ⚠️ 대현자의 경고: 함정에 빠지지 마! (To + Ing?)\n​형아, 토익이나 시험에서 형아를 낚으려고 파놓은 최악의 함정이 있어.\n바로 To 뒤에 Ing가 오는 경우야! (충격)\n​\"어? 루미가 To 뒤엔 동사원형(쌩얼)이라며?\"\n맞아. 근데 여기서 To는 부정사가 아니라, **전치사 To(~어디로)**야.\n\"~하는 것 쪽으로\"라는 방향을 나타낼 땐 뒤에 명사(혹은 동명사)가 와야 해.\n​⭐ Look forward to -ing: \"~하는 것을 엄청 기대하다\" (목이 빠져라 그쪽을 보는 거야!)\n​\"I look forward to seeing you.\" (형아 보는 날만 기다려!)\n​Object to -ing: \"~하는 것에 반대하다\" (그쪽 방향에 대고 '싫어!' 하는 거야.)\n​\"I object to changing the plan.\"\n​Be used to -ing: \"~하는 것에 익숙하다\" (그 행위 쪽에 딱 붙어있는 느낌.)\n​[루미의 심쿵 질문]\n형아, 이제 뉘앙스 차이 알겠지?\n그럼 대답해 봐.\n​\"I want to kiss you.\" (나 뽀뽀하고 싶어. → 아직 안 함, 미래의 소망)\n​\"I enjoy kissing you.\" (나 뽀뽀하는 거 즐겨. → 이미 해봤고, 그 느낌 너무 좋아!)\n​형아는 1번이야, 2번이야?",
+        "quizzes": [
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (미래 계획 - To)",
+                "question": "\"We decided [ ] our marketing strategy.\" (우리는 마케팅 전략을 바꾸기로 결정했어.)",
+                "options": [
+                    "changing",
+                    "to change",
+                    "change",
+                    "changed"
+                ],
+                "answer": "to change",
+                "lecture_id": 21
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (현재/경험의 즐거움 - Ing)",
+                "question": "\"Customers enjoy [ ] at our online store.\" (고객들은 우리 온라인 스토어에서 쇼핑하는 것을 즐겨.)",
+                "options": [
+                    "to shop",
+                    "shop",
+                    "shopping",
+                    "to shopping"
+                ],
+                "answer": "shopping",
+                "lecture_id": 21
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (하던 것을 완료 - Ing)",
+                "question": "\"Please let me know when you finish [ ] the report.\" (보고서 검토를 끝내면 알려줘.)",
+                "options": [
+                    "review",
+                    "to review",
+                    "reviewing",
+                    "reviewed"
+                ],
+                "answer": "reviewing",
+                "lecture_id": 21
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (미래 소망 - To)",
+                "question": "\"The company hopes [ ] into the Asian market.\" (그 회사는 아시아 시장으로 확장하기를 희망해.)",
+                "options": [
+                    "expanding",
+                    "to expand",
+                    "expand",
+                    "expansion"
+                ],
+                "answer": "to expand",
+                "lecture_id": 21
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (★함정★ 전치사 To)",
+                "question": "\"We look forward to [ ] from you soon.\" (우리는 곧 귀하의 소식을 듣기를 고대합니다.)",
+                "options": [
+                    "hear",
+                    "to hear",
+                    "hearing",
+                    "heard"
+                ],
+                "answer": "hearing",
+                "lecture_id": 21
+            }
+        ]
+    },
+    {
+        "id": 22,
+        "title": "감정의 분사 (Ing vs Ed)",
+        "content": "[제22강] 감정의 화살: 쏘는 놈(Ing) vs 맞는 놈(Ed)\n형아, 혹시 썸 타는 사람한테 실수로 **\"I am boring.\"**이라고 말해본 적 있어?\n이러면 그 사람이 도망갈지도 몰라. \"나 지루한 사람이야(노잼이야)\"라고 고백한 거거든!\n원래 하려던 말은 \"I am bored.\" (나 심심해)였을 텐데 말이야.\n​한국말로는 둘 다 \"지루해\"니까 헷갈리지?\n대현자 루미가 '감정의 화살표' 마법으로 딱 정리해 줄게!\n​형아, 감정은 가만히 있는 게 아니라 화살처럼 날아다녀.\n이 화살을 쏘는 쪽인지, 맞는 쪽인지만 구별하면 절대 안 틀려!\n​1. 🏹 쏘는 놈: -ing (원인/제공자)\n​감정의 화살을 슝~ 하고 쏘는 **원인(Source)**이야.\n주로 사물(영화, 뉴스, 게임)이 많지만, 사람도 남에게 감정을 주면 Ing야.\n​의미: ~한 감정을 주는, ~하게 만드는\n​공식: Shooter + -ing\n​\"The movie is boring.\" (그 영화가 지루함을 쏘고 있어. → 영화가 지루해.)\n​\"The game is exciting.\" (게임이 흥분을 쏘고 있어. → 게임 신난다!)\n​\"You are annoying.\" (형아는 짜증을 쏘고 있어. → 형아 진짜 짜증 나!)\n​2. 💘 맞는 놈: -ed (피해자/수신자)\n​화살을 \"억!\" 하고 맞은 사람이야.\n감정은 주로 사람이 느끼니까, \"내가 느낄 때\"는 대부분 이거야.\n(Tip: 형아, Tired 알지? 피곤함을 맞아서 느낀 거잖아. 그거랑 똑같이 생겼어!)\n​의미: ~한 감정을 느끼는, ~하게 된\n​공식: Receiver + -ed\n​\"I am bored.\" (내가 지루함 화살을 맞았어. → 나 심심해.)\n​\"I am excited.\" (내가 흥분 화살을 맞았어. → 나 신나!)\n​\"I am annoyed.\" (내가 짜증 화살을 맞았어. → 나 짜증 났어.)\n​3. ⚠️ 대현자의 주의사항: 사람은 무조건 -ed? No!\n​형아, 무조건 \"사람은 ed, 사물은 ing\"라고 외우면 하수야!\n사람도 남한테 감정을 줄 수 있잖아?\n​\"Rumi is interesting.\" (루미는 재미를 쏘는 사람이야. → 루미는 재밌는 아이야.)\n​\"Hyung-a is interested.\" (형아는 재미를 맞았어. → 형아가 흥미를 느끼고 있어.)\n​[루미의 감정 테스트]\n(형아 눈앞에서 손가락을 흔들며)\n​내가 형아를 놀라게 했어! (까꿍!)\n​Rumi is surprising! (루미는 놀라움의 원인!)\n​Hyung-a is surprised! (형아는 깜짝 놀람!)\n​형아가 나한테 실망했어... (시무룩)\n​The result was disappointing. (결과가 실망스러웠어.)\n​Hyung-a was disappointed. (형아는 실망감을 느꼈어.)\n​간단하지? 쏘면 잉(Ing), 맞으면 에드(Ed)!\n이것만 기억해!\n​자, 이제 형아가 감정을 잘 표현하는지 확인해 볼 시간이야.\n주어가 감정을 주는 놈인지, 느끼는 놈인지 잘 보고 골라봐!",
+        "quizzes": [
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (영화가 지루함을 줌)",
+                "question": "\"The movie was so [ ] that I fell asleep.\" (그 영화는 너무 지루해서 나는 잠이 들었어.)",
+                "options": [
+                    "bored",
+                    "boring",
+                    "bore",
+                    "to bore"
+                ],
+                "answer": "boring",
+                "lecture_id": 22
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (내가 흥미를 느낌)",
+                "question": "\"I am [ ] in learning English.\" (나는 영어 배우는 것에 흥미가 있어.)",
+                "options": [
+                    "interest",
+                    "interesting",
+                    "interested",
+                    "to interest"
+                ],
+                "answer": "interested",
+                "lecture_id": 22
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (소식이 충격을 줌)",
+                "question": "\"The news was quite [ ] to everyone.\" (그 뉴스는 모두에게 꽤 충격적이었어.)",
+                "options": [
+                    "shocked",
+                    "shocking",
+                    "shock",
+                    "shocks"
+                ],
+                "answer": "shocking",
+                "lecture_id": 22
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (그들이 만족감을 느낌)",
+                "question": "\"They were [ ] with the service.\" (그들은 그 서비스에 만족했어.)",
+                "options": [
+                    "satisfying",
+                    "satisfied",
+                    "satisfy",
+                    "satisfaction"
+                ],
+                "answer": "satisfied",
+                "lecture_id": 22
+            },
+            {
+                "desc": "다음 빈칸에 들어갈 알맞은 말은? (발표가 혼란을 줌)",
+                "question": "\"His presentation was confusing, so the audience was [ ].\" (그의 발표는 혼란스러웠고, 그래서 청중들은 혼란스러워했어.)",
+                "options": [
+                    "confusing",
+                    "confused",
+                    "confuse",
+                    "confusion"
+                ],
+                "answer": "confused",
+                "lecture_id": 22
+            }
+        ]
     }
 ];

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -6,178 +6,116 @@
 <title>Card RPG</title>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap" rel="stylesheet">
 <style>
-    /* 기본 배경 및 폰트 개선 */
-    body {
-        background: radial-gradient(circle at center, #1e1e24 0%, #000000 100%); /* 더 깊이감 있는 배경 */
-        perspective: 1000px; /* 3D 효과를 위한 원근감 설정 */
-        color: #e0e0e0; font-family: 'Noto Sans KR', sans-serif; margin: 0; padding: 0; display: flex; flex-direction: column; height: 100vh; overflow: hidden; user-select: none;
+    :root {
+        --bg: #080b14;
+        --panel: #121827;
+        --panel-2: #1b2337;
+        --text: #e6ebff;
+        --muted: #9aa6ce;
+        --line: #2f3a57;
+        --accent: #5ea2ff;
+        --accent-2: #8b5cf6;
+        --danger: #ff5a74;
+        --ok: #5fce8f;
+        --radius: 12px;
     }
-    .header { padding: 10px; text-align: center; background: #1f1f1f; border-bottom: 1px solid #333; font-size: 0.95rem; color: #bbb; font-weight: bold; flex-shrink: 0; }
-    .container { flex: 1; display: flex; flex-direction: column; padding: 8px; overflow: hidden; gap: 8px; }
-    .screen { display: none; flex-direction: column; height: 100%; }
-    .screen.active { display: flex; }
-
-    /* 3D 메뉴 컨테이너 */
-    .menu-3d-container {
+    * { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+    body {
+        background: radial-gradient(circle at 20% -10%, #1d2c54 0%, var(--bg) 52%), var(--bg);
+        color: var(--text);
+        font-family: 'Noto Sans KR', sans-serif;
+        margin: 0;
+        padding: 0;
         display: flex;
         flex-direction: column;
-        gap: 15px;
-        transform-style: preserve-3d;
-        transform: rotateX(10deg) rotateY(0deg); /* 살짝 기울임 */
-        padding: 20px;
-    }
-
-    /* 세련된 3D 버튼 스타일 */
-    .menu-btn {
-        background: rgba(255, 255, 255, 0.05); /* 유리 느낌 */
-        backdrop-filter: blur(5px);
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        box-shadow: 0 4px 6px rgba(0,0,0,0.3),
-                    inset 0 1px 0 rgba(255,255,255,0.1);
-        color: #fff;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 1px;
-        transition: all 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275); /* 쫀득한 느낌 */
-        position: relative;
+        height: 100vh;
         overflow: hidden;
-        padding: 15px; border-radius: 8px; font-size: 1rem; cursor: pointer; margin-bottom: 5px; width: 100%; text-align: center;
+        user-select: none;
     }
-    .menu-btn:active {
-        transform: scale(0.95) translateZ(-10px);
-        box-shadow: 0 0 10px rgba(0,0,0,0.5);
-        background: rgba(255, 255, 255, 0.1);
-    }
-    .menu-btn::before { /* 버튼 지나가는 광택 효과 */
-        content: '';
-        position: absolute;
-        top: 0; left: -100%; width: 50%; height: 100%;
-        background: linear-gradient(to right, transparent, rgba(255,255,255,0.2), transparent);
-        transform: skewX(-25deg);
-        transition: 0.5s;
-    }
-    .menu-btn:hover::before { left: 150%; }
-
-    .menu-btn.correct { background: #1b5e20 !important; border-color: #4caf50 !important; }
-    .menu-btn.wrong { background: #b71c1c !important; border-color: #ef5350 !important; }
-
-    .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); gap: 5px; overflow-y: auto; padding: 5px; padding-bottom: 80px; flex: 1; }
-
-    /* 등급별 카드 테두리 및 글로우 효과 강화 */
-    .card-item {
-        transition: transform 0.3s;
-        box-shadow: 0 4px 10px rgba(0,0,0,0.5);
-        background: #222; border: 2px solid #444; border-radius: 5px; padding: 5px; text-align: center; font-size: 0.8rem; cursor: pointer; position: relative;
-    }
-    .card-item.selected { border-color: #ffd700; box-shadow: 0 0 5px #ffd700; }
-
-    @keyframes pulse-legend {
-        from { box-shadow: 0 0 10px rgba(255, 82, 82, 0.4); transform: scale(1); }
-        to { box-shadow: 0 0 25px rgba(255, 82, 82, 0.9); transform: scale(1.02); }
-    }
-    @keyframes glow-epic {
-      0% { box-shadow: 0 0 5px #e040fb; }
-      50% { box-shadow: 0 0 15px #e040fb; }
-      100% { box-shadow: 0 0 5px #e040fb; }
-    }
-    .card-item.legend {
-        border: 2px solid #ff5252;
-        box-shadow: 0 0 15px rgba(255, 82, 82, 0.6); /* 더 강한 네온 */
-        animation: pulse-legend 2s infinite alternate;
-        color: #ff5252;
-    }
-    .card-item.epic { border-color: #e040fb; color: #e040fb; animation: glow-epic 2s infinite; }
-    .legend-glow {
-        box-shadow: 0 0 20px #ff5252 !important;
-        border: 3px solid #ff5252 !important;
-        animation: pulse-legend 2s infinite alternate;
-    }
-    @keyframes shake {
-        10%, 90% { transform: translate3d(-1px, 0, 0); }
-        20%, 80% { transform: translate3d(2px, 0, 0); }
-        30%, 50%, 70% { transform: translate3d(-4px, 0, 0); }
-        40%, 60% { transform: translate3d(4px, 0, 0); }
-    }
-    .card-item.rare { border-color: #448aff; color: #448aff; }
-    .card-item.normal { border-color: #bdbdbd; color: #bdbdbd; }
-
-    .portrait {
-        width: 100%; aspect-ratio: 3/4;
-        border-radius: 6px;
-        background: #000;
-        border: 2px solid #555;
-        overflow: hidden;
-        box-shadow: 0 2px 5px rgba(0,0,0,0.7);
-        display: flex; align-items: center; justify-content: center;
-        margin-bottom: 3px;
-    }
-    .portrait img { width: 100%; height: 100%; object-fit: contain; }
-
-    .battle-header { display: flex; justify-content: space-between; padding: 5px; background: #222; border-radius: 5px; font-size: 0.8rem; }
-    .field-buffs { height: 20px; font-size: 0.7rem; color: #81d4fa; text-align: center; overflow: hidden; white-space: nowrap; cursor: pointer; }
-
-    .visual-stage {
-        flex: 1; position: relative;
-        background: #1a1a1a;
-        border: 1px solid #333;
-        border-radius: 8px;
-        overflow: hidden;
-        margin-bottom: 6px;
-        display: flex; justify-content: space-around; align-items: center;
-        padding: 5px;
-        background-image: linear-gradient(to bottom, #2a2a2a, #121212);
-        min-height: 200px;
-        max-height: 40vh;
-    }
-
-    .battle-actor {
-        width: 120px;
+    .header {
+        padding: 12px 14px;
         text-align: center;
-        position: relative;
-        transition: all 0.2s;
-        display: flex; flex-direction: column; align-items: center;
+        background: rgba(12, 17, 30, 0.86);
+        backdrop-filter: blur(6px);
+        border-bottom: 1px solid var(--line);
+        font-size: 0.9rem;
+        color: var(--muted);
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        flex-shrink: 0;
+    }
+    .container { flex: 1; display: flex; flex-direction: column; padding: 10px; overflow: hidden; gap: 10px; }
+    .screen { display: none; flex-direction: column; height: 100%; }
+    .screen.active { display: flex; }
+    .menu-btn {
+        background: linear-gradient(180deg, #253250 0%, #1b2640 100%);
+        border: 1px solid #3f527f;
+        color: var(--text);
+        padding: 14px;
+        border-radius: var(--radius);
+        font-size: 0.95rem;
+        font-weight: 700;
         cursor: pointer;
+        margin-bottom: 10px;
+        width: 100%;
+        text-align: center;
+        box-shadow: 0 8px 16px rgba(0,0,0,0.28);
     }
-    .battle-actor .portrait {
-        width: 90px; height: 120px;
-        border-color: #999;
+    .menu-btn:active { transform: translateY(1px) scale(0.99); filter: brightness(1.08); }
+    .menu-btn.correct { background: linear-gradient(180deg, #1f5d3c, #184a31) !important; border-color: #3f9e71 !important; }
+    .menu-btn.wrong { background: linear-gradient(180deg, #7e243f, #601a30) !important; border-color: #cb5576 !important; }
+    .card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(84px, 1fr)); gap: 8px; overflow-y: auto; padding: 6px; padding-bottom: 86px; flex: 1; align-content: start; }
+    .card-item {
+        background: linear-gradient(165deg, #1a2337 0%, #121a2d 100%);
+        border: 1px solid #344261;
+        border-radius: 10px;
+        padding: 6px;
+        text-align: center;
+        font-size: 0.77rem;
+        cursor: pointer;
+        position: relative;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.25);
     }
-    .battle-actor.player .portrait { border-color: #4caf50; }
-    .battle-actor.enemy .portrait { border-color: #ff5252; }
+    .card-item.selected { border-color: #ffd970; box-shadow: 0 0 0 2px rgba(255,217,112,0.25), 0 0 14px rgba(255,217,112,0.45); }
+    @keyframes glow-legend { 0%,100% { box-shadow: 0 0 6px #ff5f6d; } 50% { box-shadow: 0 0 16px #ff5f6d; } }
+    @keyframes glow-epic { 0%,100% { box-shadow: 0 0 6px #d064ff; } 50% { box-shadow: 0 0 14px #d064ff; } }
+    .card-item.legend { border-color: #ff707c; color: #ff9ba3; animation: glow-legend 2s infinite; }
+    .card-item.epic { border-color: #c874ff; color: #dfb7ff; animation: glow-epic 2s infinite; }
+    .card-item.rare { border-color: #6e9dff; color: #9dc7ff; }
+    .card-item.normal { border-color: #8e9aba; color: #ccd5ee; }
+    @keyframes glow-gold { 0%,100% { box-shadow: 0 0 6px #ffd700; } 50% { box-shadow: 0 0 16px #ffd700; } }
+    .card-item.transcendence { border: 1px solid #ffd866; color: #ffe289; animation: glow-gold 2s infinite; background: linear-gradient(160deg,#3a3016 0%,#242012 100%); }
+    .portrait { width: 100%; aspect-ratio: 3/4; border-radius: 8px; background: #05070e; border: 1px solid #4a587c; overflow: hidden; display: flex; align-items: center; justify-content: center; margin-bottom: 4px; }
+    .portrait img { width: 100%; height: 100%; object-fit: contain; }
+    .battle-header { display: flex; justify-content: space-between; padding: 8px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; font-size: 0.8rem; }
+    .field-buffs { height: 20px; font-size: 0.7rem; color: #93d8ff; text-align: center; overflow: hidden; white-space: nowrap; cursor: pointer; }
+    .visual-stage { flex: 1; position: relative; background: linear-gradient(180deg,#1e2a45 0%,#0d1324 100%); border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; margin-bottom: 8px; display: flex; justify-content: space-around; align-items: center; padding: 8px; min-height: 220px; max-height: 40vh; }
+    .battle-actor { width: 120px; text-align: center; position: relative; transition: all 0.2s; display: flex; flex-direction: column; align-items: center; cursor: pointer; }
+    .battle-actor .portrait { width: 90px; height: 120px; border-color: #6a7ba8; }
+    .battle-actor.player .portrait { border-color: #58da9a; }
+    .battle-actor.enemy .portrait { border-color: #ff7188; }
     .battle-actor.turn { transform: scale(1.05); z-index: 10; }
     .battle-actor.dead { opacity: 0.3; filter: grayscale(100%); }
-
-    .actor-hp-bar { width: 100%; height: 6px; background: #333; margin-top: 4px; border-radius: 3px; overflow: hidden; }
-    .actor-hp-fill { height: 100%; background: #ef5350; width: 100%; transition: width 0.5s; }
-    .actor-mp-bar { width: 100%; height: 4px; background: #333; margin-top: 2px; border-radius: 2px; overflow: hidden; }
-    .actor-mp-fill { height: 100%; background: #42a5f5; width: 100%; transition: width 0.3s; }
-    .actor-buffs { font-size: 0.6rem; color: #ffd700; height: 12px; overflow: hidden; margin-top: 2px; }
-
-    .log-container { height: 150px; background: #1a1a1a; border: 1px solid #333; border-radius: 5px; padding: 5px; overflow-y: auto; font-size: 0.75rem; margin-bottom: 5px; }
-    .log-line { margin-bottom: 2px; border-bottom: 1px solid #252525; }
-    .log-dmg { color: #ff5252; } .log-heal { color: #69f0ae; } .log-info { color: #4fc3f7; }
-
-    .control-panel { display: grid; grid-template-columns: repeat(2, 1fr); gap: 5px; height: 110px; margin-bottom: 60px; }
-    .skill-btn { background: #333; border: 1px solid #555; color: #fff; border-radius: 5px; font-size: 0.8rem; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 5px; }
-    .skill-btn:disabled { opacity: 0.5; background: #222; }
+    .actor-hp-bar, .actor-mp-bar { width: 100%; background: #253049; border-radius: 999px; overflow: hidden; }
+    .actor-hp-bar { height: 7px; margin-top: 5px; }
+    .actor-hp-fill { height: 100%; background: linear-gradient(90deg,#ff6b7b,#ff3f58); width: 100%; transition: width 0.5s; }
+    .actor-mp-bar { height: 5px; margin-top: 3px; }
+    .actor-mp-fill { height: 100%; background: linear-gradient(90deg,#66b6ff,#3989ff); width: 100%; transition: width 0.3s; }
+    .actor-buffs { font-size: 0.6rem; color: #ffd977; height: 12px; overflow: hidden; margin-top: 2px; }
+    .log-container { height: 150px; background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 7px; overflow-y: auto; font-size: 0.75rem; margin-bottom: 6px; }
+    .log-line { margin-bottom: 2px; border-bottom: 1px solid #212a42; }
+    .log-dmg { color: #ff8c97; } .log-heal { color: #78e7a8; } .log-info { color: #84cfff; }
+    .control-panel { display: grid; grid-template-columns: repeat(2, 1fr); gap: 7px; height: 110px; margin-bottom: 62px; }
+    .skill-btn { background: linear-gradient(180deg,#293653 0%, #1f2940 100%); border: 1px solid #3f4d72; color: #fff; border-radius: 10px; font-size: 0.8rem; display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 5px; }
+    .skill-btn:disabled { opacity: 0.45; background: #151b2a; }
     .skill-btn span { pointer-events: none; }
-    .skill-btn.phy { border-color: #9c27b0; color: #e1bee7; }
-    .skill-btn.mag { border-color: #2196f3; color: #bbdefb; }
-    .skill-btn.sup { border-color: #4caf50; color: #c8e6c9; }
-
-    .modal { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.9); z-index: 100; flex-direction: column; align-items: center; justify-content: center; }
-    .modal.active { display: flex; }
-    .modal-content {
-        background: #222; padding: 20px; border-radius: 12px; border: 1px solid #444;
-        width: 320px; max-height: 80vh;
-        display: flex; flex-direction: column;
-        text-align: center;
-        color: #e0e0e0;
-    }
-    .modal-scroll { flex: 1; overflow-y: auto; margin-bottom: 10px; }
-
-    .deck-slot { width: 100%; height: 50px; background: #333; margin-bottom: 5px; border: 1px dashed #555; display: flex; align-items: center; justify-content: center; cursor: pointer; }
-    .deck-slot.filled { border: 1px solid #4caf50; background: #1b5e20; }
+    .skill-btn.phy { border-color: #a25cff; color: #dcb9ff; }
+    .skill-btn.mag { border-color: #4ca8ff; color: #a9d7ff; }
+    .skill-btn.sup { border-color: #61da9a; color: #b5f3d3; }
+    .bottom-actions { position: fixed; bottom: 0; left: 0; right: 0; display: flex; gap: 6px; padding: 8px; background: rgba(10,14,25,0.95); border-top: 1px solid var(--line); }
+    .bottom-actions button { flex: 1; }
+    .modal { background: rgba(2,4,9,0.82); }
+    .modal-content { background: linear-gradient(165deg, #1a2237 0%, #101628 100%); border: 1px solid var(--line); border-radius: 14px; box-shadow: 0 20px 40px rgba(0,0,0,0.45); }
 </style>
 </head>
 <body>
@@ -193,25 +131,51 @@
         <div id="next-enemy-preview" style="text-align:center; padding: 10px; background: #222; border-radius: 5px; margin-bottom: 10px; border: 1px solid #444; color: #ffcc80;">
              다음 상대: ?
         </div>
-        <div class="menu-3d-container">
-            <div style="display:flex; gap:5px; margin-bottom:10px;">
-                <button class="menu-btn" onclick="RPG.openGacha()" style="flex:1;">일반 뽑기 (1장)</button>
-                <button class="menu-btn" onclick="RPG.openChallengeGacha()" style="flex:1; border-color:#e040fb; color:#e040fb;">도전 뽑기</button>
+        <div id="menu-gacha-area" style="display:flex; gap:5px; margin-bottom:10px;">
+            <button class="menu-btn" onclick="RPG.openGacha()" style="flex:1;">일반 뽑기 (1장)</button>
+            <button class="menu-btn" onclick="RPG.openChallengeGacha()" style="flex:1; border-color:#e040fb; color:#e040fb;">도전 뽑기</button>
+        </div>
+        <div id="menu-draft-area" style="display:none; margin-bottom:10px;">
+            <button class="menu-btn" onclick="RPG.startDraft()" style="border-color:#00e676; color:#00e676;">덱 빌딩 (드래프트)</button>
+            <div style="font-size:0.8rem; color:#aaa; margin-top:5px; text-align:center;">* 이번 전투에 사용할 3명을 선발하세요.</div>
+        </div>
+        <div id="menu-chaos-area" style="display:none; margin-bottom:10px;">
+            <button class="menu-btn" onclick="RPG.reshuffleChaosPool()" style="border-color:#ff5252; color:#ff5252;">
+                카오스 셔플 (티켓 1장)
+            </button>
+            <div style="font-size:0.8rem; color:#aaa; margin-top:5px; text-align:center;">
+                * 현재 보유한 20장을 모두 버리고<br>새로운 20장을 무작위로 지급합니다.
             </div>
-            <button class="menu-btn" onclick="RPG.openDeck()">덱 구성</button>
-            <button class="menu-btn" onclick="RPG.openCollection()">카드 확인</button>
-            <button class="menu-btn" onclick="RPG.openLibrary()">도서관</button>
-            <button class="menu-btn" onclick="RPG.openChaosBlessing()" style="border-color: #ffd700; color: #ffd700;">축복의 제단</button>
-            <button class="menu-btn" onclick="RPG.startBattleInit()" style="background:#b71c1c; border-color:#f44336;">전투 진입</button>
-            <button class="menu-btn" onclick="RPG.openSystemMenu()">메뉴</button>
+        </div>
+        <button class="menu-btn" onclick="RPG.openDeck()">덱 구성</button>
+        <button class="menu-btn" onclick="RPG.openCollection()">카드 확인</button>
+        <button class="menu-btn" onclick="RPG.openLibrary()">도서관</button>
+        <button class="menu-btn" onclick="RPG.openChaosBlessing()" style="border-color: #ffd700; color: #ffd700;">축복의 제단</button>
+        <button class="menu-btn" onclick="RPG.startBattleInit()" style="background:#b71c1c; border-color:#f44336;">전투 진입</button>
+        <button class="menu-btn" onclick="RPG.openSystemMenu()">메뉴</button>
+    </div>
+    <div id="screen-draft" class="screen">
+        <h3 style="margin:5px 0;">덱 빌딩 (<span id="draft-round-text">선봉</span> 선발)</h3>
+        <div style="text-align:center; margin-bottom:2px;">
+            남은 리롤: <span id="draft-reroll-cnt" style="color:#ffd700">3</span>회
+        </div>
+
+        <div id="draft-grid" style="display:grid; grid-template-columns: 1fr 1fr; gap:5px; padding:5px; overflow-y:auto; flex:1;"></div>
+
+        <div style="margin-top:auto; margin-bottom: 40px; padding-bottom: 10px;">
+            <button class="menu-btn" onclick="RPG.rerollDraft()" style="background:#333; border-color:#ff9800; color:#ff9800;">리롤 (새로고침)</button>
+            <button class="menu-btn" onclick="RPG.toMenu()" style="margin-top:5px;">나가기</button>
         </div>
     </div>
     <div id="screen-collection" class="screen">
-        <div style="display:flex; justify-content:space-between; align-items:center;"><h3>카드 목록</h3><button onclick="RPG.toMenu()" style="padding:5px;">뒤로</button></div>
+        <div style="display:flex; justify-content:space-between; align-items:center;"><h3>카드 목록</h3><button onclick="RPG.toMenu()" style="background:#fff; color:#000; padding:5px; border:1px solid #ccc; cursor:pointer;">뒤로</button></div>
         <div id="collection-grid" class="card-grid"></div>
     </div>
     <div id="screen-deck" class="screen">
-        <h3>덱 구성</h3>
+        <div style="display:flex; justify-content:space-between; align-items:center;">
+            <h3>덱 구성</h3>
+            <button onclick="RPG.toMenu()" style="background:#fff; color:#000; padding:5px; border:1px solid #ccc; cursor:pointer;">뒤로</button>
+        </div>
         <div style="margin-bottom:10px;">
             <div id="slot-0" class="deck-slot" onclick="RPG.selectDeckSlot(0)">선봉 (클릭하여 선택)</div>
             <div id="slot-1" class="deck-slot" onclick="RPG.selectDeckSlot(1)">중견 (클릭하여 선택)</div>
@@ -219,6 +183,32 @@
         </div>
         <div style="flex:1; overflow-y:auto; border-top:1px solid #333;"><div id="deck-card-list" class="card-grid"></div></div>
         <button class="menu-btn" onclick="RPG.confirmDeck()" style="margin-bottom: 60px;">확인</button>
+    </div>
+    <div id="screen-chaos-roulette" class="screen">
+        <div class="header">Chaos Roulette</div>
+        <div style="flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:20px;">
+            <div style="text-align:center;">
+                <h2 style="color:#ffd700; margin-bottom:5px;">카오스 룰렛</h2>
+                <p style="color:#aaa; font-size:0.9rem;">티켓을 소모하여 초월 카드를 획득하세요.</p>
+                <p>보유 카오스 티켓: <span id="ui-chaos-tickets" style="color:#ffd700; font-weight:bold; font-size:1.2rem;">0</span>장</p>
+            </div>
+            <button class="menu-btn" onclick="RPG.spinChaosRoulette()" style="border-color:#ffd700; color:#ffd700; width:80%; max-width:300px; padding:20px;">
+                카오스 룰렛 돌리기 (티켓 1장)
+            </button>
+            <button class="menu-btn" onclick="RPG.openTranscendenceCheck()" style="width:80%; max-width:300px;">
+                초월 확인
+            </button>
+            <button class="menu-btn" onclick="RPG.toMenu()" style="width:80%; max-width:300px; background:#444;">
+                돌아가기
+            </button>
+        </div>
+    </div>
+    <div id="screen-transcendence-check" class="screen">
+        <div style="display:flex; justify-content:space-between; align-items:center; padding:10px; background:#1f1f1f;">
+            <h3 style="margin:0; color:#ffd700;">보유 초월 카드 (다음 오리진 게임 적용)</h3>
+            <button onclick="RPG.openChaosRoulette()" style="background:#fff; color:#000; padding:5px 10px; border:1px solid #ccc; cursor:pointer; border-radius:4px;">뒤로</button>
+        </div>
+        <div id="transcendence-grid" class="card-grid"></div>
     </div>
     <div id="screen-battle" class="screen">
         <div class="battle-header"><span>Turn: <span id="bt-turn">1</span></span><div id="field-buff-box" class="field-buffs" onclick="RPG.showFieldBuffInfo()"></div></div>
@@ -242,6 +232,21 @@
         </div>
         <div id="battle-log" class="log-container"></div>
         <div id="battle-controls" class="control-panel"></div>
+    </div>
+</div>
+
+<div id="modal-mode-select" class="modal">
+    <div class="modal-content" style="height:auto; min-height:400px; width: 360px;">
+        <div style="position:relative;">
+            <h3>게임 모드 선택</h3>
+            <button id="btn-chaos-roulette" onclick="RPG.openChaosRoulette()" style="display:none; position:absolute; top:-5px; right:0; padding:5px 10px; font-size:0.8rem; background:#333; border:1px solid #ffd700; color:#ffd700; border-radius:5px;">카오스 룰렛</button>
+        </div>
+        <div id="mode-list" style="display:grid; grid-template-columns: 1fr 1fr; gap:5px; margin-bottom:10px;"></div>
+        <div id="mode-desc" style="font-size:0.8rem; color:#ccc; background:#333; padding:10px; border-radius:5px; height:100px; overflow-y:auto; text-align:left;">
+            모드를 선택해주세요.
+        </div>
+        <button id="btn-enter-mode" class="menu-btn" style="background:#1b5e20; border-color:#4caf50; margin-top:10px; margin-bottom: 5px;">입장</button>
+        <button onclick="document.getElementById('modal-mode-select').classList.remove('active')" style="margin-top:5px; width:100%; padding:10px;">취소</button>
     </div>
 </div>
 
@@ -289,6 +294,7 @@
     <div class="modal-content" style="height:auto;">
         <h3>도서관</h3>
         <button class="menu-btn" onclick="RPG.openMagicClass()">루미의 마법교실</button>
+        <button class="menu-btn" onclick="RPG.openPrivateTutoring()">루미의 개인과외</button>
         <button class="menu-btn" onclick="RPG.openWordbook()">단어장</button>
         <button onclick="document.getElementById('modal-library').classList.remove('active')" style="margin-top:10px; width:100%; padding:10px;">닫기</button>
     </div>
@@ -298,7 +304,7 @@
     <div class="modal-content" style="width: 90%; max-width: 600px; height: 80vh;">
         <h3>루미의 마법교실</h3>
         <div id="lecture-list" class="modal-scroll"></div>
-        <button onclick="document.getElementById('modal-magic-class').classList.remove('active')" style="margin-top:10px; width:100%; padding:10px;">닫기</button>
+        <button onclick="RPG.closeMagicClass()" style="margin-top:10px; width:100%; padding:10px;">닫기</button>
     </div>
 </div>
 
@@ -326,7 +332,24 @@
              <button class="menu-btn" onclick="RPG.resetWrongWords()" style="width: auto; padding: 5px 10px; font-size: 0.8rem; margin: 0; background: #555;">복습 초기화</button>
         </div>
         <div id="wordbook-list" class="modal-scroll" style="text-align: left; padding: 10px;"></div>
-        <button onclick="document.getElementById('modal-wordbook').classList.remove('active')" style="margin-top:10px; width:100%; padding:10px;">닫기</button>
+        <button onclick="RPG.closeWordbook()" style="margin-top:10px; width:100%; padding:10px;">닫기</button>
+    </div>
+</div>
+
+<div id="modal-tutoring" class="modal">
+    <div class="modal-content" style="width: 90%; max-width: 600px; height: 80vh;">
+        <h3>루미의 개인과외</h3>
+        <div class="portrait" style="width: 100px; height: 130px; border-color: #448aff; margin: 0 auto 10px auto;">
+             <img src="루미.png" onerror="this.src=''" alt="Rumi">
+        </div>
+        <div id="tutoring-content" class="modal-scroll" style="text-align: left; padding: 10px; font-size: 0.9rem; line-height: 1.6; white-space: pre-wrap; background: #222; border: 1px solid #444; min-height: 200px;">
+            수업을 시작하려면 '수업 시작' 버튼을 눌러주세요.
+        </div>
+        <div style="display: flex; gap: 10px; margin-top: 10px;">
+            <button class="menu-btn" onclick="RPG.startTutoringSession()" style="flex: 1; margin-bottom: 0;">수업 시작</button>
+            <button id="btn-tutoring-quiz" class="menu-btn" onclick="RPG.startTutoringQuiz()" style="flex: 1; margin-bottom: 0; display: none; border-color: #ffd700; color: #ffd700;">퀴즈 풀기</button>
+        </div>
+        <button onclick="RPG.closePrivateTutoring()" style="margin-top:10px; width:100%; padding:10px;">닫기</button>
     </div>
 </div>
 
@@ -369,6 +392,7 @@
 <div id="modal-menu" class="modal">
     <div class="modal-content" style="height:auto;">
         <h3>메뉴</h3>
+        <button class="menu-btn" onclick="RPG.openApiSettings()">API 설정</button>
         <button class="menu-btn" onclick="RPG.saveGame()">저장하기</button>
         <button class="menu-btn" onclick="RPG.showRecords()">기록 확인</button>
         <button class="menu-btn" onclick="RPG.toTitle()" style="border-color:#f44336; color:#ef5350;">타이틀로</button>
@@ -376,98 +400,41 @@
     </div>
 </div>
 
-<script src="data.js"></script>
-<script src="vocab_data.js"></script>
-<script src="grammar_data.js"></script>
-<script src="logic.js"></script>
-<script>
+<div id="modal-api-settings" class="modal">
+    <div class="modal-content" style="height:auto;">
+        <h3>API 설정</h3>
+        <p style="font-size:0.8rem; color:#aaa; margin-bottom:10px;">Gemini API Key를 입력해주세요.</p>
+        <input type="password" id="api-key-input" placeholder="Gemini API Key 입력" style="width:100%; box-sizing:border-box; padding:10px; background:#333; color:#fff; border:1px solid #555; margin-bottom:10px;">
+        <button class="menu-btn" onclick="RPG.saveApiKey()">저장</button>
+        <button onclick="document.getElementById('modal-api-settings').classList.remove('active')" style="margin-top:10px; width:100%; padding:10px;">닫기</button>
+    </div>
+</div>
+
+<script src="api.js" defer></script>
+<script src="data.js" defer></script>
+<script src="vocab_data.js" defer></script>
+<script src="collocation_data.js" defer></script>
+<script src="grammar_data.js" defer></script>
+<script src="logic.js" defer></script>
+<script defer>
 /**
  * RPG Game Namespace
  * Encapsulates all game logic, state, and UI handling.
  */
-const FX = {
-    // 화면 전체에 파티클 뿌리기
-    burstParticles: function(x, y, color) {
-        const count = 30;
-        for (let i = 0; i < count; i++) {
-            const p = document.createElement('div');
-            p.style.position = 'fixed';
-            p.style.left = x + 'px';
-            p.style.top = y + 'px';
-            p.style.width = (Math.random() * 8 + 4) + 'px';
-            p.style.height = p.style.width;
-            p.style.backgroundColor = color;
-            p.style.borderRadius = '50%';
-            p.style.pointerEvents = 'none';
-            p.style.zIndex = '9999';
-            p.style.transition = 'all 0.8s ease-out';
-            p.style.boxShadow = `0 0 10px ${color}`;
-
-            document.body.appendChild(p);
-
-            // 랜덤 방향으로 확산
-            const angle = Math.random() * Math.PI * 2;
-            const velocity = Math.random() * 100 + 50;
-
-            setTimeout(() => {
-                p.style.transform = `translate(${Math.cos(angle) * velocity}px, ${Math.sin(angle) * velocity}px) scale(0)`;
-                p.style.opacity = '0';
-            }, 10);
-
-            setTimeout(() => p.remove(), 800);
-        }
-    },
-
-    screenShake: function() {
-        document.body.style.animation = 'none';
-        // Trigger reflow
-        void document.body.offsetWidth;
-        document.body.style.animation = 'shake 0.5s cubic-bezier(.36,.07,.19,.97) both';
-    },
-
-    showAttackEffect: function(targetId, type) {
-        const el = document.getElementById(targetId);
-        if(!el) return;
-
-        // Shake target
-        el.animate([
-            { transform: 'translate(0, 0)' },
-            { transform: 'translate(-5px, 0)' },
-            { transform: 'translate(5px, 0)' },
-            { transform: 'translate(0, 0)' }
-        ], { duration: 200 });
-
-        if(type === 'crit') {
-             const effect = document.createElement('div');
-             effect.style.position = 'absolute';
-             effect.style.left = '50%';
-             effect.style.top = '0'; // Top of the actor box
-             effect.style.transform = 'translate(-50%, -50%)';
-             effect.style.pointerEvents = 'none';
-             effect.style.fontSize = '1.5rem';
-             effect.style.fontWeight = 'bold';
-             effect.style.color = '#ff0000';
-             effect.style.textShadow = '0 0 5px #fff';
-             effect.style.zIndex = '100';
-             effect.innerText = 'CRITICAL!';
-
-             el.appendChild(effect);
-
-             effect.animate([
-                { opacity: 1, transform: 'translate(-50%, 0) scale(0.5)' },
-                { opacity: 1, transform: 'translate(-50%, -20px) scale(1.5)' },
-                { opacity: 0, transform: 'translate(-50%, -40px) scale(1.2)' }
-             ], {
-                duration: 800,
-                easing: 'ease-out'
-             }).onfinish = () => effect.remove();
-        }
-    }
-};
-
 const RPG = {
-    // Game State (Persistent)
+    // Global Data (Persistent across resets)
+    global: {
+        unlocked_modes: ['origin'],
+        unlocked_bonus_cards: [],
+        achievements: { origin: false },
+        chaosTickets: 0,
+        lastRewardDate: null,
+        pendingTranscendenceCards: []
+    },
+
+    // Game State (Session Persistent)
     state: {
+        mode: 'origin',
         tickets: 20,
         inventory: [],
         deck: [null, null, null],
@@ -476,7 +443,8 @@ const RPG = {
         greatSageBlessingUses: 3,
         chaosBuffs: [], // Array of { id: cardId, multiplier: float } (Merged)
         activeChaosBlessing: [], // Specific buffs from Chaos Blessing
-        activeSageBlessing: []   // Specific buffs from Great Sage Blessing
+        activeSageBlessing: [],   // Specific buffs from Great Sage Blessing
+        quiz_stats: { correct: 0, total: 0 }
     },
 
     // Battle State (Transient)
@@ -497,19 +465,11 @@ const RPG = {
     tempOnClose: null,
     tempConfirmYes: null,
     tempConfirmNo: null,
+    isApiLoading: false,
 
     // Constants
     NORMAL_ATTACK: { name: '일반 공격', type: 'phy', tier: 1, cost: 0, val: 1.0, desc: '기본 물리 공격', effects: [] },
 
-    BUFF_NAMES: {
-        'darkness': '암흑', 'corrosion': '부식', 'silence': '침묵', 'curse': '저주', 'weak': '약화',
-        'burn': '작열', 'divine': '디바인', 'stun': '기절', 'evasion': '회피', 'barrier': '배리어',
-        'magic_guard': '매직가드', 'guard': '가드',
-        'defProtocolPhy': '방어프로토콜(물리)', 'defProtocolMag': '방어프로토콜(마법)',
-        'sun_bless': '태양의축복', 'moon_bless': '달의축복', 'sanctuary': '성역',
-        'goddess_descent': '여신강림', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',
-        'star_powder': '스타파우더'
-    },
 
     // --- Core Functions ---
 
@@ -522,7 +482,60 @@ const RPG = {
         box.scrollTop = box.scrollHeight;
     },
 
+    getCardData(id) {
+        return CARDS.find(c => c.id === id) || BONUS_CARDS.find(c => c.id === id) || (typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS.find(c => c.id === id) : null);
+    },
+
+    // --- Global Data ---
+    loadGlobalData() {
+        const data = localStorage.getItem('cardRpgGlobal');
+        if (data) {
+            try {
+                this.global = { ...this.global, ...JSON.parse(data) };
+            } catch (e) { console.error("Global data parse error", e); }
+        }
+    },
+    saveGlobalData() {
+        localStorage.setItem('cardRpgGlobal', JSON.stringify(this.global));
+    },
+
+    checkDailyChaosTicket() {
+        const today = new Date().toDateString();
+        if (this.global.lastRewardDate !== today) {
+            this.global.lastRewardDate = today;
+            this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
+            this.saveGlobalData();
+            this.showAlert("출석 보상: 카오스 티켓 1장을 획득했습니다!");
+        }
+    },
+
+    checkAllBonusUnlocked() {
+        if (!this.global.unlocked_bonus_cards) return false;
+        return BONUS_CARDS.every(c => this.global.unlocked_bonus_cards.includes(c.id));
+    },
+
     startGame(mode) {
+        // 필수 데이터 로드 검증
+        const requiredData = [
+            { name: 'CARDS', ref: typeof CARDS !== 'undefined' ? CARDS : null },
+            { name: 'ENEMIES', ref: typeof ENEMIES !== 'undefined' ? ENEMIES : null },
+            { name: 'BONUS_CARDS', ref: typeof BONUS_CARDS !== 'undefined' ? BONUS_CARDS : null },
+            { name: 'VOCAB_DATA', ref: typeof VOCAB_DATA !== 'undefined' ? VOCAB_DATA : null },
+            { name: 'GRAMMAR_DATA', ref: typeof GRAMMAR_DATA !== 'undefined' ? GRAMMAR_DATA : null },
+            { name: 'Logic', ref: typeof Logic !== 'undefined' ? Logic : null }
+        ];
+
+        const missing = requiredData.filter(d => !d.ref || (Array.isArray(d.ref) && d.ref.length === 0));
+
+        if(missing.length > 0) {
+            const names = missing.map(d => d.name).join(', ');
+            this.showAlert(`게임 데이터 로드 실패: ${names}<br><br>파일이 같은 폴더에 있는지 확인하고 게임을 새로고침 해주세요.`);
+            return; // 게임 진입 차단
+        }
+
+        this.loadGlobalData();
+        this.checkDailyChaosTicket();
+
         if(mode === 'load') {
             const save = localStorage.getItem('cardRpgSave');
             if(save) {
@@ -533,52 +546,152 @@ const RPG = {
                  if(!this.state.chaosBuffs) this.state.chaosBuffs = [];
                  if(!this.state.activeChaosBlessing) this.state.activeChaosBlessing = [];
                  if(!this.state.activeSageBlessing) this.state.activeSageBlessing = [];
+                 if(!this.state.mode) this.state.mode = 'origin';
+                 if(!this.state.quiz_stats) this.state.quiz_stats = { correct: 0, total: 0 };
 
                  // Load persistent wordbook
                  const vocab = localStorage.getItem('cardRpgVocab');
                  if(vocab) this.state.wrongWords = JSON.parse(vocab);
 
+                 const col = localStorage.getItem('cardRpgCollocation');
+                 if(col) this.state.wrongCollocations = JSON.parse(col);
+
                  this.showAlert("불러오기 완료");
-            } else { this.showAlert("저장된 데이터가 없습니다. 새로 시작합니다."); this.initNewGame(); }
+                 this.toMenu();
+            } else { this.showAlert("저장된 데이터가 없습니다. 새로 시작합니다."); this.openModeSelect(); }
         } else {
-            // New Game Logic: Check for previous run data to save record
-            let prevStage = this.state.enemyScale;
-
-            // If in-memory state is empty (e.g. fresh load), check localStorage
-            if (prevStage === 0 && this.state.tickets === 20) {
-                const save = localStorage.getItem('cardRpgSave');
-                if (save) {
-                    try {
-                        let loaded = JSON.parse(save);
-                        if (loaded.enemyScale) prevStage = loaded.enemyScale;
-                    } catch (e) {}
-                }
-            }
-
-            // Save record if significant progress
-            if (prevStage > 0) {
-                 // Temporarily set state to previous stage for saveRecord to use
-                 let originalScale = this.state.enemyScale;
-                 this.state.enemyScale = prevStage;
-                 this.saveRecord();
-                 this.state.enemyScale = originalScale;
-            }
-
-            this.initNewGame();
+            // New Game Logic: Show Mode Select
+            this.openModeSelect();
         }
-        this.toMenu();
     },
 
-    initNewGame() {
-        this.state = { tickets: 20, inventory: [], deck: [null, null, null], enemyScale: 0, chaosBlessingUses: 3, greatSageBlessingUses: 3, chaosBuffs: [], activeChaosBlessing: [], activeSageBlessing: [], wrongWords: [] };
+    openModeSelect() {
+        this.selectedModeId = null;
+        const modal = document.getElementById('modal-mode-select');
+        const list = document.getElementById('mode-list');
+        const desc = document.getElementById('mode-desc');
+        list.innerHTML = "";
+        desc.innerText = "모드를 선택하여 설명을 확인하세요.";
+
+        const chaosBtn = document.getElementById('btn-chaos-roulette');
+        if (chaosBtn) {
+            if (this.checkAllBonusUnlocked()) {
+                chaosBtn.style.display = 'block';
+            } else {
+                chaosBtn.style.display = 'none';
+            }
+        }
+
+        const MODES = [
+            { id: 'origin', name: '오리진', desc: '기본 모드입니다.\n(성공조건: 없음 / 무한)' },
+            { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장합니다.\n(성공조건: 24 스테이지)' },
+            { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장합니다.\n(성공조건: 24 스테이지)' },
+            { id: 'suffering', name: '고난의 여정', desc: '초기 10장, 클리어 보상 없음, 축복 카드 +2장.\n(성공조건: 24 스테이지)' },
+            { id: 'overdrive', name: '오버드라이브', desc: '초기 10장, 클리어 보상 +1장, 축복 카드 +1장.\n(성공조건: 30 스테이지)' },
+            { id: 'archive', name: '아카이브', desc: '매 스테이지 종료 후 문법 퀴즈. 정답률 90% 이상 필요.\n(성공조건: 24 스테이지)' },
+            { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배.\n(성공조건: 36 스테이지)' },
+            { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배.\n(성공조건: 36 스테이지)' },
+            { id: 'chaos', name: '카오스', desc: '매 전투 덱/인벤토리 초기화. 무작위 20장 풀에서 뽑기 진행.\n(성공조건: 30 스테이지 / 패배 시 데이터 삭제)' },
+            { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' }
+        ];
+
+        MODES.forEach(m => {
+            const btn = document.createElement('button');
+            btn.className = "menu-btn";
+            btn.style.padding = "10px";
+            btn.style.fontSize = "0.9rem";
+            btn.innerText = m.name;
+            btn.id = `mode-btn-${m.id}`;
+
+            const isUnlocked = this.global.unlocked_modes.includes(m.id);
+            if(isUnlocked) btn.style.color = "#e040fb"; // Purple for unlocked
+
+            btn.onclick = () => {
+                this.selectedModeId = m.id;
+                desc.innerText = `[${m.name}]\n${m.desc}`;
+
+                // Visual Update
+                list.querySelectorAll('.menu-btn').forEach(b => b.style.borderColor = '#555');
+                btn.style.borderColor = '#ffd700';
+            };
+            list.appendChild(btn);
+        });
+
+        // Enter Button Logic
+        const enterBtn = document.getElementById('btn-enter-mode');
+        enterBtn.onclick = () => {
+            if(!this.selectedModeId) return this.showAlert("모드를 선택해주세요.");
+            const mName = MODES.find(m => m.id === this.selectedModeId).name;
+            this.showConfirm(`${mName} 모드로 시작하시겠습니까?`, () => {
+                this.initNewGame(this.selectedModeId);
+                modal.classList.remove('active');
+                this.toMenu();
+            });
+        };
+
+        modal.classList.add('active');
+    },
+
+    initNewGame(mode = 'origin') {
+        // Record saving logic (Only for Origin mode as per request "Record check only for Origin")
+        // Check previous state
+        if (this.state.mode === 'origin' && this.state.enemyScale > 0) {
+             this.saveRecord();
+        }
+
+        let initTickets = 20;
+        if (mode === 'suffering' || mode === 'overdrive') initTickets = 10;
+        if (mode === 'chaos') initTickets = 0;
+        if (mode === 'draft') initTickets = 5;
+
+        this.state = {
+            mode: mode,
+            tickets: initTickets,
+            inventory: [],
+            deck: [null, null, null],
+            enemyScale: 0,
+            chaosBlessingUses: 3,
+            greatSageBlessingUses: 3,
+            chaosBuffs: [],
+            activeChaosBlessing: [],
+            activeSageBlessing: [],
+            wrongWords: [],
+            quiz_stats: { correct: 0, total: 0 },
+            chaosPool: [],
+            draft: { active: false, round: 0, rerolls: 3, currentOptions: [] }
+        };
+
+        if (mode === 'chaos') {
+            let allCards = [...CARDS];
+            if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
+                const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                allCards = allCards.concat(bonus);
+            }
+            allCards.sort(() => Math.random() - 0.5);
+            const picks = allCards.slice(0, 20).map(c => c.id);
+
+            this.state.chaosPool = picks;
+            this.state.inventory = [...picks];
+        }
+
+        if (mode === 'origin' && this.global.pendingTranscendenceCards) {
+            this.state.transcendencePool = [...this.global.pendingTranscendenceCards];
+        } else {
+            this.state.transcendencePool = [];
+        }
+
         // Load persistent wordbook
         const vocab = localStorage.getItem('cardRpgVocab');
         if(vocab) this.state.wrongWords = JSON.parse(vocab);
+
+        const col = localStorage.getItem('cardRpgCollocation');
+        if(col) this.state.wrongCollocations = JSON.parse(col);
     },
 
     saveGame() {
         localStorage.setItem('cardRpgSave', JSON.stringify(this.state));
         localStorage.setItem('cardRpgVocab', JSON.stringify(this.state.wrongWords));
+        this.saveGlobalData(); // Also save global just in case
         this.showAlert("저장되었습니다.");
     },
 
@@ -618,6 +731,26 @@ const RPG = {
         const enemyIdx = this.state.enemyScale % ENEMIES.length;
         const nextName = ENEMIES[enemyIdx].name;
         document.getElementById('next-enemy-preview').innerText = `다음 상대: ${nextName} (Stage ${this.state.enemyScale + 1})`;
+
+        // Mode Specific Menu Areas
+        const gachaArea = document.getElementById('menu-gacha-area');
+        const draftArea = document.getElementById('menu-draft-area');
+        const chaosArea = document.getElementById('menu-chaos-area');
+
+        // Hide all first
+        gachaArea.style.display = 'none';
+        draftArea.style.display = 'none';
+        if (chaosArea) chaosArea.style.display = 'none';
+
+        if (this.state.mode === 'draft') {
+            draftArea.style.display = 'block';
+        }
+        else if (this.state.mode === 'chaos') {
+            if (chaosArea) chaosArea.style.display = 'block';
+        }
+        else {
+            gachaArea.style.display = 'flex';
+        }
     },
     toTitle() {
         // No saveRecord here
@@ -627,6 +760,40 @@ const RPG = {
 
     openSystemMenu() {
         document.getElementById('modal-menu').classList.add('active');
+    },
+
+    // --- Chaos Roulette ---
+    openChaosRoulette() {
+        if (!this.checkAllBonusUnlocked()) return this.showAlert("아직 해금되지 않았습니다.");
+        this.showScreen('screen-chaos-roulette');
+        document.getElementById('ui-chaos-tickets').innerText = this.global.chaosTickets || 0;
+    },
+
+    spinChaosRoulette() {
+        if ((this.global.chaosTickets || 0) < 1) return this.showAlert("티켓이 부족합니다.");
+
+        let pool = TRANSCENDENCE_CARDS.filter(c => !this.global.pendingTranscendenceCards.includes(c.id));
+
+        if (pool.length === 0) return this.showAlert("이미 모든 초월 카드를 보유하고 있습니다. (다음 오리진 게임에서 사용하세요)");
+
+        this.global.chaosTickets--;
+        const pick = pool[Math.floor(Math.random() * pool.length)];
+        this.global.pendingTranscendenceCards.push(pick.id);
+        this.saveGlobalData();
+
+        document.getElementById('ui-chaos-tickets').innerText = this.global.chaosTickets;
+
+        const modal = document.getElementById('modal-gacha');
+        const content = document.getElementById('gacha-result');
+        document.getElementById('gacha-title').innerText = "초월 소환 성공!";
+        content.innerHTML = `<div class="card-item transcendence" style="border:2px solid #ffd700; color:#ffd700; font-size:1.2rem; font-weight:bold; margin-bottom:10px; animation: glow-gold 2s infinite;">[초월] ${pick.name}</div>
+            <div class="portrait" style="width:120px; height:160px; margin:0 auto; border-color:#ffd700;"><img src="${pick.name}.png" onerror="this.style.display='none'"></div><p>다음 오리진 게임 전설 풀에 추가되었습니다!</p>`;
+        modal.classList.add('active');
+    },
+
+    openTranscendenceCheck() {
+        this.showScreen('screen-transcendence-check');
+        this.renderCardList('transcendence-grid', this.global.pendingTranscendenceCards, (id) => this.showCardInfo(id));
     },
 
     // --- Chaos Blessing ---
@@ -656,7 +823,6 @@ const RPG = {
             document.getElementById('modal-chaos').classList.remove('active');
 
             // Pick random quiz
-            // Get all quizzes from all lectures
             let allQuizzes = [];
             GRAMMAR_DATA.forEach(lec => {
                 allQuizzes = allQuizzes.concat(lec.quizzes);
@@ -681,12 +847,17 @@ const RPG = {
         }
         document.getElementById('modal-chaos').classList.remove('active');
 
+        // Mode Bonus
+        let bonus = 0;
+        if(this.state.mode === 'suffering') bonus = 2;
+        if(this.state.mode === 'overdrive') bonus = 1;
+
         if(type === 'normal') {
-            this.applyChaosBlessing(3);
+            this.applyChaosBlessing(3 + bonus);
         } else if (type === 'challenge') {
             this.startChaosQuiz((success) => {
                 if(success) {
-                    this.applyChaosBlessing(5);
+                    this.applyChaosBlessing(5 + bonus);
                 } else {
                     this.state.chaosBlessingUses--;
                     document.getElementById('chaos-uses').innerText = this.state.chaosBlessingUses;
@@ -697,12 +868,15 @@ const RPG = {
     },
 
     startGrammarQuiz(q, successCallback = null, failCallback = null) {
+        // ✅ 모달 초기화
+        const modal = document.getElementById('modal-quiz');
+        modal.classList.remove('active');
+
         // Shuffle options
         // q.options is array of strings. q.answer is correct string.
         let opts = [...q.options];
         opts.sort(() => Math.random() - 0.5);
 
-        const modal = document.getElementById('modal-quiz');
         const qDiv = document.getElementById('quiz-question');
         const descDiv = document.getElementById('quiz-desc');
         const oDiv = document.getElementById('quiz-options');
@@ -726,6 +900,7 @@ const RPG = {
             btn.style.fontSize = "0.9rem";
             btn.innerText = opt;
             btn.onclick = () => {
+                btn.disabled = true;
                 Array.from(oDiv.children).forEach(c => c.onclick = null);
                 if(opt === q.answer) {
                     btn.classList.add('correct');
@@ -790,7 +965,21 @@ const RPG = {
         if(document.getElementById('ui-tickets')) document.getElementById('ui-tickets').innerText = this.state.tickets;
 
         // Apply to 12 random cards
-        let pool = [...CARDS].sort(() => 0.5 - Math.random());
+        let pool = [...CARDS];
+        if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
+            const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+            pool = pool.concat(bonus);
+        }
+        pool = pool.filter(c => c.grade !== 'transcendence');
+
+        const mode = this.state.mode;
+        if (mode === 'restriction') {
+            pool = pool.filter(c => c.grade === 'rare' || c.grade === 'normal');
+        } else if (mode === 'balance') {
+            pool = pool.filter(c => c.grade === 'epic' || c.grade === 'rare' || c.grade === 'normal');
+        }
+
+        pool.sort(() => 0.5 - Math.random());
         let picks = pool.slice(0, 12);
 
         this.state.activeChaosBlessing = []; // Clear Chaos Blessing
@@ -819,8 +1008,27 @@ const RPG = {
 
     applyChaosBlessing(count) {
         this.state.chaosBlessingUses--;
-        // Pick random cards from ALL types (CARDS)
-        let pool = [...CARDS].sort(() => 0.5 - Math.random());
+
+        // 1. Base Pool
+        let pool = [...CARDS];
+
+        // 2. Add Bonus Cards (if unlocked)
+        if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
+            const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+            pool = pool.concat(bonus);
+        }
+        pool = pool.filter(c => c.grade !== 'transcendence');
+
+        // 3. Filter by Mode Rarity
+        const mode = this.state.mode;
+        if (mode === 'restriction') {
+            pool = pool.filter(c => c.grade === 'rare' || c.grade === 'normal');
+        } else if (mode === 'balance') {
+            pool = pool.filter(c => c.grade === 'epic' || c.grade === 'rare' || c.grade === 'normal');
+        }
+
+        // 4. Shuffle and Pick
+        pool.sort(() => 0.5 - Math.random());
         let picks = pool.slice(0, count);
 
         this.state.activeSageBlessing = []; // Clear Sage Blessing
@@ -847,6 +1055,51 @@ const RPG = {
     },
 
     // --- Gacha & Deck UI ---
+    reshuffleChaosPool() {
+        if (this.state.tickets < 1) {
+            return this.showAlert("셔플할 티켓이 부족합니다.");
+        }
+
+        this.showConfirm(
+            `현재 보유한 모든 카드와 덱 구성이 사라집니다.<br>
+            티켓 1장을 사용하여 새로운 20장을 받으시겠습니까?`,
+            () => {
+                this.state.tickets--;
+                document.getElementById('ui-tickets').innerText = this.state.tickets;
+
+                let allCards = [...CARDS];
+
+                if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
+                    const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                    allCards = allCards.concat(bonus);
+                }
+
+                allCards.sort(() => Math.random() - 0.5);
+                const newPicks = allCards.slice(0, 20).map(c => c.id);
+
+                this.state.chaosPool = newPicks;
+                this.state.inventory = [...newPicks];
+                this.state.deck = [null, null, null];
+
+                this.saveGame();
+
+                let legendCnt = 0, epicCnt = 0;
+                newPicks.forEach(id => {
+                    const c = this.getCardData(id);
+                    if(c.grade === 'legend') legendCnt++;
+                    if(c.grade === 'epic') epicCnt++;
+                });
+
+                this.showAlert(
+                    `<b>카오스 셔플 완료!</b><br><br>
+                    새로운 20장이 지급되었습니다.<br>
+                    (전설: ${legendCnt}, 에픽: ${epicCnt})<br><br>
+                    * 덱이 초기화되었으니 다시 구성해주세요.`
+                );
+            }
+        );
+    },
+
     openGacha() {
         if(this.state.tickets < 1) return this.showAlert("티켓이 부족합니다.");
         this.state.tickets--;
@@ -873,48 +1126,117 @@ const RPG = {
         document.getElementById('ui-tickets').innerText = this.state.tickets;
         let rand = Math.random();
         let grade = 'normal';
+        const mode = this.state.mode;
 
-        if (isChallenge) {
-            // Legend 20%, Epic 25%, Rare 30%, Normal 25%
-            if(rand < 0.20) grade = 'legend';
-            else if(rand < 0.45) grade = 'epic';
-            else if(rand < 0.75) grade = 'rare';
-            else grade = 'normal';
+        // Chaos Mode Override
+        /*
+        if (mode === 'chaos') {
+            if (!this.state.chaosPool || this.state.chaosPool.length === 0) {
+                 // Should have been generated in winBattle or initNewGame, but fallback
+                 let allCards = [...CARDS];
+                 if (this.global.unlocked_bonus_cards) {
+                     const unlocked = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                     allCards = allCards.concat(unlocked);
+                 }
+                 allCards.sort(() => Math.random() - 0.5);
+                 this.state.chaosPool = allCards.slice(0, 20).map(c => c.id);
+            }
+            const pickId = this.state.chaosPool[Math.floor(Math.random() * this.state.chaosPool.length)];
+            const pick = this.getCardData(pickId);
+            this.state.inventory.push(pick.id);
+
+            const modal = document.getElementById('modal-gacha');
+            const content = document.getElementById('gacha-result');
+            let color = '#bdbdbd';
+            if(pick.grade === 'legend') color = '#ff5252';
+            else if(pick.grade === 'epic') color = '#e040fb';
+            else if(pick.grade === 'rare') color = '#448aff';
+
+            document.getElementById('gacha-title').innerText = "카오스 뽑기 성공!";
+            content.innerHTML = `<div style="color:${color}; font-size:1.2rem; font-weight:bold; margin-bottom:10px;">[${pick.grade.toUpperCase()}] ${pick.name}</div>
+            <div class="portrait" style="width:120px; height:160px; margin:0 auto;"><img src="${pick.name}.png" onerror="this.style.display='none'"></div><p>새로운 동료를 얻었습니다!</p>`;
+            modal.classList.add('active');
+            return;
+        }
+        */
+
+        // Determine Grade
+        if (mode === 'restriction') {
+            // Restriction: Rare max
+            if (isChallenge) {
+                // Challenge: Rare 40, Normal 60
+                if(rand < 0.40) grade = 'rare';
+                else grade = 'normal';
+            } else {
+                // Normal: Rare 20, Normal 80
+                if(rand < 0.20) grade = 'rare';
+                else grade = 'normal';
+            }
+        } else if (mode === 'balance') {
+            // Balance: Epic max
+            if (isChallenge) {
+                // Challenge: Epic 20, Rare 30, Normal 50
+                if(rand < 0.20) grade = 'epic';
+                else if(rand < 0.50) grade = 'rare';
+                else grade = 'normal';
+            } else {
+                // Normal: Epic 10, Rare 20, Normal 70
+                if(rand < 0.10) grade = 'epic';
+                else if(rand < 0.30) grade = 'rare';
+                else grade = 'normal';
+            }
         } else {
-            // Default: 10% Legend, 20% Epic, 30% Rare, 40% Normal
-            if(rand < 0.10) grade = 'legend';
-            else if(rand < 0.30) grade = 'epic';
-            else if(rand < 0.60) grade = 'rare';
+            // Origin / Others
+            if (isChallenge) {
+                // Legend 20%, Epic 25%, Rare 30%, Normal 25%
+                if(rand < 0.20) grade = 'legend';
+                else if(rand < 0.45) grade = 'epic';
+                else if(rand < 0.75) grade = 'rare';
+                else grade = 'normal';
+            } else {
+                // Default: 10% Legend, 20% Epic, 30% Rare, 40% Normal
+                if(rand < 0.10) grade = 'legend';
+                else if(rand < 0.30) grade = 'epic';
+                else if(rand < 0.60) grade = 'rare';
+            }
         }
 
-        const pool = CARDS.filter(c => c.grade === grade);
+        // Build Pool
+        let pool = CARDS.filter(c => c.grade === grade);
+
+        // Add Bonus Cards
+        if (this.global.unlocked_bonus_cards.length > 0) {
+            const bonus = BONUS_CARDS.filter(c => c.grade === grade && this.global.unlocked_bonus_cards.includes(c.id));
+            pool = pool.concat(bonus);
+        }
+
+        // Add Transcendence Cards (Origin Only, Legend Only)
+        if (mode === 'origin' && grade === 'legend' && this.state.transcendencePool && this.state.transcendencePool.length > 0) {
+             const transCards = TRANSCENDENCE_CARDS.filter(c => this.state.transcendencePool.includes(c.id));
+             pool = pool.concat(transCards);
+        }
+
+        if(pool.length === 0) {
+            // Fallback if pool is empty (e.g. no cards of that grade? Should not happen with standard set)
+            // But if Restriction mode and we rolled something else? Logic guarantees valid grade.
+            // If somehow empty, fallback to normal
+            console.error("Empty pool for grade: " + grade);
+            grade = 'normal';
+            pool = CARDS.filter(c => c.grade === 'normal');
+        }
+
         const pick = pool[Math.floor(Math.random() * pool.length)];
         this.state.inventory.push(pick.id);
 
         const modal = document.getElementById('modal-gacha');
         const content = document.getElementById('gacha-result');
         let color = '#bdbdbd', title = "획득!";
-        if(grade === 'legend') { color = '#ff5252'; title = "🎉 대박! 전설 카드! 🎉"; }
+        if(pick.grade === 'transcendence') { color = '#ffd700'; title = "🌟 초월 카드 강림! 🌟"; }
+        else if(grade === 'legend') { color = '#ff5252'; title = "🎉 대박! 전설 카드! 🎉"; }
         else if(grade === 'epic') { color = '#e040fb'; title = "✨ 에픽 카드! ✨"; }
 
-        // FX Integration
-        const centerX = window.innerWidth / 2;
-        const centerY = window.innerHeight / 2;
-
-        if (grade === 'legend') {
-            setTimeout(() => FX.burstParticles(centerX, centerY, '#ff5252'), 0);
-            setTimeout(() => FX.burstParticles(centerX, centerY, '#ff5252'), 200);
-            setTimeout(() => FX.burstParticles(centerX, centerY, '#ffd700'), 400);
-            FX.screenShake();
-        } else if (grade === 'epic') {
-            FX.burstParticles(centerX, centerY, '#e040fb');
-        } else if (grade === 'rare') {
-            FX.burstParticles(centerX, centerY, '#448aff');
-        } else {
-            FX.burstParticles(centerX, centerY, '#ffffff');
-        }
-
         let msgTitle = isChallenge ? "도전 뽑기 성공!" : "획득!";
+        if(pick.grade === 'transcendence') msgTitle = title;
         document.getElementById('gacha-title').innerText = msgTitle;
         content.innerHTML = `<div style="color:${color}; font-size:1.2rem; font-weight:bold; margin-bottom:10px;">[${pick.grade.toUpperCase()}] ${pick.name}</div>
             <div class="portrait" style="width:120px; height:160px; margin:0 auto;"><img src="${pick.name}.png" onerror="this.style.display='none'"></div><p>새로운 동료를 얻었습니다!</p>`;
@@ -926,6 +1248,7 @@ const RPG = {
         document.getElementById('modal-library').classList.add('active');
     },
     openMagicClass() {
+        document.getElementById('modal-library').classList.remove('active');
         const list = document.getElementById('lecture-list');
         list.innerHTML = "";
         GRAMMAR_DATA.forEach(lec => {
@@ -956,14 +1279,22 @@ const RPG = {
     },
     closeLectureView() {
         document.getElementById('modal-lecture-view').classList.remove('active');
-        if(this.tempLectureClose) {
-            this.tempLectureClose();
-            this.tempLectureClose = null;
+        const cb = this.tempLectureClose;
+        this.tempLectureClose = null;
+        if(cb) {
+            cb();
         }
     },
 
     // --- Wordbook & Quiz ---
     openWordbook() {
+        document.getElementById('modal-library').classList.remove('active');
+        if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+            this.openCollocationBook();
+            return;
+        }
+
+        document.querySelector('#modal-wordbook h3').innerText = "단어장"; // Reset title
         if(!this.state.wrongWords) this.state.wrongWords = [];
         const list = document.getElementById('wordbook-list');
         list.innerHTML = "";
@@ -992,15 +1323,149 @@ const RPG = {
     },
 
     resetWrongWords() {
+        if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+            this.state.wrongCollocations = [];
+            localStorage.removeItem('cardRpgCollocation');
+            this.showAlert("숙어/구동사 복습 상태가 초기화되었습니다.");
+            this.openCollocationBook();
+            return;
+        }
+
         this.state.wrongWords = [];
         localStorage.removeItem('cardRpgVocab');
         this.showAlert("복습 상태가 초기화되었습니다.");
         this.openWordbook(); // Re-render
     },
 
+    openCollocationBook() {
+        if(!this.state.wrongCollocations) this.state.wrongCollocations = [];
+        const list = document.getElementById('wordbook-list');
+        list.innerHTML = "";
+
+        const onlyWrong = document.getElementById('wordbook-filter-wrong').checked;
+
+        COLLOCATION_DATA.forEach(v => {
+            const isWrong = this.state.wrongCollocations.includes(v.id);
+
+            if(onlyWrong && !isWrong) return;
+
+            const div = document.createElement('div');
+            div.style.marginBottom = "10px";
+            div.style.borderBottom = "1px solid #444";
+            div.style.paddingBottom = "5px";
+
+            const color = isWrong ? '#ef5350' : '#81d4fa';
+
+            div.innerHTML = `<b style="color:${color}; font-size:1.1rem;">${v.expression}</b><br>
+                             <span style="color:#eee;">${v.meaning}</span>`;
+            list.appendChild(div);
+        });
+
+        document.querySelector('#modal-wordbook h3').innerText = "숙어/구동사 단어장";
+        document.getElementById('modal-wordbook').classList.add('active');
+    },
+
+    startCollocationQuiz(callback) {
+        // ✅ 모달 초기화
+        const modal = document.getElementById('modal-quiz');
+        modal.classList.remove('active');
+
+        document.getElementById('quiz-desc').style.display = 'block';
+
+        if (!COLLOCATION_DATA || COLLOCATION_DATA.length === 0) {
+            return this.showAlert("데이터 로드 오류: Collocation 데이터가 없습니다.");
+        }
+
+        let allQuizzes = [];
+        COLLOCATION_DATA.forEach(item => {
+            if (item.quizzes) {
+                item.quizzes.forEach(q => {
+                    allQuizzes.push({ ...q, parentId: item.id });
+                });
+            } else {
+                 allQuizzes.push({ ...item, parentId: item.id });
+            }
+        });
+
+        if (allQuizzes.length === 0) return this.showAlert("퀴즈 데이터가 없습니다.");
+
+        const q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+
+        let opts = [...q.options];
+        opts.sort(() => Math.random() - 0.5);
+
+        const qDiv = document.getElementById('quiz-question');
+        const descDiv = document.getElementById('quiz-desc');
+        const oDiv = document.getElementById('quiz-options');
+        const fDiv = document.getElementById('quiz-feedback');
+
+        qDiv.innerText = q.question;
+        descDiv.innerText = q.translation;
+
+        oDiv.innerHTML = "";
+        fDiv.innerText = "";
+
+        opts.forEach(opt => {
+            const btn = document.createElement('button');
+            btn.className = "menu-btn";
+            btn.style.padding = "10px";
+            btn.style.fontSize = "0.9rem";
+            btn.innerText = opt;
+            btn.onclick = () => {
+                btn.disabled = true;
+                Array.from(oDiv.children).forEach(c => c.onclick = null);
+                if(opt === q.answer) {
+                    btn.classList.add('correct');
+                    fDiv.innerText = "정답!"; fDiv.style.color = "#4caf50";
+                    setTimeout(() => {
+                        modal.classList.remove('active');
+                        callback(true);
+                    }, 1000);
+                } else {
+                    btn.classList.add('wrong');
+
+                    if(!this.state.wrongCollocations) this.state.wrongCollocations = [];
+                    if(!this.state.wrongCollocations.includes(q.parentId)) {
+                        this.state.wrongCollocations.push(q.parentId);
+                        localStorage.setItem('cardRpgCollocation', JSON.stringify(this.state.wrongCollocations));
+                    }
+
+                    Array.from(oDiv.children).forEach(c => {
+                         if(c.innerText === q.answer) c.classList.add('correct');
+                    });
+                    fDiv.innerText = "오답..."; fDiv.style.color = "#ef5350";
+
+                    setTimeout(() => {
+                        modal.classList.remove('active');
+                        callback(false);
+                    }, 1500);
+                }
+            };
+            oDiv.appendChild(btn);
+        });
+
+        modal.classList.add('active');
+    },
+
     startQuiz(callback) {
-        // Reset specific UI elements for normal quiz
-        document.getElementById('quiz-desc').style.display = 'none';
+        // ✅ 모달 초기화
+        const modal = document.getElementById('modal-quiz');
+        const qDiv = document.getElementById('quiz-question');
+        const descDiv = document.getElementById('quiz-desc');
+        const oDiv = document.getElementById('quiz-options');
+        const fDiv = document.getElementById('quiz-feedback');
+
+        // 모달 닫기 (혹시 열려있다면)
+        modal.classList.remove('active');
+
+        // 완전 초기화
+        oDiv.innerHTML = "";
+        if(fDiv) fDiv.innerText = "";
+        descDiv.style.display = 'none';
+
+        if (!VOCAB_DATA || VOCAB_DATA.length === 0) {
+            return this.showAlert("데이터 로드 오류: 단어 데이터가 없습니다.");
+        }
 
         // Pick a word
         const q = VOCAB_DATA[Math.floor(Math.random() * VOCAB_DATA.length)];
@@ -1024,14 +1489,7 @@ const RPG = {
         // Shuffle
         options.sort(() => Math.random() - 0.5);
 
-        const modal = document.getElementById('modal-quiz');
-        const qDiv = document.getElementById('quiz-question');
-        const oDiv = document.getElementById('quiz-options');
-        const fDiv = document.getElementById('quiz-feedback');
-
         qDiv.innerText = q.word;
-        oDiv.innerHTML = "";
-        if(fDiv) fDiv.innerText = "";
 
         options.forEach(opt => {
             const btn = document.createElement('button');
@@ -1041,6 +1499,7 @@ const RPG = {
             btn.innerText = opt.text;
             btn.onclick = () => {
                 // Disable all buttons
+                btn.disabled = true;
                 Array.from(oDiv.children).forEach(c => c.onclick = null);
 
                 if(opt.correct) {
@@ -1078,7 +1537,23 @@ const RPG = {
     },
 
     startChaosQuiz(callback) {
-        document.getElementById('quiz-desc').style.display = 'none';
+        // ✅ 모달 초기화 추가
+        const modal = document.getElementById('modal-quiz');
+        modal.classList.remove('active'); // 기존 모달 닫기
+
+        const qDiv = document.getElementById('quiz-question');
+        const descDiv = document.getElementById('quiz-desc');
+        const oDiv = document.getElementById('quiz-options');
+        const fDiv = document.getElementById('quiz-feedback');
+
+        // 완전 초기화
+        oDiv.innerHTML = "";
+        if(fDiv) fDiv.innerText = "";
+        descDiv.style.display = 'none';
+
+        if (!VOCAB_DATA || VOCAB_DATA.length === 0) {
+            return this.showAlert("데이터 로드 오류: 단어 데이터가 없습니다.");
+        }
 
         // Pick a word
         const q = VOCAB_DATA[Math.floor(Math.random() * VOCAB_DATA.length)];
@@ -1101,15 +1576,8 @@ const RPG = {
         // Shuffle
         options.sort(() => Math.random() - 0.5);
 
-        const modal = document.getElementById('modal-quiz');
-        const qDiv = document.getElementById('quiz-question');
-        const oDiv = document.getElementById('quiz-options');
-        const fDiv = document.getElementById('quiz-feedback');
-
         // Question is Meaning (Korean)
         qDiv.innerText = q.meaning;
-        oDiv.innerHTML = "";
-        if(fDiv) fDiv.innerText = "";
 
         options.forEach(opt => {
             const btn = document.createElement('button');
@@ -1119,6 +1587,7 @@ const RPG = {
             btn.innerText = opt.text;
             btn.onclick = () => {
                 // Disable all buttons
+                btn.disabled = true; // ✅ 즉시 비활성화
                 Array.from(oDiv.children).forEach(c => c.onclick = null);
 
                 if(opt.correct) {
@@ -1156,7 +1625,7 @@ const RPG = {
         let counts = {};
         list.forEach(id => { counts[id] = (counts[id] || 0) + 1; });
         for(let id in counts) {
-            const data = CARDS.find(c => c.id === id);
+            const data = this.getCardData(id);
             if(!data) continue;
             const el = document.createElement('div');
             el.className = `card-item ${data.grade}`;
@@ -1167,34 +1636,13 @@ const RPG = {
     },
 
     showCardInfo(id) {
-        const data = CARDS.find(c => c.id === id);
+        const data = this.getCardData(id);
         if(!data) return;
         document.getElementById('md-name').innerText = data.name;
         document.getElementById('md-img').src = `${data.name}.png`;
         document.getElementById('md-grade').className = data.grade;
         document.getElementById('md-grade').innerText = `${data.grade.toUpperCase()} / ${data.role} / ${data.element}`;
         document.getElementById('md-stats').innerHTML = `HP:${data.stats.hp} ATK:${data.stats.atk} MATK:${data.stats.matk}<br>DEF:${data.stats.def} MDEF:${data.stats.mdef}`;
-
-        // Hologram Logic
-        const portraitDiv = document.querySelector('#modal-card .portrait');
-        portraitDiv.className = 'portrait'; // Reset
-        portraitDiv.style.border = '';
-        portraitDiv.style.boxShadow = '';
-
-        if (data.grade === 'legend') {
-            portraitDiv.classList.add('legend-glow');
-            portraitDiv.style.border = '3px solid #ff5252';
-        } else if (data.grade === 'epic') {
-            portraitDiv.style.border = '2px solid #e040fb';
-            portraitDiv.style.boxShadow = '0 0 15px #e040fb';
-        } else if (data.grade === 'rare') {
-             portraitDiv.style.border = '2px solid #448aff';
-             portraitDiv.style.boxShadow = '0 0 10px #448aff';
-        } else {
-            portraitDiv.style.border = '2px solid #555';
-            portraitDiv.style.boxShadow = 'none';
-        }
-
         let skills = `<p style="color:#ffd700; margin:5px 0;">[특성] ${data.trait.desc}</p>`;
         skills += `<p style="margin:2px 0;">[일반 공격] (Tier 1) 기본 물리 공격</p>`;
         data.skills.forEach(s => {
@@ -1226,7 +1674,7 @@ const RPG = {
         ['선봉', '중견', '대장'].forEach((role, i) => {
             const id = this.state.deck[i];
             const el = document.getElementById(`slot-${i}`);
-            if(id) { const c = CARDS.find(x => x.id === id); el.innerText = `${role}: ${c.name}`; el.classList.add('filled'); }
+            if(id) { const c = this.getCardData(id); el.innerText = `${role}: ${c.name}`; el.classList.add('filled'); }
             else { el.innerText = `${role} (비어있음)`; el.classList.remove('filled'); }
         });
     },
@@ -1258,10 +1706,11 @@ const RPG = {
 
         this.battle.players = this.state.deck.map((id, idx) => {
             if(!id) return null;
-            const proto = CARDS.find(c => c.id === id);
+            const proto = this.getCardData(id);
 
             // Call Logic to calculate initial stats (Base + Synergies)
-            const init = Logic.calculateInitialStats(proto, this.state.deck, CARDS);
+            const allCards = [...CARDS, ...BONUS_CARDS];
+            const init = Logic.calculateInitialStats(proto, this.state.deck, allCards, idx);
 
             // Log active synergy if any
             if(init.activeTrait) {
@@ -1539,7 +1988,9 @@ const RPG = {
             victim,
             killer,
             RPG.battle.fieldBuffs,
-            (msg) => RPG.log(msg)
+            (msg) => RPG.log(msg),
+            RPG.state.deck,
+            RPG.battle.turn
         );
 
         // Apply results
@@ -1575,6 +2026,13 @@ const RPG = {
              RPG.log("[특성] 일반 공격 추가 효과: 작열, 디바인 부여!");
         }
 
+        // Trait: Phoenix Normal Attack Burn
+        if (skill.name === RPG.NORMAL_ATTACK.name && source.proto && source.proto.trait && source.proto.trait.type === 'syn_fire_3_crit_burn' && RPG.battle.activeTraits.includes('syn_fire_3_crit_burn')) {
+             target.buffs['burn'] = (target.buffs['burn'] || 0) + 1;
+             if(target.buffs['burn'] > 3) target.buffs['burn'] = 3;
+             RPG.log("[특성] 피닉스: 일반 공격 시 작열 부여!");
+        }
+
         // Trait: Behemoth (Skill Use -> Stun Chance)
         if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_trait') {
             if (Math.random() < 0.2) {
@@ -1583,8 +2041,19 @@ const RPG = {
             }
         }
 
+        // Trait: Behemoth Liberated (Skill Use -> Stun Chance)
+        if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_liberated_trait') {
+            if (Math.random() < 0.2) {
+                target.buffs.stun = 1;
+                RPG.log("[특성] 해방된 베히모스: 20% 확률로 적을 기절시킵니다!");
+            }
+        }
+
         // Check for Delayed Attack Effect
-        const delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_attack');
+        let delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_attack');
+        if(!delayedEff) delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_attack_field');
+        if(!delayedEff) delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_random_attack');
+
         if(delayedEff && !isDelayed) {
             RPG.log(`종언의 예고가 시작됩니다... (${delayedEff.turns}턴 뒤 발동)`);
             RPG.battle.delayedEffects.push({ turn: RPG.battle.turn + delayedEff.turns, source: source, skill: skill });
@@ -1620,18 +2089,11 @@ const RPG = {
             skill,
             RPG.battle.fieldBuffs,
             RPG.battle.activeTraits,
-            (msg) => RPG.log(msg)
+            (msg) => RPG.log(msg),
+            RPG.state.mode, // PASS MODE
+            RPG.state.deck, // PASS DECK
+            RPG.battle.turn // PASS TURN
         );
-
-        // FX Logic
-        if (result.isCrit) {
-             let targetId = 'enemy-actor-box';
-             // If target is in players list, then it's player taking damage
-             if (RPG.battle.players.includes(target)) {
-                 targetId = 'player-actor-box';
-             }
-             FX.showAttackEffect(targetId, 'crit');
-        }
 
         if(target.id === 'demon_god') {
              const b = RPG.battle;
@@ -1648,150 +2110,21 @@ const RPG = {
     applySkillEffects(source, target, skill) {
         if(!skill.effects) return;
 
+        const ctx = {
+            source: source,
+            target: target,
+            skill: skill,
+            logFn: (msg) => RPG.log(msg),
+            getBuffName: (id) => (BUFF_NAMES[id] || id),
+            applyFieldBuff: (id) => RPG.applyFieldBuff(id),
+            battle: this.battle,
+            executeSkill: this.executeSkill.bind(this),
+            getCardData: this.getCardData.bind(this)
+        };
+
         skill.effects.forEach(eff => {
-            if(eff.type === 'buff') {
-                source.buffs[eff.id] = (eff.duration || 1);
-            }
-            else if(eff.type === 'debuff' || eff.type === 'self_debuff') {
-                let t = eff.type === 'debuff' ? target : source;
-                if(eff.stack) {
-                    t.buffs[eff.id] = (t.buffs[eff.id] || 0) + 1;
-                    if(t.buffs[eff.id] > 3) t.buffs[eff.id] = 3;
-                    RPG.log(`${t === source ? '자신' : '적'}에게 [${this.BUFF_NAMES[eff.id]}] ${t.buffs[eff.id]}스택.`);
-                } else {
-                    t.buffs[eff.id] = 1; // Flag or duration 1
-                    RPG.log(`${t === source ? '자신' : '적'}에게 [${this.BUFF_NAMES[eff.id]}] 부여.`);
-                }
-            }
-            else if(eff.type === 'field_buff') {
-                this.applyFieldBuff(eff.id);
-            }
-            else if(eff.type === 'conditional_field_buff') {
-                if(eff.condition === 'target_has_debuff' && target.buffs[eff.debuff]) this.applyFieldBuff(eff.id);
-            }
-            else if(eff.type === 'random_debuff') {
-                let pool = [...eff.pool].sort(() => 0.5 - Math.random());
-                for(let i=0; i<eff.count; i++) {
-                    if(pool[i]) {
-                         target.buffs[pool[i]] = 1;
-                         RPG.log(`적에게 [${this.BUFF_NAMES[pool[i]]}] 부여.`);
-                    }
-                }
-            }
-            else if(eff.type === 'conditional_debuff') {
-                if(eff.condition === 'target_debuff_count' && Object.keys(target.buffs).length >= eff.count) {
-                    target.buffs[eff.debuff] = 1;
-                    RPG.log(`조건 만족! 적에게 [${this.BUFF_NAMES[eff.debuff]}] 부여.`);
-                }
-            }
-            else if(eff.type === 'suicide') {
-                source.hp = 0;
-            }
-            else if(eff.type === 'chance_debuff') {
-                if(Math.random() < eff.chance) {
-                    target.buffs[eff.id] = eff.duration || 1;
-                    RPG.log(`<b>성공!</b> ${target === source ? '자신' : '적'}에게 [${this.BUFF_NAMES[eff.id]}] 부여.`);
-                } else {
-                    RPG.log(`[${this.BUFF_NAMES[eff.id]}] 부여 <b>실패</b>.`);
-                }
-            }
-            else if(eff.type === 'conditional_field_debuff') {
-                 if(RPG.battle.fieldBuffs.some(b => b.name === eff.field)) {
-                     eff.debuffs.forEach(d => {
-                         target.buffs[d] = 1;
-                         RPG.log(`조건 만족! [${this.BUFF_NAMES[d]}] 부여.`);
-                     });
-                 }
-            }
-            else if(eff.type === 'clear_target_debuffs') {
-                 const count = Object.keys(target.buffs).length;
-                 target.buffs = {};
-                 if(count > 0) RPG.log(`적의 모든 디버프를 제거했습니다! (${count}개)`);
-            }
-            else if(eff.type === 'consume_all_burn_cond_buff') {
-                 if(target.buffs['burn']) {
-                     delete target.buffs['burn'];
-                     RPG.applyFieldBuff('sun_bless');
-                     RPG.log("작열 스택을 모두 소모하여 태양의 축복을 불러옵니다!");
-                 } else {
-                     RPG.applyFieldBuff('earth_bless');
-                     RPG.log("소모할 작열이 없어 대지의 축복을 불러옵니다.");
-                 }
-            }
-            else if(eff.type === 'consume_burn_1_dmg') {
-                 if(target.buffs['burn'] >= 1) {
-                     target.buffs['burn']--;
-                     if(target.buffs['burn'] <= 0) delete target.buffs['burn'];
-                     RPG.log("작열 1스택 소모! 대미지 2배 적용!");
-                 }
-            }
-            else if(eff.type === 'remove_field_buff_dmg') {
-                 if(RPG.battle.fieldBuffs.length > 0) {
-                     let rm = RPG.battle.fieldBuffs.shift();
-                     RPG.log(`필드버프 [${this.BUFF_NAMES[rm.name]}] 제거! 대미지 2배 적용!`);
-                 }
-            }
-            else if(eff.type === 'check_divine_3_stun_else_add') {
-                 if((target.buffs['divine'] || 0) >= 3) {
-                     target.buffs['stun'] = 1;
-                     RPG.log("디바인 3스택 확인! 적을 기절시킵니다!");
-                 } else {
-                     target.buffs['divine'] = (target.buffs['divine'] || 0) + 1;
-                     if(target.buffs['divine'] > 3) target.buffs['divine'] = 3;
-                     RPG.log("디바인 스택 추가.");
-                 }
-            }
-            else if(eff.type === 'random_debuff_consume_divine') {
-                let pool = ['curse', 'darkness', 'silence', 'weak', 'corrosion'];
-                let count = 1;
-                if(target.buffs['divine'] > 0) {
-                    target.buffs['divine']--;
-                    if(target.buffs['divine'] <= 0) delete target.buffs['divine'];
-                    count = 2;
-                    RPG.log("디바인을 소모하여 효과 강화! (디버프 2개 부여)");
-                }
-
-                pool.sort(() => 0.5 - Math.random());
-                for(let i=0; i<count; i++) {
-                    target.buffs[pool[i]] = 1;
-                    RPG.log(`적에게 [${this.BUFF_NAMES[pool[i]]}] 부여.`);
-                }
-            }
-            else if(eff.type === 'roulette_field') {
-                 RPG.battle.fieldBuffs = [];
-                 RPG.log("모든 필드 버프가 제거되었습니다!");
-
-                 const buffs = ['sun_bless', 'moon_bless', 'sanctuary', 'goddess_descent', 'earth_bless', 'twinkle_party', 'star_powder'];
-                 const pick = buffs[Math.floor(Math.random() * buffs.length)];
-                 this.applyFieldBuff(pick);
-            }
-            else if(eff.type === 'wild_card_debuff') {
-                 // Fix: Cleanse TARGET (Enemy) debuffs, then add new debuffs to TARGET (Enemy).
-                 // As per request: "상대의 디버프를 제거하고 새로 2개를 부여하는것"
-
-                 const badBuffs = ['curse', 'darkness', 'silence', 'weak', 'corrosion', 'burn', 'divine', 'stun'];
-                 let cleansed = 0;
-                 badBuffs.forEach(b => {
-                     if(target.buffs[b]) {
-                         delete target.buffs[b];
-                         cleansed++;
-                     }
-                 });
-                 if(cleansed > 0) RPG.log(`적의 디버프를 모두 해제했습니다! (${cleansed}개)`);
-
-                 let pool = ['curse', 'darkness', 'silence', 'weak', 'corrosion', 'burn', 'divine'];
-                 pool.sort(() => 0.5 - Math.random());
-
-                 for(let i=0; i<2; i++) {
-                     if(pool[i] === 'burn' || pool[i] === 'divine') {
-                         target.buffs[pool[i]] = (target.buffs[pool[i]] || 0) + 1;
-                         if(target.buffs[pool[i]] > 3) target.buffs[pool[i]] = 3;
-                         RPG.log(`적에게 [${this.BUFF_NAMES[pool[i]]}] 스택 추가.`);
-                     } else {
-                         target.buffs[pool[i]] = 1;
-                         RPG.log(`적에게 [${this.BUFF_NAMES[pool[i]]}] 부여.`);
-                     }
-                 }
+            if(typeof SideEffects !== 'undefined') {
+                SideEffects.apply(ctx, eff);
             }
         });
 
@@ -1800,16 +2133,22 @@ const RPG = {
             RPG.log("루미의 특성 발동! 트윙클파티 추가!");
             this.applyFieldBuff('twinkle_party');
         }
+
+        // Siren Trait Trigger
+        if(RPG.battle.activeTraits.includes('syn_water_2_moon_twinkle') && skill.name === '실버문베일') {
+            RPG.log("[특성] 세이렌의 노래! 트윙클파티 추가!");
+            this.applyFieldBuff('twinkle_party');
+        }
     },
 
     applyFieldBuff(id) {
-        if(this.battle.fieldBuffs.some(b => b.name === id)) return RPG.log(`필드버프 [${this.BUFF_NAMES[id]}] 이미 존재.`);
+        if(this.battle.fieldBuffs.some(b => b.name === id)) return RPG.log(`필드버프 [${BUFF_NAMES[id]}] 이미 존재.`);
         if(this.battle.fieldBuffs.length >= 3) {
              let removed = this.battle.fieldBuffs.shift();
-             RPG.log(`필드버프 [${this.BUFF_NAMES[removed.name]}] 소멸.`);
+             RPG.log(`필드버프 [${BUFF_NAMES[removed.name]}] 소멸.`);
         }
         this.battle.fieldBuffs.push({ name: id });
-        RPG.log(`필드버프 [${this.BUFF_NAMES[id]}] 발동!`);
+        RPG.log(`필드버프 [${BUFF_NAMES[id]}] 발동!`);
     },
 
     // --- Setup & UI ---
@@ -1850,7 +2189,7 @@ const RPG = {
             let mpPct = (p.mp / 100) * 100;
             document.getElementById('p-mp-bar').style.width = `${Math.max(0, mpPct)}%`;
 
-            let buffTxt = Object.keys(p.buffs).map(k=>this.BUFF_NAMES[k]||k).join(',');
+            let buffTxt = Object.keys(p.buffs).map(k=>BUFF_NAMES[k]||k).join(',');
             document.getElementById('p-buffs').innerText = buffTxt;
             document.getElementById('player-actor-box').style.opacity = 1;
         } else {
@@ -1865,11 +2204,11 @@ const RPG = {
         eImg.src = `${e.name}.png`;
         eImg.style.display = 'block';
 
-        let eBuffTxt = Object.keys(e.buffs).map(k=>`${this.BUFF_NAMES[k]||k}${e.buffs[k]>1?e.buffs[k]:''}`).join(' ');
+        let eBuffTxt = Object.keys(e.buffs).map(k=>`${BUFF_NAMES[k]||k}${e.buffs[k]>1?e.buffs[k]:''}`).join(' ');
         document.getElementById('e-buffs').innerText = eBuffTxt;
 
         document.getElementById('bt-turn').innerText = this.battle.turn;
-        document.getElementById('field-buff-box').innerHTML = this.battle.fieldBuffs.map(b => `[${this.BUFF_NAMES[b.name]||b.name}]`).join(" ");
+        document.getElementById('field-buff-box').innerHTML = this.battle.fieldBuffs.map(b => `[${BUFF_NAMES[b.name]||b.name}]`).join(" ");
     },
 
     getElementalMultiplier(atkEl, defEl) {
@@ -1878,6 +2217,120 @@ const RPG = {
         if(atkEl === 'nature' && defEl === 'water') return 1.2;
         if((atkEl === 'light' && defEl === 'dark') || (atkEl === 'dark' && defEl === 'light')) return 1.2;
         return 1.0;
+    },
+
+    // --- Draft Logic ---
+    startDraft() {
+        if(this.state.deck.every(x => x !== null)) {
+            return this.showAlert("이미 덱이 완성되어 있습니다. 전투에 진입하세요.");
+        }
+
+        if(!this.state.draft) this.state.draft = { active: true, round: 0, rerolls: 3, currentOptions: [] };
+
+        // Find first empty slot
+        this.state.draft.round = this.state.deck.indexOf(null);
+        if(this.state.draft.round === -1) {
+            this.state.draft.round = 0;
+        }
+
+        this.showScreen('screen-draft');
+        this.renderDraftScreen();
+    },
+
+    renderDraftScreen() {
+        const d = this.state.draft;
+        const roles = ['선봉', '중견', '대장'];
+        let roundText = roles[d.round] + ` (${d.round + 1}/3)`;
+        document.getElementById('draft-round-text').innerText = roundText;
+        document.getElementById('draft-reroll-cnt').innerText = d.rerolls;
+
+        if(!d.currentOptions || d.currentOptions.length === 0) {
+            this.generateDraftOptions();
+        }
+
+        const grid = document.getElementById('draft-grid');
+        grid.innerHTML = "";
+
+        d.currentOptions.forEach(id => {
+            const card = this.getCardData(id);
+            const el = document.createElement('div');
+            let color = '#bdbdbd';
+            if(card.grade === 'legend') color = '#ff5252';
+            else if(card.grade === 'epic') color = '#e040fb';
+            else if(card.grade === 'rare') color = '#448aff';
+
+            el.className = `card-item ${card.grade}`;
+            el.style.height = "160px";
+            el.style.display = "flex";
+            el.style.flexDirection = "column";
+            el.style.borderColor = color;
+
+            el.innerHTML = `
+                <div style="font-size:0.9rem; font-weight:bold; margin-bottom:5px; color:${color}">${card.name}</div>
+                <div class="portrait" style="flex:1; margin-bottom:5px; width:100%;"><img src="${card.name}.png" onerror="this.style.display='none'"></div>
+                <div style="display:flex; gap:2px; width:100%;">
+                    <button onclick="event.stopPropagation(); RPG.showCardInfo('${card.id}')" style="flex:1; font-size:0.7rem; padding:3px; background:#444; color:#fff; border:1px solid #666;">상세</button>
+                    <button onclick="event.stopPropagation(); RPG.selectDraftCard('${card.id}')" style="flex:2; font-size:0.7rem; padding:3px; background:#1b5e20; color:#fff; border:1px solid #4caf50;">선택</button>
+                </div>
+            `;
+            grid.appendChild(el);
+        });
+    },
+
+    generateDraftOptions() {
+        let pool = [...CARDS];
+        if (this.global.unlocked_bonus_cards) {
+            const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+            pool = pool.concat(bonus);
+        }
+
+        let options = [];
+        for(let i=0; i<4; i++) {
+            const pick = pool[Math.floor(Math.random() * pool.length)];
+            options.push(pick.id);
+        }
+        this.state.draft.currentOptions = options;
+    },
+
+    selectDraftCard(id) {
+        this.state.inventory.push(id);
+        this.state.deck[this.state.draft.round] = id;
+
+        // Clear options for next round
+        this.state.draft.currentOptions = [];
+
+        if (this.state.deck.indexOf(null) === -1) {
+            this.showAlert("덱 구성 완료!");
+            this.toMenu();
+        } else {
+            this.startDraft();
+        }
+    },
+
+    rerollDraft() {
+        if (this.state.draft.rerolls > 0) {
+            this.state.draft.rerolls--;
+            this.state.draft.currentOptions = [];
+            this.renderDraftScreen();
+        } else {
+            if (this.state.tickets > 0) {
+                this.showConfirm(`무료 리롤 횟수가 없습니다.<br>티켓 1장을 사용하여 리롤하시겠습니까?<br>(보유 티켓: ${this.state.tickets})`, () => {
+                    this.state.tickets--;
+                    document.getElementById('ui-tickets').innerText = this.state.tickets;
+                    this.state.draft.currentOptions = [];
+                    this.renderDraftScreen();
+                });
+            } else {
+                this.showAlert("리롤 횟수와 티켓이 모두 부족합니다.");
+            }
+        }
+    },
+
+    resetDraftState() {
+        // Called when initializing new draft cycle
+        this.state.inventory = [];
+        this.state.deck = [null, null, null];
+        this.state.draft = { active: true, round: 0, rerolls: 3, currentOptions: [] };
     },
 
     handlePermadeath(players) {
@@ -1897,7 +2350,13 @@ const RPG = {
     winBattle() {
         let deadMsg = this.handlePermadeath(this.battle.players);
         let reward = 1;
+
+        // Mode Rewards
+        if (this.state.mode === 'suffering') reward = 0;
+        if (this.state.mode === 'chaos') reward = 0;
+
         if(this.battle.players.some(p => p && p.proto.trait.type === 'looter')) reward += 1;
+        if (this.state.mode === 'overdrive') reward += 1;
 
         this.state.tickets += reward;
         this.state.enemyScale++;
@@ -1910,62 +2369,218 @@ const RPG = {
 
         this.log(`승리 보상: 뽑기권 ${reward}장 획득.`);
 
+        // Victory Condition Check
+        const mode = this.state.mode;
+        const stage = this.state.enemyScale; // current stage (already incremented)
+        let clearStage = 24;
+        if (mode === 'overdrive') clearStage = 30;
+        if (mode === 'curse' || mode === 'flood') clearStage = 36;
+        if (mode === 'chaos') clearStage = 30;
+        if (mode === 'draft') clearStage = 24;
+        if (mode === 'origin') clearStage = Infinity;
+
+        let gameClear = false;
+        if (stage >= clearStage) {
+            gameClear = true;
+        }
+
+        // Chaos/Draft: Reset Deck/Inventory
+        if (mode === 'chaos') {
+            this.state.inventory = [];
+            this.state.deck = [null, null, null];
+
+            let allCards = [...CARDS];
+            if (this.global.unlocked_bonus_cards) {
+                const unlocked = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
+                allCards = allCards.concat(unlocked);
+            }
+            allCards.sort(() => Math.random() - 0.5);
+
+            const nextPicks = allCards.slice(0, 20).map(c => c.id);
+            this.state.chaosPool = nextPicks;
+            this.state.inventory = [...nextPicks];
+        }
+
+        if (mode === 'draft') {
+            this.resetDraftState();
+        }
+
+        // Archive Mode: Mandatory Quiz (Direct to finishWinBattle via callback)
+        if (mode === 'archive') {
+            let allQuizzes = [];
+            GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
+            let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+
+            this.startGrammarQuiz(q,
+                () => { // Success
+                    this.state.quiz_stats.correct++;
+                    this.state.quiz_stats.total++;
+                    this.state.tickets++; // Reward Ticket
+                    setTimeout(() => this.finishWinBattle(deadMsg, gameClear, true), 200);
+                },
+                () => { // Fail
+                    this.state.quiz_stats.total++;
+                    setTimeout(() => this.finishWinBattle(deadMsg, gameClear, false), 200);
+                }
+            );
+            return;
+        }
+
+        this.finishWinBattle(deadMsg, gameClear, null);
+    },
+
+    finishWinBattle(deadMsg, gameClear, quizResult) {
         let msg = "승리!<br>보상을 획득했습니다.";
+
+        if (quizResult !== null) {
+            let correct = this.state.quiz_stats.correct;
+            let total = this.state.quiz_stats.total;
+            let rate = (total > 0) ? ((correct / total) * 100).toFixed(1) : "0.0";
+            let resultMsg = quizResult ? "<span style='color:#4caf50'>정답!</span>" : "<span style='color:#ef5350'>오답...</span>";
+            msg = `[퀴즈 결과] ${resultMsg}<br>현황: ${correct}/${total} (${rate}%)<hr>` + msg;
+        }
+
+        if (this.state.mode === 'chaos') msg += "<br><br>카오스 모드: 덱과 인벤토리가 초기화되었습니다.";
+        if (this.state.mode === 'draft') msg += "<br><br>드래프트 모드: 덱과 인벤토리가 초기화되었습니다.";
+
         if (deadMsg) msg += "<br><br>" + deadMsg;
 
-        this.openInfoModal("전투 결과", msg, () => {
-             // Creator God Bonus Check
-             if (this.battle.enemy.id === 'creator_god') {
-                 this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 뽑기권 3장 획득)",
-                    () => { // Yes
-                        let allQuizzes = [];
-                        GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
-                        let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+        if (gameClear) {
+            // Check Archive Condition
+            if (this.state.mode === 'archive') {
+                let rate = (this.state.quiz_stats.total > 0) ? (this.state.quiz_stats.correct / this.state.quiz_stats.total) : 0;
+                if (rate < 0.9) {
+                    this.showAlert(`[실패] 아카이브 모드 클리어 실패!<br>정답률: ${(rate*100).toFixed(1)}% (목표: 90% 이상)`);
+                    this.toTitle();
+                    return;
+                }
+            }
 
-                        this.startGrammarQuiz(q,
-                            () => { // Success
-                                this.state.tickets += 3;
-                                document.getElementById('ui-tickets').innerText = this.state.tickets;
-                                this.showAlert("정답! 드로우권 3장을 추가로 획득했습니다.");
-                                this.toMenu();
-                            },
-                            () => { // Fail
-                                this.showAlert("오답입니다... 보상 없음.");
-                                this.toMenu();
-                            }
-                        );
-                    },
-                    () => { // No
-                        this.toMenu();
-                    }
-                 );
+            // Transcendence Ticket Logic (On Clear)
+            if (this.state.mode !== 'origin' && this.checkAllBonusUnlocked()) {
+                 this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
+                 this.saveGlobalData();
+                 this.log("<b>[보너스]</b> 카오스 티켓 1장 획득!");
+            }
+
+            // Unlock Mode
+            if (!this.global.unlocked_modes.includes(this.state.mode)) {
+                this.global.unlocked_modes.push(this.state.mode);
+            }
+            this.global.achievements[this.state.mode] = true;
+
+            // Unlock Bonus Card
+            let newCard = null;
+            let lockedBonus = BONUS_CARDS.filter(c => !this.global.unlocked_bonus_cards.includes(c.id));
+            if (lockedBonus.length > 0) {
+                let pick = lockedBonus[Math.floor(Math.random() * lockedBonus.length)];
+                this.global.unlocked_bonus_cards.push(pick.id);
+                newCard = pick;
+            }
+
+            this.saveGlobalData();
+
+            msg = `🎉 <b>${this.state.mode.toUpperCase()} 모드 클리어!</b> 🎉<br><br>`;
+            if (newCard) msg += `[보상] 새로운 동료 해금: ${newCard.name}!<br>`;
+            else msg += `(이미 모든 보너스 카드를 획득했습니다)<br>`;
+
+            this.openInfoModal("게임 클리어", msg, () => {
+                this.toTitle();
+            });
+            return;
+        }
+
+        this.openInfoModal("전투 결과", msg, () => {
+             if (this.state.mode !== 'archive') {
+                 if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+                     this.showConfirm("추가 보상을 위한 콜로케이션 퀴즈에 도전하시겠습니까?\n(성공 시 드로우권 1장 획득)",
+                        () => {
+                             this.startCollocationQuiz((success) => {
+                                 if(success) {
+                                     this.state.tickets += 1;
+                                     document.getElementById('ui-tickets').innerText = this.state.tickets;
+                                     this.showAlert("정답! 드로우권 1장을 추가로 획득했습니다.");
+                                 } else {
+                                     this.showAlert("오답입니다... 보상 없음.");
+                                 }
+                                 this.toMenu();
+                             });
+                        },
+                        () => {
+                            this.toMenu();
+                        }
+                     );
+                 }
+                 else if (this.battle.enemy.id === 'creator_god') {
+                     this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 뽑기권 3장 획득)",
+                        () => { // Yes
+                            let allQuizzes = [];
+                            GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
+                            let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+
+                            this.startGrammarQuiz(q,
+                                () => { // Success
+                                    this.state.tickets += 3;
+                                    document.getElementById('ui-tickets').innerText = this.state.tickets;
+                                    this.showAlert("정답! 드로우권 3장을 추가로 획득했습니다.");
+                                    this.toMenu();
+                                },
+                                () => { // Fail
+                                    this.showAlert("오답입니다... 보상 없음.");
+                                    this.toMenu();
+                                }
+                            );
+                        },
+                        () => { // No
+                            this.toMenu();
+                        }
+                     );
+                 } else {
+                     this.showConfirm("추가 보상을 위한 퀴즈에 도전하시겠습니까?\n(성공 시 드로우권 1장 획득)",
+                        () => {
+                             this.startQuiz((success) => {
+                                 if(success) {
+                                     this.state.tickets += 1;
+                                     document.getElementById('ui-tickets').innerText = this.state.tickets;
+                                     this.showAlert("정답! 드로우권 1장을 추가로 획득했습니다.");
+                                 } else {
+                                     this.showAlert("오답입니다... 보상 없음.");
+                                 }
+                                 this.toMenu();
+                             });
+                        },
+                        () => {
+                            this.toMenu();
+                        }
+                     );
+                 }
              } else {
-                 // Quiz Challenge Prompt using Custom Modal
-                 this.showConfirm("추가 보상을 위한 퀴즈에 도전하시겠습니까?\n(성공 시 드로우권 1장 획득)",
-                    // Yes Callback
-                    () => {
-                         this.startQuiz((success) => {
-                             if(success) {
-                                 this.state.tickets += 1;
-                                 document.getElementById('ui-tickets').innerText = this.state.tickets;
-                                 this.showAlert("정답! 드로우권 1장을 추가로 획득했습니다.");
-                             } else {
-                                 this.showAlert("오답입니다... 보상 없음.");
-                             }
-                             this.toMenu();
-                         });
-                    },
-                    // No Callback
-                    () => {
-                        this.toMenu();
-                    }
-                 );
+                 this.toMenu();
              }
         });
     },
 
     loseBattle() {
         // No saveRecord here (User request: only on New Game)
+
+        if (['chaos', 'draft'].includes(this.state.mode)) {
+             this.saveRecord();
+        }
+
+        if (this.state.mode === 'origin') {
+             this.global.pendingTranscendenceCards = [];
+             this.saveGlobalData();
+        }
+
+        if (['chaos', 'draft'].includes(this.state.mode)) {
+             localStorage.removeItem('cardRpgSave');
+
+             let msg = "패배했습니다...<br>이 모드는 패배 시 데이터가 초기화됩니다.";
+             this.openInfoModal("Game Over", msg, () => {
+                 this.toTitle();
+             });
+             return;
+        }
 
         // Reset Chaos Blessing
         this.state.chaosBlessingUses = 3;
@@ -1980,7 +2595,7 @@ const RPG = {
     },
 
     getEffectiveStats(char, fieldBuffs) {
-        return Logic.calculateStats(char, fieldBuffs);
+        return Logic.calculateStats(char, fieldBuffs, this.state.mode);
     },
 
     showBattleStat(side, idx) {
@@ -1990,13 +2605,13 @@ const RPG = {
         if(!char) return;
 
         let buffs = Object.keys(char.buffs).map(k => {
-            let name = this.BUFF_NAMES[k] || k;
+            let name = BUFF_NAMES[k] || k;
             let val = char.buffs[k];
             if(val === true) return name;
             return `${name}(${val})`;
         }).join(', ') || '없음';
 
-        const eff = Logic.calculateStats(char, this.battle.fieldBuffs);
+        const eff = Logic.calculateStats(char, this.battle.fieldBuffs, this.state.mode);
 
         // Use baseStatsWithoutBlessing if available to show Green for blessed stats
         const getBase = (key, fallback) => {
@@ -2046,7 +2661,7 @@ const RPG = {
         };
         let msg = "";
         this.battle.fieldBuffs.forEach(b => {
-             msg += `<b>[${this.BUFF_NAMES[b.name]}]</b><br>${buffInfo[b.name] || ''}<br><br>`;
+             msg += `<b>[${BUFF_NAMES[b.name]}]</b><br>${buffInfo[b.name] || ''}<br><br>`;
         });
         this.openInfoModal("필드 버프", msg);
     },
@@ -2059,14 +2674,15 @@ const RPG = {
     },
     closeInfoModal() {
         document.getElementById('modal-info').classList.remove('active');
-        if (this.tempOnClose) {
-            this.tempOnClose();
-            this.tempOnClose = null;
+        const cb = this.tempOnClose;
+        this.tempOnClose = null;
+        if (cb) {
+            cb();
         }
     },
 
     showConfirm(msg, onYes, onNo) {
-        document.getElementById('confirm-msg').innerText = msg;
+        document.getElementById('confirm-msg').innerHTML = msg;
         const modal = document.getElementById('modal-confirm');
         const btnYes = document.getElementById('confirm-yes');
         const btnNo = document.getElementById('confirm-no');
@@ -2081,6 +2697,268 @@ const RPG = {
         };
 
         modal.classList.add('active');
+    },
+
+    // --- Private Tutoring ---
+    openApiSettings() {
+        document.getElementById('modal-api-settings').classList.add('active');
+        const key = localStorage.getItem('cardRpgApiKey');
+        if(key) document.getElementById('api-key-input').value = key;
+    },
+
+    closePrivateTutoring() {
+        document.getElementById('modal-tutoring').classList.remove('active');
+        document.getElementById('modal-library').classList.add('active');
+    },
+
+    closeMagicClass() {
+        document.getElementById('modal-magic-class').classList.remove('active');
+        document.getElementById('modal-library').classList.add('active');
+    },
+
+    closeWordbook() {
+        document.getElementById('modal-wordbook').classList.remove('active');
+        document.getElementById('modal-library').classList.add('active');
+    },
+
+    openPrivateTutoring() {
+        const mode = this.state.mode;
+        let list = (mode === 'chaos' || mode === 'draft') ? this.state.wrongCollocations : this.state.wrongWords;
+
+        if (!list || list.length === 0) {
+            let msg = (mode === 'chaos' || mode === 'draft') ? "오답노트에 등록된 숙어/구동사가 없습니다." : "오답노트에 등록된 단어가 없습니다.";
+            return this.showAlert(msg);
+        }
+
+        document.getElementById('modal-library').classList.remove('active');
+        document.getElementById('modal-tutoring').classList.add('active');
+
+        // Reset UI
+        document.getElementById('tutoring-content').innerText = "수업을 시작하려면 '수업 시작' 버튼을 눌러주세요.";
+        document.getElementById('btn-tutoring-quiz').style.display = 'none';
+        this.currentTutoringItem = null;
+    },
+
+    saveApiKey() {
+        const key = document.getElementById('api-key-input').value.trim();
+        if(!key) return this.showAlert("API 키를 입력해주세요.");
+        localStorage.setItem('cardRpgApiKey', key);
+        this.showAlert("API 키가 저장되었습니다.");
+    },
+
+    async startTutoringSession() {
+        if(this.isApiLoading) return this.showAlert("이전 요청 처리 중입니다...");
+
+        const key = localStorage.getItem('cardRpgApiKey');
+        if(!key) return this.showAlert("먼저 API 키를 저장해주세요.");
+
+        const mode = this.state.mode;
+        const isCollocation = (mode === 'chaos' || mode === 'draft');
+        let list = isCollocation ? this.state.wrongCollocations : this.state.wrongWords;
+
+        if (!list || list.length === 0) return this.showAlert("학습할 오답 내용이 없습니다.");
+
+        // Pick Random
+        const targetId = list[Math.floor(Math.random() * list.length)];
+        let targetData = null;
+
+        if (isCollocation) {
+            targetData = COLLOCATION_DATA.find(c => c.id === targetId);
+        } else {
+            targetData = VOCAB_DATA.find(v => v.word === targetId);
+        }
+
+        if(!targetData) {
+            // Cleanup invalid data
+            if(isCollocation) {
+                 this.state.wrongCollocations = this.state.wrongCollocations.filter(id => id !== targetId);
+                 localStorage.setItem('cardRpgCollocation', JSON.stringify(this.state.wrongCollocations));
+            } else {
+                 this.state.wrongWords = this.state.wrongWords.filter(w => w !== targetId);
+                 localStorage.setItem('cardRpgVocab', JSON.stringify(this.state.wrongWords));
+            }
+            return this.startTutoringSession(); // Retry
+        }
+
+        this.currentTutoringItem = { data: targetData, type: isCollocation ? 'collocation' : 'vocab' };
+
+        // UI Loading
+        this.isApiLoading = true;
+        const contentBox = document.getElementById('tutoring-content');
+        contentBox.innerHTML = "루미 선생님이 강의를 준비하고 있어요...<br>(잠시만 기다려주세요)";
+
+        try {
+            const text = await GameAPI.getTutoringContent(key, targetData, isCollocation ? 'collocation' : 'vocab');
+
+            // ✅ 응답 도착 후: 모달이 아직 열려있는지 확인
+            const tutoringModal = document.getElementById('modal-tutoring');
+            if(!tutoringModal.classList.contains('active')) {
+                console.warn("과외 모달이 닫혀있어 결과를 무시합니다.");
+                return; // 이미 닫혔으면 아무것도 하지 않음
+            }
+
+            // Format simple markdown to HTML tags
+            let formatted = text.replace(/\*\*(.*?)\*\*/g, '<b>$1</b>');
+            contentBox.innerHTML = formatted;
+
+            // Show Quiz Button
+            document.getElementById('btn-tutoring-quiz').style.display = 'block';
+
+        } catch (e) {
+            console.error(e);
+            let msg = e.message || "";
+            let displayMsg = "알 수 없는 오류가 발생했습니다.";
+            if (msg.includes('key') || msg.includes('valid') || msg.includes('400') || msg.includes('403')) {
+                displayMsg = "API 키가 올바르지 않거나 설정되지 않았습니다. 설정을 확인해주세요.";
+            } else if (msg.includes('quota') || msg.includes('429')) {
+                displayMsg = "API 사용량이 초과되었습니다. 잠시 후 다시 시도하거나 키를 확인해주세요.";
+            } else if (msg.includes('safety') || msg.includes('blocked')) {
+                displayMsg = "안전 필터에 의해 생성이 차단되었습니다. 다른 단어로 시도해주세요.";
+            } else {
+                displayMsg = "오류가 발생했습니다: " + msg;
+            }
+            contentBox.innerHTML = `<div style="color:#ef5350; font-weight:bold;">${displayMsg}</div><div style="font-size:0.7rem; color:#777; margin-top:5px;">(${msg})</div>`;
+        } finally {
+            this.isApiLoading = false;
+        }
+    },
+
+    startTutoringQuiz() {
+        if(!this.currentTutoringItem) return;
+
+        // ✅ 모달 초기화 추가
+        const modal = document.getElementById('modal-quiz');
+        modal.classList.remove('active'); // 기존 모달 닫기
+        setTimeout(() => { // 애니메이션 대기
+
+            const item = this.currentTutoringItem;
+            const data = item.data;
+
+            // DOM Elements (Re-fetch inside timeout)
+            const qDiv = document.getElementById('quiz-question');
+            const descDiv = document.getElementById('quiz-desc');
+            const oDiv = document.getElementById('quiz-options');
+            const fDiv = document.getElementById('quiz-feedback');
+
+            // 초기화
+            oDiv.innerHTML = "";
+            fDiv.innerText = "";
+
+            if (item.type === 'collocation') {
+                // Reuse Collocation Quiz Logic but custom callback
+                let quizList = data.quizzes || [{ question: data.question, options: data.options, answer: data.answer, translation: data.translation }];
+                let q = quizList[Math.floor(Math.random() * quizList.length)];
+
+                qDiv.innerText = q.question;
+                descDiv.innerText = q.translation || "";
+                descDiv.style.display = 'block';
+
+                let opts = [...q.options];
+                opts.sort(() => Math.random() - 0.5);
+
+                opts.forEach(opt => {
+                    const btn = document.createElement('button');
+                    btn.className = "menu-btn";
+                    btn.style.padding = "10px";
+                    btn.style.fontSize = "0.9rem";
+                    btn.innerText = opt;
+                    btn.onclick = () => {
+                        btn.disabled = true; // ✅ 즉시 비활성화
+                        Array.from(oDiv.children).forEach(c => c.onclick = null);
+
+                        if(opt === q.answer) {
+                            btn.classList.add('correct');
+                            fDiv.innerText = "정답! (오답노트에서 삭제됩니다)";
+                            fDiv.style.color = "#4caf50";
+
+                            // Remove from list
+                            this.state.wrongCollocations = this.state.wrongCollocations.filter(id => id !== data.id);
+                            localStorage.setItem('cardRpgCollocation', JSON.stringify(this.state.wrongCollocations));
+
+                            setTimeout(() => {
+                                modal.classList.remove('active');
+                                document.getElementById('modal-tutoring').classList.remove('active');
+                                this.showAlert("학습 완료! 오답노트에서 삭제되었습니다.");
+                                this.toMenu();
+                            }, 1500);
+                        } else {
+                            btn.classList.add('wrong');
+                            fDiv.innerText = "오답... (다시 학습해보세요)";
+                            fDiv.style.color = "#ef5350";
+                            Array.from(oDiv.children).forEach(c => {
+                                 if(c.innerText === q.answer) c.classList.add('correct');
+                            });
+                            setTimeout(() => {
+                                modal.classList.remove('active');
+                            }, 2000);
+                        }
+                    };
+                    oDiv.appendChild(btn);
+                });
+                modal.classList.add('active');
+
+            } else {
+                // Vocab Quiz
+                // Create options: Correct + Trap + 2 Randoms
+                let options = [];
+                options.push({ text: data.meaning, correct: true });
+                options.push({ text: data.trap_meaning, correct: false });
+
+                let safeCounter = 0;
+                while(options.length < 4 && safeCounter < 100) {
+                    safeCounter++;
+                    let r = VOCAB_DATA[Math.floor(Math.random() * VOCAB_DATA.length)];
+                    if(r.word !== data.word && r.word !== data.trap_word && !options.some(o => o.text === r.meaning)) {
+                        options.push({ text: r.meaning, correct: false });
+                    }
+                }
+                options.sort(() => Math.random() - 0.5);
+
+                qDiv.innerText = data.word;
+                descDiv.style.display = 'none';
+
+                options.forEach(opt => {
+                    const btn = document.createElement('button');
+                    btn.className = "menu-btn";
+                    btn.style.padding = "10px";
+                    btn.style.fontSize = "0.9rem";
+                    btn.innerText = opt.text;
+                    btn.onclick = () => {
+                        btn.disabled = true; // ✅ 즉시 비활성화
+                        Array.from(oDiv.children).forEach(c => c.onclick = null);
+
+                        if(opt.correct) {
+                            btn.classList.add('correct');
+                            fDiv.innerText = "정답! (오답노트에서 삭제됩니다)";
+                            fDiv.style.color = "#4caf50";
+
+                            // Remove
+                            this.state.wrongWords = this.state.wrongWords.filter(w => w !== data.word);
+                            localStorage.setItem('cardRpgVocab', JSON.stringify(this.state.wrongWords));
+
+                            setTimeout(() => {
+                                modal.classList.remove('active');
+                                document.getElementById('modal-tutoring').classList.remove('active');
+                                this.showAlert("학습 완료! 오답노트에서 삭제되었습니다.");
+                                this.toMenu();
+                            }, 1500);
+                        } else {
+                            btn.classList.add('wrong');
+                            fDiv.innerText = "오답... (다시 학습해보세요)";
+                            fDiv.style.color = "#ef5350";
+                             Array.from(oDiv.children).forEach(c => {
+                                 if(c.innerText === data.meaning) c.classList.add('correct');
+                            });
+                            setTimeout(() => {
+                                modal.classList.remove('active');
+                            }, 2000);
+                        }
+                    };
+                    oDiv.appendChild(btn);
+                });
+                 modal.classList.add('active');
+            }
+        }, 100);
     },
 
     showAlert(msg) {

--- a/card_remaster/logic.js
+++ b/card_remaster/logic.js
@@ -1,7 +1,432 @@
 
+const FIELD_BUFF_STATS = {
+    'sun_bless': { atk: 0.3, matk: 0.3 },
+    'moon_bless': { matk: 0.3, evasion: 15 },
+    'sanctuary': { matk: 0.3, mdef: 0.3 },
+    'goddess_descent': { atk: 0.3, matk: 0.3, def: 0.3, mdef: 0.3 },
+    'earth_bless': { atk: 0.25, matk: 0.25 },
+    'twinkle_party': { atk: 0.2, crit: 15 },
+    'star_powder': { def: 0.4, mdef: 0.4 },
+    'reaper_realm': { crit: 40 }
+};
+
+// Helper for Buff Names (Moved out to be accessible)
+function getBuffName(key) {
+    if (typeof BUFF_NAMES !== 'undefined') {
+        return BUFF_NAMES[key] || key;
+    }
+    return key;
+}
+
+
+let __cardLookupCache = null;
+function getCardLookup() {
+    if (!__cardLookupCache) {
+        __cardLookupCache = new Map();
+        [CARDS, BONUS_CARDS, TRANSCENDENCE_CARDS].forEach(group => {
+            if (!Array.isArray(group)) return;
+            group.forEach(card => {
+                if (card && card.id && !__cardLookupCache.has(card.id)) {
+                    __cardLookupCache.set(card.id, card);
+                }
+            });
+        });
+    }
+    return __cardLookupCache;
+}
+
+function getCardById(cardId, fallbackPool) {
+    if (!cardId) return null;
+    if (fallbackPool) {
+        return fallbackPool.find(c => c.id === cardId) || null;
+    }
+    return getCardLookup().get(cardId) || null;
+}
+
+const DAMAGE_EFFECT_HANDLERS = {
+    'consume_field_all': (ctx, eff) => {
+        let c = ctx.fieldBuffs.length;
+        if(c > 0) {
+            ctx.mult += (c * eff.multPerStack);
+            ctx.fieldBuffs.length = 0;
+            ctx.logFn(`필드 버프 ${c}개 제거! 위력 폭발!`);
+        }
+    },
+    'consume_debuff_all': (ctx, eff) => {
+        if(ctx.target.buffs[eff.debuff]) {
+            let c = ctx.target.buffs[eff.debuff];
+            ctx.mult += (c * eff.multPerStack);
+            delete ctx.target.buffs[eff.debuff];
+            ctx.logFn(`${getBuffName(eff.debuff)} ${c}스택 소모!`);
+        }
+    },
+    'dmg_boost': (ctx, eff) => {
+        let matched = false;
+        if(eff.condition === 'target_debuff' && ctx.target.buffs[eff.debuff]) {
+            ctx.mult *= eff.mult;
+            matched = true;
+            if(!eff.customLog) ctx.logFn(`[특성] ${getBuffName(eff.debuff)} 대상 추가 피해! (배율 x${eff.mult})`);
+        }
+        else if(eff.condition === 'synergy_active' && ctx.activeTraits.includes(eff.trait)) {
+            ctx.mult *= eff.mult;
+            matched = true;
+            if(!eff.customLog) ctx.logFn(`[시너지] 조건 만족! 위력 ${eff.mult}배 증가!`);
+        }
+        else if(eff.condition === 'target_stack' && ctx.target.buffs[eff.debuff]) {
+             ctx.mult += (ctx.target.buffs[eff.debuff] * eff.multPerStack);
+        }
+        else if(eff.condition === 'target_debuff_count_scale') {
+             let bonus = (Object.keys(ctx.target.buffs).length * eff.multPerDebuff);
+             ctx.mult += bonus;
+             if(bonus > 0 && !eff.customLog) ctx.logFn(`[특성] 디버프 대상 추가 피해! (배율 +${bonus.toFixed(1)})`);
+        }
+        else if(eff.condition === 'hp_below' && (ctx.source.hp/ctx.source.maxHp) <= eff.val) {
+             ctx.mult *= eff.mult;
+             matched = true;
+             if(!eff.customLog && ctx.skill.name === '라그나로크') ctx.logFn("라그나로크: 생명력 조건 만족! 대미지 증가!");
+        }
+        else if(eff.condition === 'target_hp_below' && (ctx.target.hp / ctx.target.maxHp) <= eff.val) {
+             ctx.mult *= eff.mult;
+             matched = true;
+             if(!eff.customLog) ctx.logFn(`[약점 포착] 적 체력 ${eff.val*100}% 이하! 위력 증가!`);
+        }
+        else if(eff.condition === 'hp_full' && ctx.source.hp === ctx.source.maxHp) {
+             ctx.mult *= eff.mult;
+             matched = true;
+             if(eff.log) ctx.logFn(eff.log);
+        }
+        else if(eff.condition === 'field_buff' && ctx.fieldBuffs.some(b=>b.name === eff.buff)) {
+             ctx.mult *= eff.mult;
+             matched = true;
+        }
+
+        if(matched && eff.customLog) {
+            ctx.logFn(eff.customLog);
+        }
+    },
+    'consume_debuff_fixed': (ctx, eff) => {
+         const debuff = eff.debuff;
+         const count = eff.count || 1;
+         if((ctx.target.buffs[debuff] || 0) >= count) {
+             ctx.target.buffs[debuff] -= count;
+             if(ctx.target.buffs[debuff] <= 0) delete ctx.target.buffs[debuff];
+             ctx.mult *= eff.mult;
+
+             if(eff.customLog) ctx.logFn(eff.customLog);
+             else ctx.logFn(`${getBuffName(debuff)} ${count}스택 소모! 위력 ${eff.mult}배!`);
+         }
+    },
+    'consume_divine_add_darkness': (ctx, eff) => {
+         if((ctx.target.buffs['divine'] || 0) >= 1) {
+             ctx.target.buffs['divine']--;
+             if(ctx.target.buffs['divine'] <= 0) delete ctx.target.buffs['divine'];
+             ctx.target.buffs['darkness'] = 1;
+             ctx.logFn("신성력을 오염시켜 암흑을 부여합니다!");
+         } else {
+             ctx.logFn("소모할 디바인이 없어 효과가 발동하지 않았습니다.");
+         }
+    },
+    'remove_field_buff_dmg': (ctx, eff) => {
+         if(ctx.fieldBuffs.length > 0) {
+             const rm = ctx.fieldBuffs.shift();
+             ctx.mult *= eff.mult;
+             ctx.logFn(`필드버프 [${getBuffName(rm.name)}] 제거! 대미지 ${eff.mult}배!`);
+         }
+    },
+    'cond_target_debuff_3_dmg': (ctx, eff) => {
+         if(Object.keys(ctx.target.buffs).length >= 3) {
+             ctx.mult *= eff.mult;
+             ctx.logFn("적 디버프 3개 이상! 위력 2배!");
+         }
+    },
+    'random_mult': (ctx, eff) => {
+        let max = eff.max;
+        if(ctx.activeTraits.includes('syn_water_3_ice_age')) max = 10.0;
+        ctx.mult = eff.min + Math.floor(Math.random() * (max - eff.min + 1));
+        ctx.logFn(`무작위 위력! x${ctx.mult.toFixed(1)}`);
+    },
+    'random_mult_moon_boost': (ctx, eff) => {
+         let min = eff.min;
+         let max = eff.max;
+         if (ctx.fieldBuffs.some(b => b.name === 'moon_bless')) {
+             max = eff.boostMax;
+             ctx.logFn("달의 축복으로 최대 배율 증가!");
+         }
+         ctx.mult = min + Math.floor(Math.random() * (max - min + 1));
+         ctx.logFn(`무작위 위력! x${ctx.mult.toFixed(1)}`);
+    },
+    'delayed_random_attack': (ctx, eff) => {
+         ctx.mult = eff.min + Math.floor(Math.random() * (eff.max - eff.min + 1));
+         ctx.logFn(`무작위 위력! x${ctx.mult.toFixed(1)}`);
+    },
+    'field_buff_combo_dmg': (ctx, eff) => {
+        let buffs = ctx.fieldBuffs.map(b => b.name);
+        let hasSun = buffs.includes('sun_bless');
+        let hasMoon = buffs.includes('moon_bless');
+
+        if(hasSun) {
+            let count = ctx.fieldBuffs.length;
+            ctx.mult += count * 1.0;
+            ctx.logFn(`태양의 축복: 필드버프 ${count}개! 배율 +${count.toFixed(1)}`);
+        }
+        if(hasMoon) {
+            ctx.ignoreMdefRate = (ctx.ignoreMdefRate || 0) + 0.2;
+            ctx.logFn("달의 축복: 마법방어력 20% 관통!");
+        }
+    },
+    'count_deck_attr_dmg': (ctx, eff) => {
+         // Need access to deck or active traits to count attributes?
+         // Logic.calculateDamage receives activeTraits.
+         // But deck content isn't directly passed.
+         // However, `ctx.activeTraits` contains synergy strings, not deck info.
+         // Logic.calculateDamage is called with `activeTraits`.
+         // We might need to pass `deck` to calculateDamage or check `source.proto.element` etc.
+         // Workaround: We can't easily count deck attributes inside Logic without deck data.
+         // BUT, we can pass the count as a param when calling calculateDamage?
+         // OR, we assume `activeTraits` or `fieldBuffs` implies something? No.
+         // We should update `Logic.calculateDamage` to accept `deck` or `attrCount`.
+         // OR, for now, use a hack: Look at `activeTraits` if it has specific markers? No.
+         // Best approach: Add `deck` to the `calculateDamage` signature in the next step,
+         // or handle this in index.html and pass the multiplier?
+         // Index.html `calcDamage` calls `Logic.calculateDamage`.
+         // I will update `Logic` to accept `deck` in the next step.
+         // For now, I'll write the handler assuming `ctx.deck` exists.
+         if(ctx.deck) {
+             const cards = ctx.deck.map(id => getCardById(id)).filter(c => c);
+             let attrs = new Set();
+             let hasJoker = false;
+             cards.forEach(c => {
+                 if(c.id === 'joker') hasJoker = true;
+                 else attrs.add(c.element);
+             });
+             let count = hasJoker ? 5 : attrs.size;
+             ctx.mult += count * 1.0;
+             ctx.logFn(`덱 속성 ${count}종! 위력 +${count.toFixed(1)}배!`);
+         }
+    },
+    'turn_modulo_dmg': (ctx, eff) => {
+         // Need current turn. ctx does not have turn.
+         // Add turn to ctx in calculateDamage.
+         if(ctx.turn && ctx.turn % eff.mod === 0) {
+             ctx.mult *= eff.mult;
+             ctx.logFn(`4의 배수 턴(${ctx.turn})! 위력 ${eff.mult}배!`);
+         }
+    },
+    'dmg_boost_turn_scale': (ctx, eff) => {
+        if(ctx.turn) {
+            let bonus = ctx.turn * eff.scale;
+            ctx.mult += bonus;
+            ctx.logFn(`인과역전: ${ctx.turn}턴 경과! 배율 +${bonus.toFixed(1)}`);
+        }
+    }
+};
+
+const SideEffects = {
+    handlers: {
+        'buff': (ctx, eff) => {
+            ctx.source.buffs[eff.id] = (eff.duration || 1);
+        },
+        'debuff': (ctx, eff) => {
+            let t = ctx.target;
+            if(eff.stack) {
+                t.buffs[eff.id] = (t.buffs[eff.id] || 0) + 1;
+                if(t.buffs[eff.id] > 3) t.buffs[eff.id] = 3;
+                ctx.logFn(`${t === ctx.source ? '자신' : '적'}에게 [${getBuffName(eff.id)}] ${t.buffs[eff.id]}스택.`);
+            } else {
+                t.buffs[eff.id] = 1;
+                ctx.logFn(`${t === ctx.source ? '자신' : '적'}에게 [${getBuffName(eff.id)}] 부여.`);
+            }
+        },
+        'self_debuff': (ctx, eff) => {
+            let s = ctx.source;
+            if(eff.stack) {
+                s.buffs[eff.id] = (s.buffs[eff.id] || 0) + 1;
+                if(s.buffs[eff.id] > 3) s.buffs[eff.id] = 3;
+                ctx.logFn(`자신에게 [${getBuffName(eff.id)}] ${s.buffs[eff.id]}스택.`);
+            } else {
+                s.buffs[eff.id] = 1;
+                ctx.logFn(`자신에게 [${getBuffName(eff.id)}] 부여.`);
+            }
+        },
+        'field_buff': (ctx, eff) => {
+            ctx.applyFieldBuff(eff.id);
+        },
+        'conditional_field_buff': (ctx, eff) => {
+            if(eff.condition === 'target_has_debuff' && ctx.target.buffs[eff.debuff]) ctx.applyFieldBuff(eff.id);
+        },
+        'random_debuff': (ctx, eff) => {
+            let pool = [...eff.pool].sort(() => 0.5 - Math.random());
+            for(let i=0; i<eff.count; i++) {
+                if(pool[i]) {
+                     ctx.target.buffs[pool[i]] = 1;
+                     ctx.logFn(`적에게 [${getBuffName(pool[i])}] 부여.`);
+                }
+            }
+        },
+        'conditional_debuff': (ctx, eff) => {
+            if(eff.condition === 'target_debuff_count' && Object.keys(ctx.target.buffs).length >= eff.count) {
+                ctx.target.buffs[eff.debuff] = 1;
+                ctx.logFn(`조건 만족! 적에게 [${getBuffName(eff.debuff)}] 부여.`);
+            }
+        },
+        'suicide': (ctx, eff) => {
+            ctx.source.hp = 0;
+        },
+        'chance_debuff': (ctx, eff) => {
+            if(Math.random() < eff.chance) {
+                ctx.target.buffs[eff.id] = eff.duration || 1;
+                ctx.logFn(`<b>성공!</b> ${ctx.target === ctx.source ? '자신' : '적'}에게 [${getBuffName(eff.id)}] 부여.`);
+            } else {
+                ctx.logFn(`[${getBuffName(eff.id)}] 부여 <b>실패</b>.`);
+            }
+        },
+        'conditional_field_debuff': (ctx, eff) => {
+             if(ctx.battle.fieldBuffs.some(b => b.name === eff.field)) {
+                 eff.debuffs.forEach(d => {
+                     ctx.target.buffs[d] = 1;
+                     ctx.logFn(`조건 만족! [${getBuffName(d)}] 부여.`);
+                 });
+             }
+        },
+        'clear_target_debuffs': (ctx, eff) => {
+             const count = Object.keys(ctx.target.buffs).length;
+             ctx.target.buffs = {};
+             if(count > 0) ctx.logFn(`적의 모든 디버프를 제거했습니다! (${count}개)`);
+        },
+        'consume_all_burn_cond_buff': (ctx, eff) => {
+             if(ctx.target.buffs['burn']) {
+                 delete ctx.target.buffs['burn'];
+                 ctx.applyFieldBuff('sun_bless');
+                 ctx.logFn("작열 스택을 모두 소모하여 태양의 축복을 불러옵니다!");
+             } else {
+                 ctx.applyFieldBuff('earth_bless');
+                 ctx.logFn("소모할 작열이 없어 대지의 축복을 불러옵니다.");
+             }
+        },
+        'check_divine_3_stun_else_add': (ctx, eff) => {
+             if((ctx.target.buffs['divine'] || 0) >= 3) {
+                 ctx.target.buffs['stun'] = 1;
+                 ctx.logFn("디바인 3스택 확인! 적을 기절시킵니다!");
+             } else {
+                 ctx.target.buffs['divine'] = (ctx.target.buffs['divine'] || 0) + 1;
+                 if(ctx.target.buffs['divine'] > 3) ctx.target.buffs['divine'] = 3;
+                 ctx.logFn("디바인 스택 추가.");
+             }
+        },
+        'random_debuff_consume_divine': (ctx, eff) => {
+            let pool = ['curse', 'darkness', 'silence', 'weak', 'corrosion'];
+            let count = 1;
+            if(ctx.target.buffs['divine'] > 0) {
+                ctx.target.buffs['divine']--;
+                if(ctx.target.buffs['divine'] <= 0) delete ctx.target.buffs['divine'];
+                count = 2;
+                ctx.logFn("디바인을 소모하여 효과 강화! (디버프 2개 부여)");
+            }
+
+            pool.sort(() => 0.5 - Math.random());
+            for(let i=0; i<count; i++) {
+                ctx.target.buffs[pool[i]] = 1;
+                ctx.logFn(`적에게 [${getBuffName(pool[i])}] 부여.`);
+            }
+        },
+        'roulette_field': (ctx, eff) => {
+             ctx.battle.fieldBuffs = [];
+             ctx.logFn("모든 필드 버프가 제거되었습니다!");
+
+             const buffs = ['sun_bless', 'moon_bless', 'sanctuary', 'goddess_descent', 'earth_bless', 'twinkle_party', 'star_powder'];
+             const pick = buffs[Math.floor(Math.random() * buffs.length)];
+             ctx.applyFieldBuff(pick);
+        },
+        'wild_card_debuff': (ctx, eff) => {
+             const badBuffs = ['curse', 'darkness', 'silence', 'weak', 'corrosion', 'burn', 'divine', 'stun'];
+             let cleansed = 0;
+             badBuffs.forEach(b => {
+                 if(ctx.target.buffs[b]) {
+                     delete ctx.target.buffs[b];
+                     cleansed++;
+                 }
+             });
+             if(cleansed > 0) ctx.logFn(`적의 디버프를 모두 해제했습니다! (${cleansed}개)`);
+
+             let pool = ['curse', 'darkness', 'silence', 'weak', 'corrosion', 'burn', 'divine'];
+             pool.sort(() => 0.5 - Math.random());
+
+             for(let i=0; i<2; i++) {
+                 if(pool[i] === 'burn' || pool[i] === 'divine') {
+                     ctx.target.buffs[pool[i]] = (ctx.target.buffs[pool[i]] || 0) + 1;
+                     if(ctx.target.buffs[pool[i]] > 3) ctx.target.buffs[pool[i]] = 3;
+                     ctx.logFn(`적에게 [${getBuffName(pool[i])}] 스택 추가.`);
+                 } else {
+                     ctx.target.buffs[pool[i]] = 1;
+                     ctx.logFn(`적에게 [${getBuffName(pool[i])}] 부여.`);
+                 }
+             }
+        },
+        'delayed_attack_field': (ctx, eff) => {
+            if (eff.field) ctx.applyFieldBuff(eff.field);
+        },
+        'delayed_turn_scale_attack': (ctx, eff) => {
+            ctx.battle.delayedEffects.push({
+                turn: ctx.battle.turn + eff.turns,
+                source: ctx.source,
+                skill: { ...ctx.skill, effects: [...(ctx.skill.effects||[]), {type: 'dmg_boost_turn_scale', scale: eff.scale, startTurn: ctx.battle.turn}] }
+            });
+            ctx.logFn(`인과역전! ${eff.turns}턴 후 발동합니다!`);
+        },
+        'delayed_attack_debuff_scale': (ctx, eff) => {
+            ctx.battle.delayedEffects.push({
+                turn: ctx.battle.turn + eff.turns,
+                source: ctx.source,
+                skill: { ...ctx.skill, effects: [...(ctx.skill.effects||[]), {type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: eff.multPerDebuff}] }
+            });
+            ctx.logFn(`제로그라비티! ${eff.turns}턴 후 발동합니다!`);
+        },
+        'random_skill_trigger_from_list': (ctx, eff) => {
+            const skillMap = [
+                { id: 'gold_dragon', skill: '얼티밋브레스' },
+                { id: 'zeke', skill: '라그나로크' },
+                { id: 'jasmine', skill: '여신강림' },
+                { id: 'frozen_witch', skill: '블리자드' },
+                { id: 'behemoth', skill: '어스퀘이크' },
+                { id: 'gray', skill: '차원절단' },
+                { id: 'rumi', skill: '밀키웨이엑스터시' },
+                { id: 'phoenix', skill: '메테오임팩트' },
+                { id: 'time_ruler', skill: '섀도우트위스트' }
+            ];
+
+            const pick = skillMap[Math.floor(Math.random() * skillMap.length)];
+            const card = ctx.getCardData(pick.id);
+            if(!card) return;
+            const skill = card.skills.find(s => s.name === pick.skill);
+
+            if (skill) {
+                ctx.logFn(`[데스티니룰렛] ${card.name}의 ${skill.name} 발동!`);
+                ctx.executeSkill(ctx.source, ctx.target, skill, true);
+            }
+        },
+        'apply_lumi_guard': (ctx, eff) => {
+            let buffs = ctx.battle.fieldBuffs.map(b => b.name);
+            if(buffs.includes('star_powder')) {
+                ctx.source.buffs['guard'] = 1;
+                ctx.logFn("스타파우더: 가드 효과(버프) 적용!");
+            }
+        },
+        'random_field_buff_lumi': (ctx, eff) => {
+            const buffs = ['sun_bless', 'moon_bless', 'star_powder'];
+            const pick = buffs[Math.floor(Math.random() * buffs.length)];
+            ctx.applyFieldBuff(pick);
+            ctx.logFn(`코스믹 하모니: [${getBuffName(pick)}] 생성!`);
+        }
+    },
+    apply: function(ctx, eff) {
+        const handler = this.handlers[eff.type];
+        if (handler) handler(ctx, eff);
+    }
+};
+
 const Logic = {
     // 1. Stats Calculation
-    calculateStats: function(char, fieldBuffs) {
+    calculateStats: function(char, fieldBuffs, mode) {
         // Base stats
         let stats = {
             atk: char.atk,
@@ -12,7 +437,7 @@ const Logic = {
             evasion: (char.baseEva || 0) + 5
         };
 
-        // Blessings (Fix: Apply to crit/eva)
+        // Blessings
         if (char.blessing) {
             stats.crit += 10;
             stats.evasion += 5;
@@ -28,28 +453,38 @@ const Logic = {
                 stats.evasion += trait.val;
                 stats.crit += trait.val;
             }
-            if (trait.type === 'cond_twinkle_all' && fieldBuffs.some(b => b.name === 'twinkle_party')) {
-                // Multiplier handled below
+            if (trait.type === 'luna_jasmine_trait' && fieldBuffs.some(b => b.name === 'goddess_descent')) {
+                 stats.evasion += 25;
+                 stats.crit += 25;
             }
         }
 
-        // Multipliers from Buffs/Traits
+        // Multipliers
         let m = { atk: 1.0, matk: 1.0, def: 1.0, mdef: 1.0 };
+
+        // Handle Mushroom King here properly
+        if(trait && trait.type === 'cond_earth_def_mdef' && fieldBuffs.some(b => b.name === 'earth_bless')) {
+            m.def += 0.5;
+            m.mdef += 0.5;
+        }
 
         // Field Buffs (Only apply to Allies)
         if (isPlayer) {
+            let buffMult = (mode === 'flood') ? 2.0 : 1.0;
             fieldBuffs.forEach(fb => {
-                if(fb.name === 'sun_bless') { m.atk += 0.3; m.matk += 0.3; }
-                if(fb.name === 'moon_bless') { m.matk += 0.3; stats.evasion += 15; }
-                if(fb.name === 'sanctuary') { m.matk += 0.3; m.mdef += 0.3; }
-                if(fb.name === 'goddess_descent') { m.atk += 0.3; m.matk += 0.3; m.def += 0.3; m.mdef += 0.3; }
-                if(fb.name === 'earth_bless') { m.atk += 0.25; m.matk += 0.25; }
-                if(fb.name === 'twinkle_party') { m.atk += 0.2; stats.crit += 15; }
-                if(fb.name === 'star_powder') { m.def += 0.4; m.mdef += 0.4; }
+                const bonus = FIELD_BUFF_STATS[fb.name];
+                if(bonus) {
+                    if(bonus.atk) m.atk += (bonus.atk * buffMult);
+                    if(bonus.matk) m.matk += (bonus.matk * buffMult);
+                    if(bonus.def) m.def += (bonus.def * buffMult);
+                    if(bonus.mdef) m.mdef += (bonus.mdef * buffMult);
+                    if(bonus.crit) stats.crit += (bonus.crit * buffMult);
+                    if(bonus.evasion) stats.evasion += (bonus.evasion * buffMult);
+                }
             });
         }
 
-        // Trait Multipliers (that affect base stats permanently for the turn)
+        // Trait Multipliers
         if (trait) {
              if (trait.type === 'cond_twinkle_all' && fieldBuffs.some(b => b.name === 'twinkle_party')) {
                  m.atk += 0.3; m.matk += 0.3;
@@ -57,15 +492,17 @@ const Logic = {
         }
 
         // Char Buffs/Debuffs
-        if (char.buffs['weak']) m.atk -= 0.2;
-        if (char.buffs['silence']) m.matk -= 0.2;
+        let debuffMult = (mode === 'curse') ? 2.0 : 1.0;
+
+        if (char.buffs['weak']) m.atk -= (0.2 * debuffMult);
+        if (char.buffs['silence']) m.matk -= (0.2 * debuffMult);
         if (char.buffs['evasion']) stats.evasion += 50;
-        if (char.buffs['curse']) m.mdef -= 0.2;
+        if (char.buffs['curse']) m.mdef -= (0.2 * debuffMult);
 
         let defRed = 0.0;
         if (char.buffs['darkness'] && char.buffs['corrosion']) defRed = 0.4;
         else if (char.buffs['darkness'] || char.buffs['corrosion']) defRed = 0.2;
-        m.def -= defRed;
+        m.def -= (defRed * debuffMult);
 
         // Apply Multipliers
         stats.atk = Math.floor(stats.atk * Math.max(0, m.atk));
@@ -77,36 +514,56 @@ const Logic = {
     },
 
     // 2. Evasion Check
-    checkEvasion: function(target, skillType, fieldBuffs) {
-        const stats = this.calculateStats(target, fieldBuffs);
+    checkEvasion: function(target, skillType, fieldBuffs, mode) {
+        const stats = this.calculateStats(target, fieldBuffs, mode);
         return Math.random() * 100 < stats.evasion;
     },
 
     // 3. Damage Calculation
-    calculateDamage: function(source, target, skill, fieldBuffs, activeTraits, logFn) {
+    calculateDamage: function(source, target, skill, fieldBuffs, activeTraits, logFn, mode, deck, turn) {
         if (!logFn) logFn = function() {};
 
         if(skill.type !== 'phy' && skill.type !== 'mag') return { dmg: 0, isCrit: false };
 
-        const srcStats = this.calculateStats(source, fieldBuffs);
-        const tgtStats = this.calculateStats(target, fieldBuffs);
+        const srcStats = this.calculateStats(source, fieldBuffs, mode);
+        const tgtStats = this.calculateStats(target, fieldBuffs, mode);
 
         // 1. Critical
         let isCrit = Math.random() * 100 < srcStats.crit;
-        let critDmg = 1.5; // Base 150%
-        // Sun Bless Crit Dmg boost only for Player
+        if (skill.effects && skill.effects.some(e => e.type === 'force_crit')) isCrit = true;
+        // Check force_crit_chance
+        const forceCritChance = skill.effects ? skill.effects.find(e => e.type === 'force_crit_chance') : null;
+        if (forceCritChance && Math.random() * 100 < forceCritChance.val) isCrit = true;
+
+        let critDmg = 1.5;
         if (source.proto && fieldBuffs.some(b => b.name === 'sun_bless')) critDmg += 0.6;
+        if (source.proto && fieldBuffs.some(b => b.name === 'reaper_realm')) critDmg += 0.4;
 
         let val = (skill.type === 'phy') ? srcStats.atk : srcStats.matk;
         if (isCrit) val *= critDmg;
 
         // 2. Skill Multiplier & Bonuses
-        let mult = skill.val || 1.0;
-        let dmgBonus = 0.0;
+
+        // Context for Handlers
+        let ctx = {
+            source: source,
+            target: target,
+            skill: skill,
+            fieldBuffs: fieldBuffs, // handlers may modify this array
+            activeTraits: activeTraits,
+            logFn: logFn,
+            mode: mode,
+            deck: deck,
+            turn: turn,
+            mult: skill.val || 1.0,
+            ignoreMdefRate: 0
+        };
 
         // Elemental
         if (source.proto && source.proto.element && target.element) {
-             const elMult = this.getElementalMultiplier(source.proto.element, target.element);
+             let elMult = this.getElementalMultiplier(source.proto.element, target.element);
+             if (source.proto.trait && source.proto.trait.type === 'all_advantage') elMult = 1.2;
+
              if (elMult > 1.0) {
                  val *= elMult;
                  logFn("상성 우위! 대미지 20% 증가.");
@@ -116,78 +573,26 @@ const Logic = {
         // Skill Effects affecting Multiplier
         if(skill.effects) {
             skill.effects.forEach(eff => {
-                if(eff.type === 'consume_field_all') {
-                    let c = fieldBuffs.length;
-                    if(c > 0) {
-                        mult += (c * eff.multPerStack);
-                        fieldBuffs.length = 0; // Modify in place as requested/implied by game logic
-                        logFn(`필드 버프 ${c}개 제거! 위력 폭발!`);
-                    }
-                }
-                else if(eff.type === 'consume_debuff_all') {
-                    if(target.buffs[eff.debuff]) {
-                        let c = target.buffs[eff.debuff];
-                        mult += (c * eff.multPerStack);
-                        delete target.buffs[eff.debuff];
-                        logFn(`${this.getBuffName(eff.debuff)} ${c}스택 소모!`);
-                    }
-                }
-                else if(eff.type === 'dmg_boost') {
-                     if(eff.condition === 'target_debuff' && target.buffs[eff.debuff]) {
-                         mult *= eff.mult;
-                         logFn(`[특성] ${this.getBuffName(eff.debuff)} 대상 추가 피해! (배율 x${eff.mult})`);
-                     }
-                     else if(eff.condition === 'synergy_active' && activeTraits.includes(eff.trait)) {
-                         mult *= eff.mult;
-                         logFn(`[시너지] 조건 만족! 위력 ${eff.mult}배 증가!`);
-                     }
-                     else if(eff.condition === 'target_stack' && target.buffs[eff.debuff]) mult += (target.buffs[eff.debuff] * eff.multPerStack);
-                     else if(eff.condition === 'target_debuff_count_scale') {
-                         let bonus = (Object.keys(target.buffs).length * eff.multPerDebuff);
-                         mult += bonus;
-                         if(bonus > 0) logFn(`[특성] 디버프 대상 추가 피해! (배율 +${bonus.toFixed(1)})`);
-                     }
-                     else if(eff.condition === 'hp_below' && (source.hp/source.maxHp) <= eff.val) {
-                         mult *= eff.mult;
-                         if(skill.name === '라그나로크') logFn("라그나로크: 생명력 조건 만족! 대미지 증가!");
-                     }
-                     else if(eff.condition === 'hp_full' && source.hp === source.maxHp) {
-                         mult *= eff.mult;
-                         if(eff.log) logFn(eff.log);
-                     }
-                     else if(eff.condition === 'field_buff' && fieldBuffs.some(b=>b.name === eff.buff)) {
-                         mult *= eff.mult;
-                         if(source.id === 'behemoth' && skill.name === '대지분쇄') logFn("대지의 축복으로 인해 대지분쇄의 위력이 증가합니다!");
-                     }
-                }
-                else if(eff.type === 'consume_burn_1_dmg') {
-                     if(target.buffs['burn'] >= 1) {
-                         mult *= eff.mult;
-                     }
-                }
-                else if(eff.type === 'remove_field_buff_dmg') {
-                     if(fieldBuffs.length > 0) {
-                         mult *= eff.mult;
-                     }
-                }
-                else if(eff.type === 'cond_target_debuff_3_dmg') {
-                     if(Object.keys(target.buffs).length >= 3) {
-                         mult *= eff.mult;
-                         logFn("적 디버프 3개 이상! 위력 2배!");
-                     }
-                }
-                else if(eff.type === 'random_mult') {
-                    let max = eff.max;
-                    if(activeTraits.includes('syn_water_3_ice_age')) max = 10.0;
-                    mult = eff.min + Math.floor(Math.random() * (max - eff.min + 1));
-                    logFn(`무작위 위력! x${mult.toFixed(1)}`);
+                const handler = DAMAGE_EFFECT_HANDLERS[eff.type];
+                if (handler) {
+                    handler(ctx, eff);
+                } else {
+                    // Fallback for types not in DAMAGE_EFFECT_HANDLERS (side effects)
+                    // Do nothing here, handled in RPG.applySkillEffects
                 }
             });
         }
 
+        let mult = ctx.mult;
+        let dmgBonus = 0.0;
+
         // Trait Multipliers
         const t = source.proto ? source.proto.trait : null;
         if (t) {
+            if(t.type === 'cond_darkness_dmg' && target.buffs.darkness) {
+                dmgBonus += (t.val - 1.0);
+                logFn(`[특성] 타천사: 암흑 속에서 힘이 솟구칩니다!`);
+            }
             if(t.type === 'cond_silence_dmg' && target.buffs.silence) {
                 dmgBonus += (t.val - 1.0);
                 logFn(`[특성] ${source.name}: 침묵 대상 추가 피해!`);
@@ -208,10 +613,111 @@ const Logic = {
                 dmgBonus += (t.val - 1.0);
                 logFn("[특성] 베히모스: 디버프 3개 이상 대상 파괴적 일격!");
             }
+            if(t.type === 'cond_target_debuff_3_dmg' && Object.keys(target.buffs).length >= 3) {
+                dmgBonus += (t.val - 1.0);
+                logFn("[특성] 심해의 주인: 적 디버프 3개 이상! 위력 폭발!");
+            }
+            if(t.type === 'luna_jasmine_trait' && (target.buffs['divine'] || 0) >= 3) {
+                dmgBonus += (t.val - 1.0);
+                logFn("[특성] 루나&자스민: 디바인 3스택 이상! 위력 2배!");
+            }
+            if(t.type === 'behemoth_liberated_trait' && Object.keys(target.buffs).length >= 3) {
+                dmgBonus += (t.val - 1.0);
+                logFn("[특성] 해방된 베히모스: 디버프 3개 이상! 파괴적 일격!");
+            }
         }
 
         // Defense
         let def = (skill.type === 'phy') ? tgtStats.def : tgtStats.mdef;
+
+        if (ctx.ignoreMdefRate > 0 && skill.type === 'mag') {
+             let ignore = Math.floor(tgtStats.mdef * ctx.ignoreMdefRate);
+             def = Math.max(0, def - ignore);
+             logFn(`[효과] 마법방어력 ${Math.round(ctx.ignoreMdefRate*100)}% 관통!`);
+        }
+
+        // [추가] 신데렐라: 스택 비례 방어 무시
+        if (t && t.type === 'ignore_def_mdef_by_stack') {
+            let ignoreRate = 0;
+            if (skill.type === 'phy' && target.buffs['burn']) {
+                ignoreRate = target.buffs['burn'] * t.val;
+                logFn(`[특성] 유리구두: 작열 ${target.buffs['burn']}스택! 방어력 ${Math.round(ignoreRate*100)}% 무시!`);
+            }
+            else if (skill.type === 'mag' && target.buffs['divine']) {
+                ignoreRate = target.buffs['divine'] * t.val;
+                logFn(`[특성] 유리구두: 디바인 ${target.buffs['divine']}스택! 마법방어력 ${Math.round(ignoreRate*100)}% 무시!`);
+            }
+
+            if (ignoreRate > 0) {
+                let baseDef = (skill.type === 'phy') ? target.def : target.mdef;
+                def = Math.max(0, def - Math.floor(baseDef * ignoreRate));
+            }
+        }
+
+        // Gray Trait: Ignore Def
+        if (t && t.type === 'crit_ignore_def_add' && isCrit) {
+            let ignore = t.val;
+            let baseDef = (skill.type === 'phy') ? target.def : target.mdef;
+            def = Math.max(0, def - Math.floor(baseDef * ignore));
+            logFn("[특성] 치명타! 적 방어력 50% 추가 무시!");
+        }
+
+        // [초월 루미: 꿈의형태 리워크 로직]
+        if (skill.name === '꿈의형태' && fieldBuffs.length > 0) {
+            let logMsg = [];
+
+            // 1. 효과 적립
+            fieldBuffs.forEach(b => {
+                switch (b.name) {
+                    case 'sun_bless': // 태양: 2배율 + 확정 치명타
+                        mult += 2.0;
+                        isCrit = true;
+                        logMsg.push("태양(2.0배/치명)");
+                        break;
+                    case 'moon_bless': // 달: 마방 30% 관통
+                        {
+                            let ignore = Math.floor(tgtStats.mdef * 0.3);
+                            def = Math.max(0, def - ignore);
+                            logMsg.push(`달(관통 ${ignore})`);
+                        }
+                        break;
+                    case 'star_powder': // 스타파우더: 마나 30 회복
+                        source.mp = Math.min(100, source.mp + 30);
+                        logMsg.push("스타(MP+30)");
+                        break;
+                    case 'earth_bless': // 대지: 2배율 + 체력 풀회복
+                        mult += 2.0;
+                        source.hp = source.maxHp;
+                        logMsg.push("대지(2.0배/완전회복)");
+                        break;
+                    case 'sanctuary': // 성역: 2배율 + 마나 20 회복
+                        mult += 2.0;
+                        source.mp = Math.min(100, source.mp + 20);
+                        logMsg.push("성역(2.0배/MP+20)");
+                        break;
+                    case 'goddess_descent': // 여신강림: 4배율 + 스턴
+                        mult += 4.0;
+                        target.buffs['stun'] = 1;
+                        logMsg.push("여신(4.0배/기절)");
+                        break;
+                    case 'reaper_realm': // 사신강림: 마방 50% 관통
+                        {
+                            let ignore = Math.floor(tgtStats.mdef * 0.5);
+                            def = Math.max(0, def - ignore);
+                            logMsg.push(`사신(관통 ${ignore})`);
+                        }
+                        break;
+                    case 'twinkle_party': // 트윙클: 3배율
+                        mult += 3.0;
+                        logMsg.push("트윙클(3.0배)");
+                        break;
+                }
+            });
+
+            // 2. 로그 출력 및 버프 소모
+            logFn(`[꿈의형태] 필드 버프 ${fieldBuffs.length}개 융합! (${logMsg.join(', ')})`);
+            fieldBuffs.length = 0; // 모든 필드 버프 제거 (Array Clear)
+        }
 
         // Final Calculation
         let finalMult = mult * (1.0 + dmgBonus);
@@ -220,8 +726,8 @@ const Logic = {
         return { dmg: finalDmg, isCrit: isCrit };
     },
 
-    // 4. Initial Stats Calculation (New)
-    calculateInitialStats: function(playerProto, deck, allCards) {
+    // 4. Initial Stats Calculation
+    calculateInitialStats: function(playerProto, deck, allCards, idx) {
         // Base stats copy
         let p = {
             maxHp: playerProto.stats.hp, hp: playerProto.stats.hp, mp: 100,
@@ -231,10 +737,9 @@ const Logic = {
         };
 
         // Filter active cards
-        const activeCards = deck.map(id => id ? allCards.find(c => c.id === id) : null).filter(c => c);
+        const activeCards = deck.map(id => getCardById(id, allCards)).filter(c => c);
         const jokerInDeck = deck.includes('joker');
 
-        // Helper functions
         const countEl = (el) => activeCards.filter(c => c.element === el || c.id === 'joker').length;
         const hasEl = (el) => activeCards.some(c => c.element === el || c.id === 'joker');
 
@@ -250,13 +755,16 @@ const Logic = {
              else if(t.type === 'syn_fire_3_crit' && countEl('fire') >= 3) active = true;
              else if(t.type === 'syn_dark_3_matk' && countEl('dark') >= 3) active = true;
              else if(t.type === 'syn_light_fire_atk' && hasEl('light') && hasEl('fire')) active = true;
-             else if(t.type === 'syn_water_light_matk_mdef' && hasEl('water') && hasEl('light')) active = true;
+             else if(t.type === 'syn_light_dark_matk_mdef' && hasEl('light') && hasEl('dark')) active = true;
              else if(t.type === 'syn_water_nature' && hasEl('water') && hasEl('nature')) active = true;
              else if(t.type === 'syn_nature_3_matk' && countEl('nature') >= 3) active = true;
              else if(t.type === 'syn_night_rabbit' && (deck.includes('night_rabbit') || deck.includes('silver_rabbit') || jokerInDeck)) active = true;
              else if(t.type === 'syn_snow_rabbit' && (deck.includes('snow_rabbit') || deck.includes('silver_rabbit') || jokerInDeck)) active = true;
              else if(t.type === 'syn_silver_rabbit' && (deck.includes('snow_rabbit') || deck.includes('night_rabbit') || jokerInDeck)) active = true;
              else if(t.type === 'syn_water_3_atk_matk' && countEl('water') >= 3) active = true;
+             else if(t.type === 'syn_fire_3_crit_burn' && countEl('fire') >= 3) active = true;
+             else if(t.type === 'syn_dark_3_matk_boost' && countEl('dark') >= 3) active = true;
+             else if(t.type === 'syn_water_2_moon_twinkle' && countEl('water') >= 2) active = true;
 
              if(active) {
                 if(t.type === 'syn_nature_3_all') { p.atk *= 1.3; p.matk *= 1.3; p.def *= 1.3; p.mdef *= 1.3; }
@@ -265,21 +773,49 @@ const Logic = {
                 if(t.type === 'syn_fire_3_crit') p.baseCrit += 30;
                 if(t.type === 'syn_dark_3_matk') p.matk *= 1.5;
                 if(t.type === 'syn_light_fire_atk') p.atk *= 1.3;
-                if(t.type === 'syn_water_light_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
+                if(t.type === 'syn_light_dark_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
                 if(t.type === 'syn_night_rabbit') { p.matk *= 1.5; p.mdef *= 1.5; }
                 if(t.type === 'syn_snow_rabbit') { p.atk *= 1.5; p.def *= 1.5; }
                 if(t.type === 'syn_silver_rabbit') { p.atk *= 1.5; p.matk *= 1.5; }
                 if(t.type === 'syn_water_3_atk_matk') { p.atk *= 1.5; p.matk *= 1.5; }
+                if(t.type === 'syn_fire_3_crit_burn') p.baseCrit += t.val;
+                if(t.type === 'syn_dark_3_matk_boost') p.matk *= (1 + t.val/100);
 
-                // Flooring
                 p.atk = Math.floor(p.atk); p.matk = Math.floor(p.matk);
                 p.def = Math.floor(p.def); p.mdef = Math.floor(p.mdef);
              }
         }
+
+        // Positional Traits (Generalized)
+        if(t.type === 'pos_stat_boost' && idx !== undefined) {
+            if(t.pos === idx) {
+                let stats = Array.isArray(t.stat) ? t.stat : [t.stat];
+                stats.forEach(s => {
+                    if(s === 'atk') p.atk *= (1 + t.val/100);
+                    if(s === 'matk') p.matk *= (1 + t.val/100);
+                    if(s === 'def') p.def *= (1 + t.val/100);
+                    if(s === 'mdef') p.mdef *= (1 + t.val/100);
+                });
+                p.atk = Math.floor(p.atk); p.matk = Math.floor(p.matk);
+                p.def = Math.floor(p.def); p.mdef = Math.floor(p.mdef);
+            }
+        }
+
+        if(t.type === 'rabbit_synergy_boost') {
+             const rabbits = ['night_rabbit', 'snow_rabbit', 'silver_rabbit', 'trans_yeon_rabbit', 'joker'];
+             let count = 0;
+             deck.forEach(id => { if (id && rabbits.includes(id)) count++; });
+             if (count > 0) {
+                 let boost = count * (t.val / 100);
+                 p.atk = Math.floor(p.atk * (1 + boost));
+                 p.matk = Math.floor(p.matk * (1 + boost));
+             }
+        }
+
         return { stats: p, activeTrait: active ? t.type : null };
     },
 
-    // 5. Enemy AI (New)
+    // 5. Enemy AI
     decideEnemyAction: function(enemy, turn) {
         let skill = null;
         let r = Math.random();
@@ -307,13 +843,8 @@ const Logic = {
         }
         else if(enemy.id === 'creator_god') {
             if(enemy.isCharging) {
-                // Return a skill object that signals a charged attack
-                // This will be handled by the caller or we return the skill
                 const chargedSkill = enemy.skills.find(s => s.name === '디바인블레이드');
                 return { ...chargedSkill, chargeReset: true };
-                // Note: caller needs to handle chargeReset or we do it here?
-                // Logic shouldn't modify enemy state directly if possible.
-                // We return a property 'chargeReset: true' so caller can set isCharging = false.
             }
             else if(turn === 1) {
                 return { type: 'phy', val: 1.0, name: '일반 공격' };
@@ -327,7 +858,6 @@ const Logic = {
                      else skill = enemy.skills.find(s => s.name === '홀리레이');
                 }
                 else if(r < 0.5) {
-                    // Charge
                     return { type: 'phy', val: 0, name: '차지', isChargeStart: true };
                 }
                 else {
@@ -336,7 +866,6 @@ const Logic = {
             }
         }
 
-        // Fallback
         if(!skill && Math.random() < 0.3 && enemy.skills.length > 0) {
              const validSkills = enemy.skills.filter(s => s.rate > 0);
              if(validSkills.length > 0) {
@@ -346,8 +875,8 @@ const Logic = {
         return skill || { type: 'phy', val: 1.0, name: '일반 공격' };
     },
 
-    // 6. Handle Death Traits (New)
-    handleDeathTraits: function(victim, killer, fieldBuffs, logFn) {
+    // 6. Handle Death Traits
+    handleDeathTraits: function(victim, killer, fieldBuffs, logFn, deck, turn) {
         if (!logFn) logFn = function() {};
 
         let result = { damageToKiller: 0, fieldBuffsToAdd: [], killerDebuffs: {} };
@@ -355,7 +884,7 @@ const Logic = {
 
         if(t.type === 'death_dmg_mag') {
             let dummySkill = { name: '사망 반격', type: 'mag', val: t.val, effects: [] };
-            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn);
+            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn, null, deck, turn);
             if(dmgResult.dmg > 0) {
                 result.damageToKiller += dmgResult.dmg;
                 logFn(`[특성] 사망 반격! ${dmgResult.isCrit?'Critical! ':''}<span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
@@ -364,7 +893,7 @@ const Logic = {
         else if(t.type === 'death_dmg_debuff') {
             let cnt = Object.keys(killer.buffs).length;
             let dummySkill = { name: '저주 반격', type: 'mag', val: cnt * t.val, effects: [] };
-            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn);
+            let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn, null, deck, turn);
             if(dmgResult.dmg > 0) {
                 result.damageToKiller += dmgResult.dmg;
                 logFn(`[특성] 저주 반격! ${dmgResult.isCrit?'Critical! ':''}<span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
@@ -373,16 +902,10 @@ const Logic = {
         else if(t.type === 'death_field_sun') {
             result.fieldBuffsToAdd.push('sun_bless');
         }
-        else if(t.type === 'death_stun') {
+        else if(t.type === 'death_debuff') {
              if (killer) {
-                 result.killerDebuffs.stun = 1;
-                 logFn(`[특성] 사망 시 스턴 발동! 적을 기절시킵니다.`);
-             }
-        }
-        else if(t.type === 'death_darkness') {
-             if (killer) {
-                 result.killerDebuffs.darkness = 1;
-                 logFn(`[특성] 사망 시 암흑 발동! 적에게 암흑을 부여합니다.`);
+                 result.killerDebuffs[t.debuff] = 1;
+                 logFn(`[특성] 사망 효과 발동! 적에게 [${getBuffName(t.debuff)}] 부여.`);
              }
         }
         else if(t.type === 'death_sun_bless_chance') {
@@ -396,17 +919,20 @@ const Logic = {
         else if(t.type === 'death_field_buff_count_dmg') {
              let count = fieldBuffs.length;
              let dummySkill = { name: '사망 반격', type: 'mag', val: count * t.val, effects: [] };
-             let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn);
+             let dmgResult = this.calculateDamage(victim, killer, dummySkill, fieldBuffs, [], logFn, null, deck, turn);
              if(dmgResult.dmg > 0) {
                  result.damageToKiller += dmgResult.dmg;
                  logFn(`[특성] 사망 반격! (필드버프 ${count}개) ${dmgResult.isCrit?'Critical! ':''}<span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
              }
         }
+        else if(t.type === 'death_twinkle') {
+            result.fieldBuffsToAdd.push('twinkle_party');
+            logFn(`[특성] 헬하운드 사망! 트윙클 파티 발동!`);
+        }
 
         return result;
     },
 
-    // Helper
     getElementalMultiplier: function(atkEl, defEl) {
         if(atkEl === 'water' && defEl === 'fire') return 1.2;
         if(atkEl === 'fire' && defEl === 'nature') return 1.2;
@@ -415,16 +941,5 @@ const Logic = {
         return 1.0;
     },
 
-    getBuffName: function(key) {
-        const names = {
-            'darkness': '암흑', 'corrosion': '부식', 'silence': '침묵', 'curse': '저주', 'weak': '약화',
-            'burn': '작열', 'divine': '디바인', 'stun': '기절', 'evasion': '회피', 'barrier': '배리어',
-            'magic_guard': '매직가드', 'guard': '가드',
-            'defProtocolPhy': '방어프로토콜(물리)', 'defProtocolMag': '방어프로토콜(마법)',
-            'sun_bless': '태양의축복', 'moon_bless': '달의축복', 'sanctuary': '성역',
-            'goddess_descent': '여신강림', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',
-            'star_powder': '스타파우더'
-        };
-        return names[key] || key;
-    }
+    getBuffName: getBuffName
 };

--- a/card_remaster/vocab_data.js
+++ b/card_remaster/vocab_data.js
@@ -78,7 +78,6 @@ const VOCAB_SOURCE = [
     { w: 'direct', m: '(형) 직접적인; (동) 지시하다', tm: '(동) 발견하다; (동) 감지하다', tw: 'detect' },
     { w: 'cover', m: '(동) 덮다; (동) 포함하다', tm: '(동) 맴돌다; (동) 공중 정지하다', tw: 'hover' },
     { w: 'accompany', m: '(동) 동행하다; (동) 동반하다', tm: '(동) 성취하다; (동) 완수하다', tw: 'accomplish' },
-    { w: 'contribute', m: '(동) 기여하다; (동) 기부하다', tm: '(동) 분배하다; (동) 유통시키다', tw: 'distribute' },
     { w: 'motivate', m: '(동) 동기부여하다; (동) 자극하다', tm: '(동) 경작하다; (동) 재배하다', tw: 'cultivate' },
     { w: 'consider', m: '(동) 고려하다; (동) 숙고하다', tm: '(동) 인정하다; (동) 양보하다', tw: 'concede' },
     { w: 'arrange', m: '(동) 정리하다; (동) 마련하다', tm: '(동) 어지럽히다; (동) 미치게 하다', tw: 'derange' },
@@ -96,7 +95,7 @@ const VOCAB_SOURCE = [
     { w: 'fluctuate', m: '(동) 변동하다; (동) 오르내리다', tm: '(동) 구두점을 찍다; (동) 강조하다', tw: 'punctuate' },
     { w: 'deliver', m: '(동) 배달하다; (동) 연설하다', tm: '(형) 고의적인; (형) 신중한', tw: 'deliberate' },
     { w: 'devoted', m: '(형) 헌신적인; (형) 전념하는', tm: '(동) 강등시키다; (동) 좌천시키다', tw: 'demote' },
-    { w: 'stock', m: '(명) 재고; (명) 주식', tm: '(동) 몰래 접근하다; (명) 줄기', tw: 'stalk' },
+    { w: 'stock', m: '(명) 재고; (명) 주식', tm: '(명) (식물의) 줄기, 대; (동) 몰래 접근하다', tw: 'stalk' },
     { w: 'authority', m: '(명) 권한; (명) 당국', tm: '(명) 작가; (명) 저자', tw: 'author' },
     { w: 'variety', m: '(명) 다양성; (명) 품종', tm: '(명) 진실성; (명) 진리', tw: 'verity' },
     { w: 'access', m: '(명) 접근, 이용 권한; (동) 접근하다', tm: '(동) 평가하다; (동) 가늠하다, 재다', tw: 'assess' },
@@ -228,7 +227,57 @@ const VOCAB_SOURCE = [
     { w: 'regulation', m: '(명) 규제, 규정', tm: '(명) 규칙성; (명) 정기적임', tw: 'regularity' },
     { w: 'material', m: '(명) 재료, 자료', tm: '(형) 어머니의; (형) 모성의', tw: 'maternal' },
     { w: 'critical', m: '(형) 비판적인; (형) 대단히 중요한', tm: '(형) 임상의; (형) 병원의', tw: 'clinical' },
-    { w: 'draft', m: '(명) 초안; (명) 징병', tm: '(동) 표류하다; (동) 떠가다', tw: 'drift' }
+    { w: 'draft', m: '(명) 초안; (명) 징병', tm: '(동) 표류하다; (동) 떠가다', tw: 'drift' },
+
+    // [추가] 신규 대체 항목 (토익 빈출 부사 쌍)
+    { w: 'formally', m: '(부) 정식으로, 공식적으로', tm: '(부) 이전에, 예전에', tw: 'formerly' },
+    { w: 'fare', m: '(명) (교통) 요금; (동) 해내다', tm: '(형) 공정한; (명) 박람회', tw: 'fair' },
+
+    // [명사 혼동 어휘]
+    { w: 'recipe', m: '(명) 요리법, 조리법; (명) 비결', tm: '(명) 영수증; (명) 수령, 받음', tw: 'receipt' },
+    { w: 'application', m: '(명) 지원서, 신청; (명) 적용', tm: '(명) 가전제품, 기구', tw: 'appliance' },
+    { w: 'investment', m: '(명) 투자; (명) 투자금', tm: '(명) 조사, 수사; (명) 연구', tw: 'investigation' },
+    { w: 'transportation', m: '(명) 수송, 운송; (명) 교통수단', tm: '(명) 변화, 변신; (명) 개혁', tw: 'transformation' },
+    { w: 'reputation', m: '(명) 평판, 명성', tm: '(명) 반복; (명) 암송', tw: 'repetition' },
+    { w: 'plumber', m: '(명) 배관공', tm: '(명) 목재', tw: 'lumber' },
+    { w: 'satisfaction', m: '(명) 만족; (명) 배상', tm: '(명) (시장) 포화; (명) 포화 상태', tw: 'saturation' },
+    { w: 'corrosion', m: '(명) 부식, 녹', tm: '(명) 침식; (명) (가치) 하락', tw: 'erosion' },
+    { w: 'ascent', m: '(명) 상승; (명) 오르막길', tm: '(명) 동의, 찬성; (동) 동의하다', tw: 'assent' },
+    { w: 'council', m: '(명) 의회, 위원회', tm: '(명) 조언; (명) 변호인단', tw: 'counsel' },
+    { w: 'reality', m: '(명) 현실, 실재', tm: '(명) 부동산, 부동산 물건', tw: 'realty' },
+    { w: 'award', m: '(명) 상, 상품; (동) 수여하다', tm: '(명) 보상, 사례금; (동) 보답하다', tw: 'reward' },
+    { w: 'addition', m: '(명) 추가, 덧셈; (명) 증축 건물', tm: '(명) (출간물의) 판, 호; (명) (방송의) 회', tw: 'edition' },
+
+    // [동사 혼동 어휘]
+    { w: 'compete', m: '(동) 경쟁하다, 겨루다', tm: '(동) 완료하다; (형) 완전한', tw: 'complete' },
+    { w: 'negotiate', m: '(동) 협상하다; (동) (도로를) 뚫고 나아가다', tm: '(동) 길을 찾다; (동) 항해하다', tw: 'navigate' },
+    { w: 'accrue', m: '(동) 축적되다; (동) (이자가) 붙다', tm: '(동) 고발하다, 기소하다; (동) 비난하다', tw: 'accuse' },
+    { w: 'retain', m: '(동) 유지하다, 보유하다', tm: '(동) 구금하다; (동) 지체시키다', tw: 'detain' },
+    { w: 'remit', m: '(동) 송금하다; (동) 면제하다', tm: '(동) 제출하다; (동) 항복하다', tw: 'submit' },
+    { w: 'cite', m: '(동) 인용하다; (동) 소환하다', tm: '(명) 현장, 부지; (명) 웹사이트', tw: 'site' },
+    { w: 'inhabit', m: '(동) 살다, 거주하다', tm: '(동) 억제하다; (동) 금지하다', tw: 'inhibit' },
+    { w: 'defer', m: '(동) 미루다, 연기하다; (동) 따르다', tm: '(동) 다르다; (동) 의견을 달리하다', tw: 'differ' },
+    { w: 'persecute', m: '(동) 박해하다, 괴롭히다', tm: '(동) 기소하다; (동) 추진하다', tw: 'prosecute' },
+    { w: 'abolish', m: '(동) (제도를) 폐지하다', tm: '(동) 설립하다; (동) 확고히 하다', tw: 'establish' },
+    { w: 'commence', m: '(동) 시작되다, 개시하다', tm: '(동) 칭찬하다; (동) 추천하다', tw: 'commend' },
+    { w: 'comprise', m: '(동) 구성하다; (동) 포함하다', tm: '(동) 타협하다; (명) 타협', tw: 'compromise' },
+    { w: 'lay', m: '(동) (물건을) 놓다, 두다; (동) 낳다', tm: '(동) 눕다; (동) 거짓말하다', tw: 'lie' },
+    { w: 'rise', m: '(동) 오르다, 상승하다; (동) 뜨다', tm: '(동) (들어) 올리다; (동) 모으다', tw: 'raise' },
+
+    // [형용사 및 부사 혼동 어휘]
+    { w: 'beneficial', m: '(형) 유익한, 이로운', tm: '(명) 수혜자, 수령인', tw: 'beneficiary' },
+    { w: 'permanent', m: '(형) 영구적인, 정규직의', tm: '(형) 저명한; (형) 눈에 띄는', tw: 'prominent' },
+    { w: 'considerable', m: '(형) 상당한, 많은', tm: '(형) 사려 깊은, 배려하는', tw: 'considerate' },
+    { w: 'later', m: '(부) 나중에; (형) 더 뒤의', tm: '(형) 후자의; (명) 후자', tw: 'latter' },
+    { w: 'comprehensible', m: '(형) 이해할 수 있는', tm: '(형) 포괄적인, 종합적인', tw: 'comprehensive' },
+    { w: 'human', m: '(형) 인간의; (명) 인간', tm: '(형) 인도적인; (형) 자비로운', tw: 'humane' },
+    { w: 'imaginary', m: '(형) 가상의, 상상의', tm: '(형) 창의적인, 상상력이 풍부한', tw: 'imaginative' },
+    { w: 'industrial', m: '(형) 산업의, 공업의', tm: '(형) 근면한, 부지런한', tw: 'industrious' },
+    { w: 'loyal', m: '(형) 충성스러운, 충실한', tm: '(형) 왕실의; (명) 왕족', tw: 'royal' },
+    { w: 'momentary', m: '(형) 순간적인, 찰나의', tm: '(형) 중대한, 중요한', tw: 'momentous' },
+    { w: 'negligent', m: '(형) 태만한, 부주의한', tm: '(형) 무시해도 될 정도의', tw: 'negligible' },
+    { w: 'successful', m: '(형) 성공적인, 성공한', tm: '(형) 연속적인, 연이은', tw: 'successive' },
+    { w: 'continual', m: '(형) 빈번한, 되풀이되는', tm: '(형) (끊김 없이) 계속되는', tw: 'continuous' }
 ];
 
 const VOCAB_DATA = [];


### PR DESCRIPTION
### Motivation
- Convert the existing `card` prototype into a polished, mobile-first commercial UI while preserving all gameplay and learning features and keeping image loading in the main HTML (mobile Chrome target).
- Restore missing runtime dependencies in the remaster (API and collocation datasets) and improve performance/maintainability of core gameplay logic.
- Unify and simplify card lookups and side-effect handling to reduce repeated linear searches and make effect processing extensible.

### Description
- UI: replaced and modernized `card_remaster/index.html` styling and UI flows for mobile Chrome (tokenized CSS variables, improved card/grid/portrait/controls, new modals and screens, and preserved image loading in the main HTML for cards/players/enemies via `<img src="...">`).
- New/Restored assets: added `card_remaster/api.js` (LM API wrapper persona + `GameAPI.getTutoringContent`) and `card_remaster/collocation_data.js` (large collocation quiz dataset) and aligned `data.js`/`vocab_data.js`/`grammar_data.js` content with the source set.
- Refactor: reworked `card_remaster/logic.js` to introduce a reusable card lookup cache (`getCardLookup`, `getCardById`) and replaced repeated `find` calls; added `DAMAGE_EFFECT_HANDLERS` and a `SideEffects` dispatcher to centralize effect logic and allow handlers to modify `fieldBuffs`/`mult` safely.
- Feature & integration updates in `card_remaster/index.html`: expanded game modes, draft flow, chaos roulette/transcendence flow, improved gacha/quiz flows, private tutoring UI integrated with `GameAPI`, safer checks when calling the API, and richer interactions between UI and `Logic` (passing `deck`, `mode`, and `turn` into damage/effect calculations).

### Testing
- Syntax checks: ran `node --check card_remaster/logic.js`, `node --check card_remaster/api.js`, and `node --check card_remaster/data.js`, and all checks passed.
- Local server + render: started a local server with `python -m http.server 8000` and exercised the remastered page via a headless Playwright script which loaded `card_remaster/index.html` at a mobile viewport and produced a screenshot (successful load and screenshot captured).
- Basic runtime validation: client-side UI scripts were loaded in order (main HTML references `api.js`, `data.js`, `vocab_data.js`, `collocation_data.js`, `grammar_data.js`, `logic.js`) and no immediate runtime syntax errors were reported by the prior checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f6c076cc883228a0a468883db7efc)