### PR TITLE
Enforce Transcendence Card Rules by Mode

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -770,10 +770,14 @@ const RPG = {
             draft: { active: false, round: 0, rerolls: 3, currentOptions: [] }
         };
 
-        // Transfer Pending Transcendence to Active State
-        this.state.activeTranscendenceCards = [...(this.global.pendingTranscendenceCards || [])];
-        this.global.pendingTranscendenceCards = [];
-        this.saveGlobalData();
+        // Transfer Pending Transcendence to Active State (Endless Only)
+        if (this.state.gameType === 'endless') {
+             this.state.activeTranscendenceCards = [...(this.global.pendingTranscendenceCards || [])];
+             this.global.pendingTranscendenceCards = [];
+             this.saveGlobalData();
+        } else {
+             this.state.activeTranscendenceCards = [];
+        }
 
         if (mode === 'chaos') {
             let allCards = [...CARDS];
@@ -2625,7 +2629,7 @@ const RPG = {
             }
 
             // Transcendence Ticket Logic (On Clear)
-            if (this.state.mode !== 'origin' && this.checkAllBonusUnlocked()) {
+            if (this.state.gameType === 'challenge' || (this.state.mode !== 'origin' && this.checkAllBonusUnlocked())) {
                  this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
                  this.saveGlobalData();
                  this.log("<b>[보너스]</b> 카오스 티켓 1장 획득!");


### PR DESCRIPTION
This patch updates the game initialization logic to strictly separate Transcendence Card usage between Challenge and Endless modes.

1.  **Challenge Mode:**
    *   Transcendence Cards are never loaded into the active state.
    *   The global pending queue is preserved (not cleared) so cards are saved for the next Endless run.
    *   Clearing Challenge mode now explicitly guarantees a Chaos Ticket reward.

2.  **Endless Mode:**
    *   Transcendence Cards are transferred from the global pending queue to the local active state.
    *   The global pending queue is cleared.
    *   Existing logic handles the mode-specific behavior:
        *   **Origin:** Adds to inventory, consumes on use.
        *   **Draft/Chaos:** Adds to respective random pools.

Verified via Playwright scripts simulating game state transitions and checking inventory contents.

---
*PR created automatically by Jules for task [14080687744891046918](https://jules.google.com/task/14080687744891046918) started by @romarin0325-cell*