### PR TITLE
Fix Transcendence card availability in Challenge mode and synergy bugs

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -796,7 +796,7 @@ const RPG = {
         }
 
         // Origin Mode: Add Transcendence Cards directly to Inventory
-        if (mode === 'origin' && this.state.activeTranscendenceCards.length > 0) {
+        if (mode !== 'chaos' && mode !== 'draft' && this.state.activeTranscendenceCards.length > 0) {
              this.state.inventory.push(...this.state.activeTranscendenceCards);
              setTimeout(() => this.showAlert(`초월 카드 ${this.state.activeTranscendenceCards.length}장이 인벤토리에 합류했습니다!`), 500);
         }
@@ -1841,7 +1841,7 @@ const RPG = {
             const proto = this.getCardData(id);
 
             // Call Logic to calculate initial stats (Base + Synergies)
-            const allCards = [...CARDS, ...BONUS_CARDS];
+            const allCards = [...CARDS, ...BONUS_CARDS, ...(typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS : [])];
             const init = Logic.calculateInitialStats(proto, this.state.deck, allCards, idx);
 
             // Log active synergy if any
@@ -2471,7 +2471,7 @@ const RPG = {
     },
 
     cleanupTranscendenceCards() {
-        if (this.state.mode !== 'origin') return "";
+        if (['draft', 'chaos'].includes(this.state.mode)) return "";
 
         let removedNames = [];
         this.battle.players.forEach((p, idx) => {


### PR DESCRIPTION
1.  **Transcendence Availability**: Modified `RPG.initNewGame` to allow Transcendence cards (from `pendingTranscendenceCards`) to be added to the inventory in all standard modes (like Challenge, Restriction, Balance, etc.), not just 'Origin'. This prevents them from being effectively deleted when starting a Challenge run.
2.  **Synergy Calculation**: Updated `RPG.startBattleInit` to include `TRANSCENDENCE_CARDS` in the `allCards` lookup array. This ensures that `Logic.calculateInitialStats` can correctly identify these cards and calculate trait-based synergies (e.g., element counts).
3.  **Consumable Logic**: Updated `RPG.cleanupTranscendenceCards` to run for all modes except 'draft' and 'chaos'. This ensures that Transcendence cards remain one-time use consumables in Challenge mode, consistent with their behavior in Origin mode.

---
*PR created automatically by Jules for task [17222519670065083365](https://jules.google.com/task/17222519670065083365) started by @romarin0325-cell*