### PR TITLE
Fix Chaos Lord Roulette delayed skill execution

### DIFF
--- a/card/logic.js
+++ b/card/logic.js
@@ -375,8 +375,20 @@ const SideEffects = {
             const skill = card.skills.find(s => s.name === pick.skill);
 
             if (skill) {
-                ctx.logFn(`[데스티니룰렛] ${card.name}의 ${skill.name} 발동!`);
-                ctx.executeSkill(ctx.source, ctx.target, skill, true);
+                const delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_attack' || e.type === 'delayed_attack_field' || e.type === 'delayed_random_attack');
+
+                if (delayedEff) {
+                     ctx.logFn(`[데스티니룰렛] ${card.name}의 ${skill.name} 발동!`);
+                     ctx.battle.delayedEffects.push({
+                         turn: ctx.battle.turn + delayedEff.turns,
+                         source: ctx.source,
+                         skill: skill
+                     });
+                     ctx.logFn(`(지연 발동) ${delayedEff.turns}턴 뒤에 공격합니다.`);
+                } else {
+                     ctx.logFn(`[데스티니룰렛] ${card.name}의 ${skill.name} 발동!`);
+                     ctx.executeSkill(ctx.source, ctx.target, skill, true);
+                }
             }
         },
         'apply_lumi_guard': (ctx, eff) => {


### PR DESCRIPTION
Fixed a bug where delayed skills (like Earthquake) triggered by Chaos Lord's Roulette were executed immediately. The fix involves checking for delayed effect types in the `random_skill_trigger_from_list` handler and manually pushing them to the delayed effects queue if found.

---
*PR created automatically by Jules for task [5731948983086660552](https://jules.google.com/task/5731948983086660552) started by @romarin0325-cell*