### PR TITLE
Fix Chaos Roulette UI not appearing after unlocking all cards

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -768,6 +768,10 @@ const RPG = {
     // --- Chaos Roulette ---
     openChaosRoulette() {
         if (!this.checkAllBonusUnlocked()) return this.showAlert("아직 해금되지 않았습니다.");
+
+        // Fix: 모달이 화면을 가리는 문제 수정
+        document.getElementById('modal-mode-select').classList.remove('active');
+
         this.showScreen('screen-chaos-roulette');
         document.getElementById('ui-chaos-tickets').innerText = this.global.chaosTickets || 0;
     },


### PR DESCRIPTION
Fixed an issue where accessing the Chaos Roulette screen from the Mode Select modal resulted in the new screen being rendered behind the still-active modal, making it inaccessible. Added logic to explicitly close the modal upon navigation.

---
*PR created automatically by Jules for task [6695099655700539321](https://jules.google.com/task/6695099655700539321) started by @romarin0325-cell*