### PR TITLE
Fix modal display issues in Card Remastered

### DIFF
--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -116,7 +116,8 @@
     .skill-btn.sup { border-color: #61da9a; color: #b5f3d3; }
     .bottom-actions { position: fixed; bottom: 0; left: 0; right: 0; display: flex; gap: 6px; padding: 8px; background: rgba(10,14,25,0.95); border-top: 1px solid var(--line); }
     .bottom-actions button { flex: 1; }
-    .modal { background: rgba(2,4,9,0.82); }
+    .modal { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(2,4,9,0.82); z-index: 100; flex-direction: column; align-items: center; justify-content: center; }
+    .modal.active { display: flex; }
     .modal-content { background: linear-gradient(165deg, #1a2237 0%, #101628 100%); border: 1px solid var(--line); border-radius: 14px; box-shadow: 0 20px 40px rgba(0,0,0,0.45); }
     .mode-modal { background: radial-gradient(circle at 0% 0%, rgba(101, 140, 255, 0.16) 0%, transparent 42%), radial-gradient(circle at 100% 0%, rgba(193, 124, 255, 0.18) 0%, transparent 48%), linear-gradient(180deg, #151d31 0%, #101726 100%); border: 1px solid #425684; }
     .mode-btn { margin-bottom: 0; min-height: 52px; font-size: 0.85rem; }


### PR DESCRIPTION
The `card_remaster/index.html` file was missing critical CSS styles for the `.modal` class, specifically `display: none` (to hide by default), `position: fixed` (to overlay), and flexbox alignment properties. This caused modals like the "Mode Selection" screen to be rendered improperly (likely at the bottom of the document flow, potentially off-screen or unclickable) or fail to toggle visibility correctly. This fix restores the standard modal styling used in the original game but adapted for the remastered UI theme.

---
*PR created automatically by Jules for task [10915236431960001852](https://jules.google.com/task/10915236431960001852) started by @romarin0325-cell*