### PR TITLE
Revert Next Enemy UI and Buff Reaper Gray

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -712,7 +712,7 @@ const TRANSCENDENCE_CARDS = [
         trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~10배율)', effects: [{type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 10.0}] },
+            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~12배율)', effects: [{type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 12.0}] },
             { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{type: 'turn_modulo_dmg', mod: 4, mult: 2.0}, {type: 'force_crit_chance', val: 40}] }
         ]
     },

--- a/card/index.html
+++ b/card/index.html
@@ -733,7 +733,8 @@ const RPG = {
         document.getElementById('next-enemy-text').innerText = nextEnemy.name;
         const imgEl = document.getElementById('next-enemy-img');
         imgEl.src = `${nextEnemy.name}.png`;
-        imgEl.style.display = 'block';
+        imgEl.style.display = 'none';
+        imgEl.parentElement.style.display = 'none';
 
         // Mode Specific Menu Areas
         const gachaArea = document.getElementById('menu-gacha-area');


### PR DESCRIPTION
This patch addresses two user requests:
1.  **Next Enemy UI Revert:** The waiting screen (main menu) now correctly hides the enemy illustration, showing only the text order, reverting a previous UI regression.
2.  **Balance Update:** The Transcendence card 'Reaper Gray' has been buffed. The 'Void Eater' skill's maximum multiplier under 'Moon's Blessing' is increased to 12x.

---
*PR created automatically by Jules for task [17795385088559414104](https://jules.google.com/task/17795385088559414104) started by @romarin0325-cell*