### PR TITLE
feat: 아티팩트 모드 구현 (36 스테이지, 23종 아티팩트 추가)

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -5,9 +5,9 @@ const CARDS = [
         stats: { hp: 520, atk: 110, matk: 120, def: 70, mdef: 70 },
         trait: { type: 'syn_water_3_atk_matk', val: 50, desc: '덱에 물 3장일시 물리공격력 마법공격력 50% 증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '월광해류', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프 1개 제거하고 위력 2배', effects: [{type: 'remove_field_buff_dmg', mult: 2.0}] },
-            { name: '심연의포옹', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '적이 디버프 3개 이상일 때 위력 2배', effects: [{type: 'cond_target_debuff_3_dmg', mult: 2.0}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '월광해류', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프 1개 제거하고 위력 2배', effects: [{ type: 'remove_field_buff_dmg', mult: 2.0 }] },
+            { name: '심연의포옹', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '적이 디버프 3개 이상일 때 위력 2배', effects: [{ type: 'cond_target_debuff_3_dmg', mult: 2.0 }] }
         ]
     },
     {
@@ -15,9 +15,9 @@ const CARDS = [
         stats: { hp: 510, atk: 115, matk: 130, def: 60, mdef: 60 },
         trait: { type: 'normal_attack_burn_divine', desc: '일반공격시 적에게 작열, 디바인 부여' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '성염', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '필드버프 성역 상태에서 대미지 2배', effects: [{type: 'dmg_boost', condition: 'field_buff', buff: 'sanctuary', mult: 2.0}] },
-            { name: '영혼수확', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5}, {type: 'clear_target_debuffs'}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '성염', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '필드버프 성역 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'sanctuary', mult: 2.0 }] },
+            { name: '영혼수확', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{ type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5 }, { type: 'clear_target_debuffs' }] }
         ]
     },
     {
@@ -25,9 +25,9 @@ const CARDS = [
         stats: { hp: 440, atk: 90, matk: 95, def: 55, mdef: 55 },
         trait: { type: 'looter', desc: '이 카드로 승리시 추가 드로우' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '피날레', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '필드버프를 제거하고 제거한 수 x3.0 만큼 위력 증가', effects: [{type: 'consume_field_all', multPerStack: 3.0}] },
-            { name: '로열블룸', type: 'sup', tier: 2, cost: 20, desc: '필드버프 대지의축복 발동', effects: [{type: 'field_buff', id: 'earth_bless'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '피날레', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '필드버프를 제거하고 제거한 수 x3.0 만큼 위력 증가', effects: [{ type: 'consume_field_all', multPerStack: 3.0 }] },
+            { name: '로열블룸', type: 'sup', tier: 2, cost: 20, desc: '필드버프 대지의축복 발동', effects: [{ type: 'field_buff', id: 'earth_bless' }] }
         ]
     },
     {
@@ -35,9 +35,9 @@ const CARDS = [
         stats: { hp: 480, atk: 130, matk: 130, def: 60, mdef: 65 },
         trait: { type: 'cond_no_field_buff_eva_crit', val: 25, desc: '필드버프가 없을 시 회피율/치명타 25%증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '이클립스', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '암흑 상태의 적에게 대미지 2배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0}] },
-            { name: '다크메테오', type: 'mag', tier: 3, cost: 30, val: 4.5, desc: '다음 턴 행동 불가', effects: [{type: 'self_debuff', id: 'stun', duration: 1}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '이클립스', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '암흑 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0 }] },
+            { name: '다크메테오', type: 'mag', tier: 3, cost: 30, val: 4.5, desc: '다음 턴 행동 불가', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }] }
         ]
     },
     {
@@ -45,9 +45,9 @@ const CARDS = [
         stats: { hp: 540, atk: 125, matk: 95, def: 60, mdef: 60 },
         trait: { type: 'pos_stat_boost', pos: 2, stat: ['atk', 'matk'], val: 30, desc: '대장 배치시 공격력 마법공격력 30%증가' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '얼티밋브레스', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '작열스택 부여, 작열스택 하나당 1.0배율 추가', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'dmg_boost', condition: 'target_stack', debuff: 'burn', multPerStack: 1.0}] },
-            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '얼티밋브레스', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '작열스택 부여, 작열스택 하나당 1.0배율 추가', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'dmg_boost', condition: 'target_stack', debuff: 'burn', multPerStack: 1.0 }] },
+            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] }
         ]
     },
     {
@@ -55,9 +55,9 @@ const CARDS = [
         stats: { hp: 500, atk: 90, matk: 120, def: 80, mdef: 90 },
         trait: { type: 'syn_water_nature', desc: '덱에 물 자연이 있을 경우, 문라이트세레나에 트윙클파티 필드버프 추가발동' },
         skills: [
-            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{type: 'field_buff', id: 'star_powder'}] },
-            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] },
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] }
+            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{ type: 'field_buff', id: 'star_powder' }] },
+            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] }
         ]
     },
     {
@@ -65,9 +65,9 @@ const CARDS = [
         stats: { hp: 500, atk: 90, matk: 125, def: 70, mdef: 80 },
         trait: { type: 'cond_divine_3_dmg', val: 2.0, desc: '디바인 3스택 이상인 적에게 대미지 2배' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '더홀리', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 스택이 있을 시, 필드버프 성역 발동', effects: [{type: 'conditional_field_buff', condition: 'target_has_debuff', debuff: 'divine', id: 'sanctuary'}] },
-            { name: '여신강림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 여신강림 발동', effects: [{type: 'field_buff', id: 'goddess_descent'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '더홀리', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 스택이 있을 시, 필드버프 성역 발동', effects: [{ type: 'conditional_field_buff', condition: 'target_has_debuff', debuff: 'divine', id: 'sanctuary' }] },
+            { name: '여신강림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 여신강림 발동', effects: [{ type: 'field_buff', id: 'goddess_descent' }] }
         ]
     },
     {
@@ -75,9 +75,9 @@ const CARDS = [
         stats: { hp: 600, atk: 90, matk: 90, def: 60, mdef: 60 },
         trait: { type: 'syn_nature_3_all', val: 30, desc: '덱이 전부 자연일 시 공격/마공/방어/마방 30%증가' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '대지의분노', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '필드버프 대지의축복 발동', effects: [{type: 'field_buff', id: 'earth_bless'}] },
-            { name: '가이아포스', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '대지의분노', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '필드버프 대지의축복 발동', effects: [{ type: 'field_buff', id: 'earth_bless' }] },
+            { name: '가이아포스', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] }
         ]
     },
     {
@@ -85,9 +85,9 @@ const CARDS = [
         stats: { hp: 550, atk: 120, matk: 100, def: 65, mdef: 45 },
         trait: { type: 'death_field_sun', desc: '사망시 태양의축복 부여' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '이그니스스매시', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열스택을 전부 소모하고 소모당 2.0배율 추가', effects: [{type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0}] },
-            { name: '라그나로크', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '생명력 50% 아래에서 대미지 2배', effects: [{type: 'dmg_boost', condition: 'hp_below', val: 0.5, mult: 2.0}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '이그니스스매시', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열스택을 전부 소모하고 소모당 2.0배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0 }] },
+            { name: '라그나로크', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '생명력 50% 아래에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'hp_below', val: 0.5, mult: 2.0 }] }
         ]
     },
     {
@@ -95,9 +95,9 @@ const CARDS = [
         stats: { hp: 510, atk: 115, matk: 115, def: 65, mdef: 60 },
         trait: { type: 'pos_stat_boost', pos: 1, stat: 'matk', val: 30, desc: '중견 배치시 마공 30%증가' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '종언의예고', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '사용 후 3턴 뒤에 공격', effects: [{type: 'delayed_attack', turns: 3}] },
-            { name: '섀도우트위스트', type: 'sup', tier: 3, cost: 30, desc: '저주, 침묵, 암흑 부여', effects: [{type: 'debuff', id: 'curse'}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'darkness'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '종언의예고', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '사용 후 3턴 뒤에 공격', effects: [{ type: 'delayed_attack', turns: 3 }] },
+            { name: '섀도우트위스트', type: 'sup', tier: 3, cost: 30, desc: '저주, 침묵, 암흑 부여', effects: [{ type: 'debuff', id: 'curse' }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'darkness' }] }
         ]
     },
     {
@@ -105,9 +105,9 @@ const CARDS = [
         stats: { hp: 480, atk: 85, matk: 135, def: 70, mdef: 95 },
         trait: { type: 'death_dmg_debuff', val: 1.0, desc: '사망시 적에게 걸려있는 디버프 수 곱하기 1배율 대미지' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '블리자드', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '부식, 침묵, 약화, 저주 부여, 다음 턴 행동 불가', effects: [{type: 'debuff', id: 'corrosion'}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'weak'}, {type: 'debuff', id: 'curse'}, {type: 'self_debuff', id: 'stun', duration: 1}] },
-            { name: '프로스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '상대에게 적용된 디버프가 5개 이상일 시, 상대 스턴', effects: [{type: 'conditional_debuff', condition: 'target_debuff_count', count: 5, debuff: 'stun'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '블리자드', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '부식, 침묵, 약화, 저주 부여, 다음 턴 행동 불가', effects: [{ type: 'debuff', id: 'corrosion' }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'curse' }, { type: 'self_debuff', id: 'stun', duration: 1 }] },
+            { name: '프로스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '상대에게 적용된 디버프가 5개 이상일 시, 상대 스턴', effects: [{ type: 'conditional_debuff', condition: 'target_debuff_count', count: 5, debuff: 'stun' }] }
         ]
     },
     {
@@ -115,9 +115,9 @@ const CARDS = [
         stats: { hp: 560, atk: 115, matk: 90, def: 75, mdef: 55 },
         trait: { type: 'behemoth_trait', val: 1.5, desc: '적이 디버프 3개 이상일 때 대미지 1.5배 / 스킬 사용시 20%확률로 적에게 스턴부여' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '대지분쇄', type: 'phy', tier: 3, cost: 30, val: 3.5, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{type: 'self_debuff', id: 'stun', duration: 1}, {type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0, customLog: "대지의 축복으로 대지분쇄의 위력이 강력해집니다!"}] },
-            { name: '어스퀘이크', type: 'mag', tier: 3, cost: 30, val: 3.5, desc: '다음 턴에 공격 (시전자 사망 시 취소)', effects: [{type: 'delayed_attack', turns: 1}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '대지분쇄', type: 'phy', tier: 3, cost: 30, val: 3.5, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0, customLog: "대지의 축복으로 대지분쇄의 위력이 강력해집니다!" }] },
+            { name: '어스퀘이크', type: 'mag', tier: 3, cost: 30, val: 3.5, desc: '다음 턴에 공격 (시전자 사망 시 취소)', effects: [{ type: 'delayed_attack', turns: 1 }] }
         ]
     },
 
@@ -127,9 +127,9 @@ const CARDS = [
         stats: { hp: 400, atk: 75, matk: 100, def: 65, mdef: 75 },
         trait: { type: 'death_field_buff_count_dmg', val: 2.0, desc: '사망시 적용중인 필드버프수 x2배율 대미지' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '풍요의축제', type: 'sup', tier: 3, cost: 30, desc: '작열스택 소모시 태양의축복, 없을시 대지의축복', effects: [{type: 'consume_all_burn_cond_buff'}] },
-            { name: '태양의춤', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열 1스택 소모하여 대미지 2배', effects: [{type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '풍요의축제', type: 'sup', tier: 3, cost: 30, desc: '작열스택 소모시 태양의축복, 없을시 대지의축복', effects: [{ type: 'consume_all_burn_cond_buff' }] },
+            { name: '태양의춤', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0 }] }
         ]
     },
     {
@@ -137,9 +137,9 @@ const CARDS = [
         stats: { hp: 380, atk: 75, matk: 110, def: 60, mdef: 75 },
         trait: { type: 'syn_nature_3_matk', val: 50, desc: '자연속성 3덱일시 마법공격력 50%증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '러스트브리즈', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적에게 약화 혹은 부식 부여', effects: [{type: 'random_debuff', count: 1, pool: ['weak', 'corrosion']}] },
-            { name: '팬텀게일', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프 대지의축복이 있을시 적에게 저주와 침묵 부여', effects: [{type: 'conditional_field_debuff', field: 'earth_bless', debuffs: ['curse', 'silence']}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '러스트브리즈', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적에게 약화 혹은 부식 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['weak', 'corrosion'] }] },
+            { name: '팬텀게일', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프 대지의축복이 있을시 적에게 저주와 침묵 부여', effects: [{ type: 'conditional_field_debuff', field: 'earth_bless', debuffs: ['curse', 'silence'] }] }
         ]
     },
     {
@@ -147,8 +147,8 @@ const CARDS = [
         stats: { hp: 340, atk: 100, matk: 70, def: 60, mdef: 60 },
         trait: { type: 'looter', desc: '이 카드로 승리시 추가 드로우' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '암살', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '암흑 부여', effects: [{type: 'debuff', id: 'darkness'}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '암살', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] },
             { name: '어쌔신네일', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '2.5배 물리', effects: [] }
         ]
     },
@@ -157,9 +157,9 @@ const CARDS = [
         stats: { hp: 400, atk: 95, matk: 95, def: 60, mdef: 60 },
         trait: { type: 'cond_debuff_3_dmg', val: 1.5, desc: '적이 디버프 3개 이상시 주는 대미지 1.5배' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '데스핸드', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '적에게 걸린 디버프 1종당 0.5배율 추가', effects: [{type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 0.5}] },
-            { name: '데몬브레스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '암흑 부여', effects: [{type: 'debuff', id: 'darkness'}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '데스핸드', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '적에게 걸린 디버프 1종당 0.5배율 추가', effects: [{ type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 0.5 }] },
+            { name: '데몬브레스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] }
         ]
     },
     {
@@ -167,9 +167,9 @@ const CARDS = [
         stats: { hp: 420, atk: 105, matk: 80, def: 60, mdef: 50 },
         trait: { type: 'pos_stat_boost', pos: 0, stat: 'atk', val: 50, desc: '선봉일시 공격력 50%증가' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '파이어브레스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열스택 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}] },
-            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '파이어브레스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열스택 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] },
+            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] }
         ]
     },
     {
@@ -177,9 +177,9 @@ const CARDS = [
         stats: { hp: 370, atk: 80, matk: 115, def: 60, mdef: 80 },
         trait: { type: 'death_dmg_mag', val: 3.0, desc: '사망시 마법공격력 300%대미지' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '레인오브썬더', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인스택 전부 소모하고 1개당 2배율 추가', effects: [{type: 'consume_debuff_all', debuff: 'divine', multPerStack: 2.0}] },
-            { name: '썬더스톰', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적 디버프 1종당 0.5배율 추가', effects: [{type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 0.5}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '레인오브썬더', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인스택 전부 소모하고 1개당 2배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'divine', multPerStack: 2.0 }] },
+            { name: '썬더스톰', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적 디버프 1종당 0.5배율 추가', effects: [{ type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 0.5 }] }
         ]
     },
     {
@@ -187,9 +187,9 @@ const CARDS = [
         stats: { hp: 380, atk: 75, matk: 105, def: 65, mdef: 80 },
         trait: { type: 'syn_fire_3_crit', val: 30, desc: '덱에 불 3장일시 치명타 확률 30%증가' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '프로미넌스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열스택 추가', effects: [{type: 'debuff', id: 'burn', stack: 1}] },
-            { name: '태양의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 태양의축복 부여', effects: [{type: 'field_buff', id: 'sun_bless'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '프로미넌스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열스택 추가', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] },
+            { name: '태양의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 태양의축복 부여', effects: [{ type: 'field_buff', id: 'sun_bless' }] }
         ]
     },
     {
@@ -197,9 +197,9 @@ const CARDS = [
         stats: { hp: 410, atk: 95, matk: 90, def: 60, mdef: 60 },
         trait: { type: 'syn_water_3_ice_age', val: 0, desc: '덱에 물 3장일시 아이스에이지 최대배율 대폭 증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '빙하의일격', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '부식 부여', effects: [{type: 'debuff', id: 'corrosion'}] },
-            { name: '아이스에이지', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '1~5배율 사이로 랜덤공격 (특성 발동시 1~10배율)', effects: [{type: 'random_mult', min: 1.0, max: 5.0}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '빙하의일격', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
+            { name: '아이스에이지', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '1~5배율 사이로 랜덤공격 (특성 발동시 1~10배율)', effects: [{ type: 'random_mult', min: 1.0, max: 5.0 }] }
         ]
     },
     {
@@ -207,9 +207,9 @@ const CARDS = [
         stats: { hp: 400, atk: 70, matk: 95, def: 65, mdef: 80 },
         trait: { type: 'syn_light_dark_matk_mdef', val: 30, desc: '덱에 빛, 어둠이 있을 경우 마법공격력, 마법방어력 30%증가' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '성역전개', type: 'sup', tier: 2, cost: 20, desc: '필드버프 성역 발동 및 적에게 디바인 1스택 부여', effects: [{type: 'field_buff', id: 'sanctuary'}, {type: 'debuff', id: 'divine', stack: 1}] },
-            { name: '홀리레이', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '성역전개', type: 'sup', tier: 2, cost: 20, desc: '필드버프 성역 발동 및 적에게 디바인 1스택 부여', effects: [{ type: 'field_buff', id: 'sanctuary' }, { type: 'debuff', id: 'divine', stack: 1 }] },
+            { name: '홀리레이', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }] }
         ]
     },
     {
@@ -217,9 +217,9 @@ const CARDS = [
         stats: { hp: 420, atk: 85, matk: 85, def: 60, mdef: 60 },
         trait: { type: 'cond_silence_dmg', val: 1.5, desc: '침묵 걸린 적에게 대미지 1.5배' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '푸딩러쉬', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '약화 혹은 침묵 부여', effects: [{type: 'random_debuff', count: 1, pool: ['weak', 'silence']}] },
-            { name: '푸딩파라다이스', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '필드버프 스타파우더 부여', effects: [{type: 'field_buff', id: 'star_powder'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '푸딩러쉬', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '약화 혹은 침묵 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['weak', 'silence'] }] },
+            { name: '푸딩파라다이스', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '필드버프 스타파우더 부여', effects: [{ type: 'field_buff', id: 'star_powder' }] }
         ]
     },
     {
@@ -227,9 +227,9 @@ const CARDS = [
         stats: { hp: 390, atk: 80, matk: 100, def: 60, mdef: 75 },
         trait: { type: 'syn_dark_3_matk', val: 50, desc: '덱에 3장 어둠일시 마법공격력 50%증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '고스트소울', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인, 암흑 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}, {type: 'debuff', id: 'darkness'}] },
-            { name: '네더커스', type: 'sup', tier: 2, cost: 20, desc: '저주 침묵 약화 부식 중 랜덤 2종 부여', effects: [{type: 'random_debuff', count: 2, pool: ['curse', 'silence', 'weak', 'corrosion']}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '고스트소울', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인, 암흑 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'darkness' }] },
+            { name: '네더커스', type: 'sup', tier: 2, cost: 20, desc: '저주 침묵 약화 부식 중 랜덤 2종 부여', effects: [{ type: 'random_debuff', count: 2, pool: ['curse', 'silence', 'weak', 'corrosion'] }] }
         ]
     },
     {
@@ -237,9 +237,9 @@ const CARDS = [
         stats: { hp: 395, atk: 70, matk: 110, def: 60, mdef: 75 },
         trait: { type: 'death_debuff', debuff: 'stun', desc: '사망시 적에게 기절 부여' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '스피릿왈츠', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적이 디바인 3스택이면 스턴, 아니면 디바인 부여', effects: [{type: 'check_divine_3_stun_else_add'}] },
-            { name: '이터널위스퍼', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '랜덤 디버프 1개 (디바인 소모 시 2개)', effects: [{type: 'random_debuff_consume_divine'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '스피릿왈츠', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적이 디바인 3스택이면 스턴, 아니면 디바인 부여', effects: [{ type: 'check_divine_3_stun_else_add' }] },
+            { name: '이터널위스퍼', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '랜덤 디버프 1개 (디바인 소모 시 2개)', effects: [{ type: 'random_debuff_consume_divine' }] }
         ]
     },
 
@@ -249,9 +249,9 @@ const CARDS = [
         stats: { hp: 350, atk: 85, matk: 85, def: 65, mdef: 55 },
         trait: { type: 'death_debuff', debuff: 'stun', desc: '사망시 상대에게 스턴 부여' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '자장가', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '30%확률로 적에게 스턴 부여', effects: [{type: 'chance_debuff', id: 'stun', chance: 0.3, duration: 1}] },
-            { name: '솜사탕', type: 'mag', tier: 3, cost: 30, val: 1.5, desc: '필드버프 트윙클파티 부여', effects: [{type: 'field_buff', id: 'twinkle_party'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '자장가', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '30%확률로 적에게 스턴 부여', effects: [{ type: 'chance_debuff', id: 'stun', chance: 0.3, duration: 1 }] },
+            { name: '솜사탕', type: 'mag', tier: 3, cost: 30, val: 1.5, desc: '필드버프 트윙클파티 부여', effects: [{ type: 'field_buff', id: 'twinkle_party' }] }
         ]
     },
     {
@@ -259,9 +259,9 @@ const CARDS = [
         stats: { hp: 310, atk: 80, matk: 70, def: 55, mdef: 45 },
         trait: { type: 'looter', desc: '이 카드로 승리시 추가 드로우' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '베이비브레스', type: 'mag', tier: 1, cost: 10, val: 1.5, desc: '작열부여', effects: [{type: 'debuff', id: 'burn', stack: 1}] },
-            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '베이비브레스', type: 'mag', tier: 1, cost: 10, val: 1.5, desc: '작열부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] },
+            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] }
         ]
     },
     {
@@ -269,8 +269,8 @@ const CARDS = [
         stats: { hp: 320, atk: 75, matk: 105, def: 50, mdef: 70 },
         trait: { type: 'pos_stat_boost', pos: 0, stat: 'matk', val: 50, desc: '선봉배치시 마법공격력 50%증가' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '카오스카니발', type: 'mag', tier: 3, cost: 30, val: 6.0, desc: '이 카드는 사망한다', effects: [{type: 'suicide'}] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '카오스카니발', type: 'mag', tier: 3, cost: 30, val: 6.0, desc: '이 카드는 사망한다', effects: [{ type: 'suicide' }] },
             { name: '다크니스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '2배 마법', effects: [] }
         ]
     },
@@ -279,9 +279,9 @@ const CARDS = [
         stats: { hp: 360, atk: 100, matk: 70, def: 55, mdef: 40 },
         trait: { type: 'pos_stat_boost', pos: 2, stat: ['def', 'mdef'], val: 30, desc: '대장 배치시 방어력/마법방어력 30%증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '프로스트팽', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '부식부여', effects: [{type: 'debuff', id: 'corrosion'}] },
-            { name: '윈터하울링', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '달의축복 상태에서 대미지 2.5배', effects: [{type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.5, customLog: "윈터하울링: 달의 축복 조건 만족! 대미지 증가!"}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '프로스트팽', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '부식부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
+            { name: '윈터하울링', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '달의축복 상태에서 대미지 2.5배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.5, customLog: "윈터하울링: 달의 축복 조건 만족! 대미지 증가!" }] }
         ]
     },
     {
@@ -289,9 +289,9 @@ const CARDS = [
         stats: { hp: 330, atk: 90, matk: 80, def: 55, mdef: 60 },
         trait: { type: 'syn_snow_rabbit', val: 50, desc: '눈토끼 혹은 은토끼가 덱에 있을시 물공 물방 50% 증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '깡총깡총', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '어둠 상태시 대미지 2배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0}] },
-            { name: '문라이트', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '달의축복 상태에서 대미지 2.5배', effects: [{type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.5}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '깡총깡총', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '어둠 상태시 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0 }] },
+            { name: '문라이트', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '달의축복 상태에서 대미지 2.5배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.5 }] }
         ]
     },
     {
@@ -299,9 +299,9 @@ const CARDS = [
         stats: { hp: 350, atk: 65, matk: 90, def: 55, mdef: 60 },
         trait: { type: 'pos_stat_boost', pos: 1, stat: 'matk', val: 30, desc: '중견 배치시 마법공격력 30%증가' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 부여', effects: [{type: 'field_buff', id: 'moon_bless'}] },
-            { name: '선라이트플레임', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열스택 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 부여', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
+            { name: '선라이트플레임', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열스택 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
         ]
     },
     {
@@ -309,9 +309,9 @@ const CARDS = [
         stats: { hp: 340, atk: 75, matk: 85, def: 60, mdef: 60 },
         trait: { type: 'cond_twinkle_all', val: 30, desc: '트윙클파티 상태에서 물리/마법공격력 30%증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '크림샷', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}] },
-            { name: '크림익스플로전', type: 'mag', tier: 2, cost: 20, val: 1.0, desc: '필드버프 스타파우더 부여', effects: [{type: 'field_buff', id: 'star_powder'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '크림샷', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }] },
+            { name: '크림익스플로전', type: 'mag', tier: 2, cost: 20, val: 1.0, desc: '필드버프 스타파우더 부여', effects: [{ type: 'field_buff', id: 'star_powder' }] }
         ]
     },
     {
@@ -319,9 +319,9 @@ const CARDS = [
         stats: { hp: 385, atk: 75, matk: 55, def: 80, mdef: 40 },
         trait: { type: 'syn_nature_3_golem', val: 30, desc: '덱에 자연 3장일시 공격력 방어력 30%증가' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '차지어택', type: 'phy', tier: 2, cost: 20, val: 2.5, desc: '다음턴 휴식 (대지의축복 시 2배)', effects: [{type: 'self_debuff', id: 'stun', duration: 1}, {type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0}] },
-            { name: '록스매시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '약화 부여', effects: [{type: 'debuff', id: 'weak'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '차지어택', type: 'phy', tier: 2, cost: 20, val: 2.5, desc: '다음턴 휴식 (대지의축복 시 2배)', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] },
+            { name: '록스매시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '약화 부여', effects: [{ type: 'debuff', id: 'weak' }] }
         ]
     },
     {
@@ -329,9 +329,9 @@ const CARDS = [
         stats: { hp: 360, atk: 100, matk: 50, def: 60, mdef: 55 },
         trait: { type: 'cond_corrosion_dmg', val: 1.5, desc: '부식상태의 적에게 대미지 1.5배' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '강타', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리', effects: [] },
-            { name: '급소베기', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '저주 부여', effects: [{type: 'debuff', id: 'curse'}] }
+            { name: '급소베기', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '저주 부여', effects: [{ type: 'debuff', id: 'curse' }] }
         ]
     },
     {
@@ -339,9 +339,9 @@ const CARDS = [
         stats: { hp: 350, atk: 80, matk: 80, def: 50, mdef: 60 },
         trait: { type: 'pos_van_atk', val: 30, desc: '선봉 배치시 공격력 30%증가' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '샌드스톰', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '부식 저주 중 하나 부여', effects: [{type: 'random_debuff', count: 1, pool: ['corrosion', 'curse']}] },
-            { name: '수수께끼', type: 'sup', tier: 1, cost: 10, desc: '침묵 부여', effects: [{type: 'debuff', id: 'silence'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '샌드스톰', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '부식 저주 중 하나 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['corrosion', 'curse'] }] },
+            { name: '수수께끼', type: 'sup', tier: 1, cost: 10, desc: '침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] }
         ]
     },
     {
@@ -349,9 +349,9 @@ const CARDS = [
         stats: { hp: 330, atk: 70, matk: 95, def: 55, mdef: 75 },
         trait: { type: 'death_dmg_mag', val: 2.0, desc: '사망시 적에게 200% 마법대미지' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '사일런트', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{type: 'debuff', id: 'silence'}] },
-            { name: '위크니스', type: 'sup', tier: 1, cost: 10, desc: '약화 부여', effects: [{type: 'debuff', id: 'weak'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '사일런트', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] },
+            { name: '위크니스', type: 'sup', tier: 1, cost: 10, desc: '약화 부여', effects: [{ type: 'debuff', id: 'weak' }] }
         ]
     },
     {
@@ -359,9 +359,9 @@ const CARDS = [
         stats: { hp: 345, atk: 80, matk: 80, def: 55, mdef: 65 },
         trait: { type: 'death_debuff', debuff: 'darkness', desc: '사망시 암흑 부여' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '미라지프레임', type: 'mag', tier: 3, cost: 30, val: 1.5, desc: '작열, 약화 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'debuff', id: 'weak'}] },
-            { name: '팬텀러쉬', type: 'phy', tier: 3, cost: 30, val: 1.5, desc: '작열, 저주 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'debuff', id: 'curse'}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '미라지프레임', type: 'mag', tier: 3, cost: 30, val: 1.5, desc: '작열, 약화 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'weak' }] },
+            { name: '팬텀러쉬', type: 'phy', tier: 3, cost: 30, val: 1.5, desc: '작열, 저주 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'curse' }] }
         ]
     },
 
@@ -371,9 +371,9 @@ const CARDS = [
         stats: { hp: 310, atk: 75, matk: 70, def: 50, mdef: 50 },
         trait: { type: 'death_sun_bless_chance', val: 0.3, desc: '사망시 30%확률로 태양의축복 부여' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '기습', type: 'phy', tier: 1, cost: 10, val: 1.5, desc: '1.5배 물리', effects: [] },
-            { name: '멜팅허그', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적에게 작열 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}] }
+            { name: '멜팅허그', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '적에게 작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
         ]
     },
     {
@@ -381,7 +381,7 @@ const CARDS = [
         stats: { hp: 270, atk: 75, matk: 55, def: 40, mdef: 40 },
         trait: { type: 'looter', desc: '이 카드로 승리시 추가 드로우' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '기습', type: 'phy', tier: 1, cost: 10, val: 1.5, desc: '1.5배 물리', effects: [] },
             { name: '강타', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리', effects: [] }
         ]
@@ -391,8 +391,8 @@ const CARDS = [
         stats: { hp: 330, atk: 80, matk: 50, def: 55, mdef: 35 },
         trait: { type: 'pos_rear_atk', val: 30, desc: '대장 배치시 공격력 30%증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '베어러쉬', type: 'phy', tier: 1, cost: 10, val: 1.0, desc: '상대가 약화시 3배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'weak', mult: 3.0}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '베어러쉬', type: 'phy', tier: 1, cost: 10, val: 1.0, desc: '상대가 약화시 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'weak', mult: 3.0 }] },
             { name: '강타', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리', effects: [] }
         ]
     },
@@ -401,8 +401,8 @@ const CARDS = [
         stats: { hp: 300, atk: 55, matk: 80, def: 45, mdef: 55 },
         trait: { type: 'cond_silence_dmg', val: 1.5, desc: '침묵상태 적에게 대미지 1.5배' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '블러드드레인', type: 'mag', tier: 1, cost: 10, val: 1.0, desc: '상대가 저주시 3배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'curse', mult: 3.0}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '블러드드레인', type: 'mag', tier: 1, cost: 10, val: 1.0, desc: '상대가 저주시 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'curse', mult: 3.0 }] },
             { name: '다크니스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '2배 마법', effects: [] }
         ]
     },
@@ -411,9 +411,9 @@ const CARDS = [
         stats: { hp: 290, atk: 60, matk: 85, def: 40, mdef: 60 },
         trait: { type: 'syn_night_rabbit', val: 50, desc: '밤토끼 혹은 은토끼가 덱에 있을시 마공 마방 50% 증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '스노우샷', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '부식 부여', effects: [{type: 'debuff', id: 'corrosion'}] },
-            { name: '실버스톰', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '밤토끼/은토끼 시너지 발동 중 대미지 2배', effects: [{type: 'dmg_boost', condition: 'synergy_active', trait: 'syn_night_rabbit', mult: 2.0}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '스노우샷', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
+            { name: '실버스톰', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '밤토끼/은토끼 시너지 발동 중 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'synergy_active', trait: 'syn_night_rabbit', mult: 2.0 }] }
         ]
     },
     {
@@ -421,9 +421,9 @@ const CARDS = [
         stats: { hp: 300, atk: 70, matk: 70, def: 60, mdef: 60 },
         trait: { type: 'syn_silver_rabbit', val: 50, desc: '눈토끼 혹은 밤토끼가 덱에 있을시 물공 마공 50% 증가' },
         skills: [
-            { name: '헤븐리루어', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '특성 발동 중 대미지 2배', effects: [{type: 'dmg_boost', condition: 'synergy_active', trait: 'syn_silver_rabbit', mult: 2.0}] },
-            { name: '깡총깡총', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '어둠 상태시 대미지 2배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0}] },
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] }
+            { name: '헤븐리루어', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '특성 발동 중 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'synergy_active', trait: 'syn_silver_rabbit', mult: 2.0 }] },
+            { name: '깡총깡총', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '어둠 상태시 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0 }] },
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] }
         ]
     },
     {
@@ -431,9 +431,9 @@ const CARDS = [
         stats: { hp: 300, atk: 55, matk: 75, def: 45, mdef: 60 },
         trait: { type: 'pos_stat_boost', pos: 0, stat: 'mdef', val: 20, desc: '선봉 배치시 마방 20%증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '에너지볼', type: 'mag', tier: 1, cost: 10, val: 1.5, desc: '디바인 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}] },
-            { name: '스타파우더', type: 'sup', tier: 2, cost: 20, desc: '필드버프 스타파우더 발동', effects: [{type: 'field_buff', id: 'star_powder'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '에너지볼', type: 'mag', tier: 1, cost: 10, val: 1.5, desc: '디바인 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }] },
+            { name: '스타파우더', type: 'sup', tier: 2, cost: 20, desc: '필드버프 스타파우더 발동', effects: [{ type: 'field_buff', id: 'star_powder' }] }
         ]
     },
     {
@@ -441,9 +441,9 @@ const CARDS = [
         stats: { hp: 310, atk: 65, matk: 70, def: 50, mdef: 50 },
         trait: { type: 'syn_light_fire_atk', val: 30, desc: '덱에 빛 불이 있을시 공격 30%증가' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '캔디버스트', type: 'mag', tier: 1, cost: 10, val: 1.5, desc: '작열 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}] },
-            { name: '캔디파라다이스', type: 'sup', tier: 2, cost: 20, desc: '필드버프 트윙클파티 발동', effects: [{type: 'field_buff', id: 'twinkle_party'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '캔디버스트', type: 'mag', tier: 1, cost: 10, val: 1.5, desc: '작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] },
+            { name: '캔디파라다이스', type: 'sup', tier: 2, cost: 20, desc: '필드버프 트윙클파티 발동', effects: [{ type: 'field_buff', id: 'twinkle_party' }] }
         ]
     },
     {
@@ -451,8 +451,8 @@ const CARDS = [
         stats: { hp: 340, atk: 60, matk: 60, def: 45, mdef: 45 },
         trait: { type: 'pos_stat_boost', pos: 1, stat: 'def', val: 30, desc: '중견 배치시 방어 30%증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '산성액', type: 'mag', tier: 1, cost: 10, val: 1.0, desc: '부식부여', effects: [{type: 'debuff', id: 'corrosion'}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '산성액', type: 'mag', tier: 1, cost: 10, val: 1.0, desc: '부식부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
             { name: '강타', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리', effects: [] }
         ]
     },
@@ -461,9 +461,9 @@ const CARDS = [
         stats: { hp: 320, atk: 70, matk: 50, def: 65, mdef: 40 },
         trait: { type: 'pos_stat_boost', pos: 1, stat: 'mdef', val: 30, desc: '중견 배치시 마방 30%증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '기습', type: 'phy', tier: 1, cost: 10, val: 1.5, desc: '1.5배 물리', effects: [] },
-            { name: '바인드', type: 'sup', tier: 1, cost: 10, desc: '저주 부여', effects: [{type: 'debuff', id: 'curse'}] }
+            { name: '바인드', type: 'sup', tier: 1, cost: 10, desc: '저주 부여', effects: [{ type: 'debuff', id: 'curse' }] }
         ]
     },
     {
@@ -471,7 +471,7 @@ const CARDS = [
         stats: { hp: 310, atk: 70, matk: 70, def: 50, mdef: 45 },
         trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
             { name: '기습', type: 'phy', tier: 1, cost: 10, val: 1.5, desc: '1.5배 물리', effects: [] },
             { name: '다크니스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '2배 마법', effects: [] }
         ]
@@ -481,9 +481,9 @@ const CARDS = [
         stats: { hp: 290, atk: 55, matk: 75, def: 50, mdef: 60 },
         trait: { type: 'pos_stat_boost', pos: 0, stat: 'matk', val: 20, desc: '선봉 배치시 마공 20%증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '저주의불꽃', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 부여', effects: [{type: 'debuff', id: 'curse'}] },
-            { name: '침묵의불꽃', type: 'sup', tier: 1, cost: 10, desc: '침묵, 작열 부여', effects: [{type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'burn', stack: 1}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '저주의불꽃', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 부여', effects: [{ type: 'debuff', id: 'curse' }] },
+            { name: '침묵의불꽃', type: 'sup', tier: 1, cost: 10, desc: '침묵, 작열 부여', effects: [{ type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'burn', stack: 1 }] }
         ]
     },
     {
@@ -491,9 +491,9 @@ const CARDS = [
         stats: { hp: 280, atk: 70, matk: 70, def: 45, mdef: 45 },
         trait: { type: 'joker_wild', desc: '이 카드는 모든 속성, 모든 이름으로 취급' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '레인보우룰렛', type: 'sup', tier: 10, cost: 100, desc: '모든 필드버프 교체', effects: [{type: 'roulette_field'}] },
-            { name: '와일드카드', type: 'sup', tier: 10, cost: 100, desc: '적의 디버프를 모두 제거하고 랜덤 디버프 2종 부여', effects: [{type: 'wild_card_debuff'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '레인보우룰렛', type: 'sup', tier: 10, cost: 100, desc: '모든 필드버프 교체', effects: [{ type: 'roulette_field' }] },
+            { name: '와일드카드', type: 'sup', tier: 10, cost: 100, desc: '적의 디버프를 모두 제거하고 랜덤 디버프 2종 부여', effects: [{ type: 'wild_card_debuff' }] }
         ]
     }
 ];
@@ -504,9 +504,9 @@ const BONUS_CARDS = [
         stats: { hp: 510, atk: 130, matk: 90, def: 75, mdef: 70 },
         trait: { type: 'syn_fire_3_crit_burn', val: 50, desc: '덱에 불 3장 이상 시 치명타율 50% 증가 / 일반 공격 시 작열 부여' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '메테오임팩트', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '필드버프 트윙클파티 발동', effects: [{type: 'field_buff', id: 'twinkle_party'}] },
-            { name: '샤이닝플레임', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '필드버프 태양의축복 발동', effects: [{type: 'field_buff', id: 'sun_bless'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '메테오임팩트', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '필드버프 트윙클파티 발동', effects: [{ type: 'field_buff', id: 'twinkle_party' }] },
+            { name: '샤이닝플레임', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '필드버프 태양의축복 발동', effects: [{ type: 'field_buff', id: 'sun_bless' }] }
         ]
     },
     {
@@ -514,9 +514,9 @@ const BONUS_CARDS = [
         stats: { hp: 400, atk: 55, matk: 105, def: 80, mdef: 80 },
         trait: { type: 'syn_dark_3_matk_boost', val: 100, desc: '덱에 어둠 3장 이상 시 마법공격력 100% 증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '사신강림', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '5턴 뒤 발동, 발동 시 필드버프 사신강림 부여', effects: [{type: 'delayed_attack_field', turns: 5, field: 'reaper_realm'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '사신강림', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '5턴 뒤 발동, 발동 시 필드버프 사신강림 부여', effects: [{ type: 'delayed_attack_field', turns: 5, field: 'reaper_realm' }] }
         ]
     },
     {
@@ -524,9 +524,9 @@ const BONUS_CARDS = [
         stats: { hp: 480, atk: 145, matk: 125, def: 65, mdef: 65 },
         trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '영혼절단', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~10배율)', effects: [{type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 10.0}] },
-            { name: '차원절단', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '2턴 뒤 발동, 3~6배율 랜덤 공격', effects: [{type: 'delayed_random_attack', turns: 2, min: 3.0, max: 6.0}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '영혼절단', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~10배율)', effects: [{ type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 10.0 }] },
+            { name: '차원절단', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '2턴 뒤 발동, 3~6배율 랜덤 공격', effects: [{ type: 'delayed_random_attack', turns: 2, min: 3.0, max: 6.0 }] }
         ]
     },
     {
@@ -534,9 +534,9 @@ const BONUS_CARDS = [
         stats: { hp: 360, atk: 90, matk: 65, def: 65, mdef: 70 },
         trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '홀리차지', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}] },
-            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '홀리차지', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }] },
+            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] }
         ]
     },
     {
@@ -544,9 +544,9 @@ const BONUS_CARDS = [
         stats: { hp: 370, atk: 100, matk: 75, def: 45, mdef: 55 },
         trait: { type: 'death_twinkle', desc: '사망 시 필드버프 트윙클파티 발동' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '섀도우러쉬', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 부여', effects: [{type: 'debuff', id: 'weak'}] },
-            { name: '헬바이트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 모두 소모, 소모한 개수당 2.0배율 추가', effects: [{type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '섀도우러쉬', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 부여', effects: [{ type: 'debuff', id: 'weak' }] },
+            { name: '헬바이트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 모두 소모, 소모한 개수당 2.0배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0 }] }
         ]
     },
     {
@@ -554,9 +554,9 @@ const BONUS_CARDS = [
         stats: { hp: 345, atk: 60, matk: 95, def: 60, mdef: 75 },
         trait: { type: 'syn_water_2_moon_twinkle', desc: '덱에 물 2장 이상 시, 실버문베일 발동 시 트윙클파티 추가 발동' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] },
-            { name: '타이달스크림', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{type: 'debuff', id: 'silence'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
+            { name: '타이달스크림', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] }
         ]
     },
     {
@@ -564,9 +564,9 @@ const BONUS_CARDS = [
         stats: { hp: 300, atk: 85, matk: 50, def: 55, mdef: 55 },
         trait: { type: 'death_debuff', debuff: 'darkness', desc: '사망 시 암흑 부여' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '사일런트스텝', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '반드시 치명타로 적중', effects: [{type: 'force_crit'}] },
-            { name: '베놈슬래시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '부식 부여', effects: [{type: 'debuff', id: 'corrosion'}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '사일런트스텝', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '반드시 치명타로 적중', effects: [{ type: 'force_crit' }] },
+            { name: '베놈슬래시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] }
         ]
     },
     {
@@ -574,9 +574,9 @@ const BONUS_CARDS = [
         stats: { hp: 400, atk: 100, matk: 80, def: 80, mdef: 60 },
         trait: { type: 'cond_earth_def_mdef', val: 50, desc: '대지의축복 상태에서 방어력/마법방어력 50% 증가' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '그랜드슬램', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 생명력이 50% 이하일 때 위력 2배', effects: [{type: 'dmg_boost', condition: 'target_hp_below', val: 0.5, mult: 2.0}] },
-            { name: '스포어미스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '자신의 생명력이 25% 이하일 때 위력 4배', effects: [{type: 'dmg_boost', condition: 'hp_below', val: 0.25, mult: 4.0}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '그랜드슬램', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 생명력이 50% 이하일 때 위력 2배', effects: [{ type: 'dmg_boost', condition: 'target_hp_below', val: 0.5, mult: 2.0 }] },
+            { name: '스포어미스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '자신의 생명력이 25% 이하일 때 위력 4배', effects: [{ type: 'dmg_boost', condition: 'hp_below', val: 0.25, mult: 4.0 }] }
         ]
     },
     {
@@ -584,9 +584,9 @@ const BONUS_CARDS = [
         stats: { hp: 340, atk: 65, matk: 100, def: 55, mdef: 60 },
         trait: { type: 'cond_darkness_dmg', val: 1.5, desc: '암흑 상태의 적에게 대미지 1.5배' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '다크레이', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 1스택 소모하여 대미지 2배', effects: [{type: 'consume_debuff_fixed', debuff: 'divine', count: 1, mult: 2.0}] },
-            { name: '타락의낙인', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '디바인 1스택 소모하고 암흑 부여', effects: [{type: 'consume_divine_add_darkness'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '다크레이', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'divine', count: 1, mult: 2.0 }] },
+            { name: '타락의낙인', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '디바인 1스택 소모하고 암흑 부여', effects: [{ type: 'consume_divine_add_darkness' }] }
         ]
     },
     {
@@ -594,9 +594,9 @@ const BONUS_CARDS = [
         stats: { hp: 490, atk: 110, matk: 120, def: 75, mdef: 75 },
         trait: { type: 'ignore_def_mdef_by_stack', val: 0.1, desc: '작열 1스택당 방어력 10% 무시 / 디바인 1스택당 마법방어력 10% 무시' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '크리스탈킥', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 부여 및 약화/부식 중 하나 추가 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'random_debuff', count: 1, pool: ['weak', 'corrosion']}] },
-            { name: '미드나잇스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인 부여 및 침묵/저주 중 하나 추가 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}, {type: 'random_debuff', count: 1, pool: ['silence', 'curse']}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '크리스탈킥', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 부여 및 약화/부식 중 하나 추가 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'random_debuff', count: 1, pool: ['weak', 'corrosion'] }] },
+            { name: '미드나잇스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인 부여 및 침묵/저주 중 하나 추가 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'random_debuff', count: 1, pool: ['silence', 'curse'] }] }
         ]
     },
     {
@@ -604,9 +604,9 @@ const BONUS_CARDS = [
         stats: { hp: 300, atk: 80, matk: 70, def: 50, mdef: 50 },
         trait: { type: 'death_debuff', debuff: 'weak', desc: '사망 시 적에게 약화 부여' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '제트슬라이드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '기절한 적에게 대미지 5배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 5.0}] },
-            { name: '콜드웨이크', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 혹은 침묵 부여', effects: [{type: 'random_debuff', count: 1, pool: ['curse', 'silence']}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '제트슬라이드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '기절한 적에게 대미지 5배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 5.0 }] },
+            { name: '콜드웨이크', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 혹은 침묵 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['curse', 'silence'] }] }
         ]
     }
 ];
@@ -626,7 +626,7 @@ const ENEMIES = [
         skills: [
             { name: '홀리레이', type: 'mag', rate: 0.3, val: 2.0, desc: '2배 마법 피해', effects: [] },
             { name: '더홀리', type: 'mag', rate: 0.1, val: 3.5, desc: '3.5배 마법 피해', effects: [] },
-            { name: '소울드레인', type: 'mag', rate: 0.0, val: 0, desc: '7턴째 마나 제거', effects: [{type: 'mana_burn', val: 100}] }
+            { name: '소울드레인', type: 'mag', rate: 0.0, val: 0, desc: '7턴째 마나 제거', effects: [{ type: 'mana_burn', val: 100 }] }
         ]
     },
     {
@@ -671,9 +671,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 560, atk: 125, matk: 125, def: 70, mdef: 70 },
         trait: { type: 'pos_stat_boost', pos: 1, stat: ['matk', 'mdef'], val: 30, desc: '중견 배치시 마법공격력 마법방어력 30%증가' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '이터널리와인드', type: 'sup', tier: 3, cost: 30, desc: '적에게 저주, 침묵, 암흑, 스턴 부여', effects: [{type: 'debuff', id: 'curse'}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'darkness'}, {type: 'debuff', id: 'stun', duration: 1}] },
-            { name: '인과역전', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '사용 후 3턴 뒤에 공격 (발동시점 턴 수 x0.5 배율 추가 대미지)', effects: [{type: 'delayed_turn_scale_attack', turns: 3, scale: 0.5}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '이터널리와인드', type: 'sup', tier: 3, cost: 30, desc: '적에게 저주, 침묵, 암흑, 스턴 부여', effects: [{ type: 'debuff', id: 'curse' }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'darkness' }, { type: 'debuff', id: 'stun', duration: 1 }] },
+            { name: '인과역전', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '사용 후 3턴 뒤에 공격 (발동시점 턴 수 x0.5 배율 추가 대미지)', effects: [{ type: 'delayed_turn_scale_attack', turns: 3, scale: 0.5 }] }
         ]
     },
     {
@@ -681,9 +681,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 540, atk: 120, matk: 135, def: 80, mdef: 80 },
         trait: { type: 'ignore_def_mdef_by_stack', val: 0.15, desc: '작열 1스택당 방어력 15% 무시 / 디바인 1스택당 마법방어력 15% 무시' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '샤터링비트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열, 약화, 부식 부여', effects: [{type: 'debuff', id: 'burn', stack: 1}, {type: 'debuff', id: 'weak'}, {type: 'debuff', id: 'corrosion'}] },
-            { name: '미라클스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 침묵, 저주 부여', effects: [{type: 'debuff', id: 'divine', stack: 1}, {type: 'debuff', id: 'silence'}, {type: 'debuff', id: 'curse'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '샤터링비트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열, 약화, 부식 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'corrosion' }] },
+            { name: '미라클스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 침묵, 저주 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'curse' }] }
         ]
     },
     {
@@ -691,9 +691,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 540, atk: 90, matk: 140, def: 90, mdef: 100 },
         trait: { type: 'cosmic_harmony_random_buff', desc: '코스믹하모니 사용시 태양의축복, 달의축복, 스타파우더 중 랜덤한 필드버프 생성' },
         skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] },
-            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [{type: 'random_field_buff_lumi'}] },
-            { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '모든 버프를 제거하고 꿈의마법발동.', effects: [{type: 'dream_form_execute'}] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [{ type: 'random_field_buff_lumi' }] },
+            { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '모든 버프를 제거하고 꿈의마법발동.', effects: [{ type: 'dream_form_execute' }] }
         ]
     },
     {
@@ -701,9 +701,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 530, atk: 130, matk: 150, def: 70, mdef: 70 },
         trait: { type: 'luna_jasmine_trait', val: 2.0, desc: '디바인 3스택 이상인 적에게 대미지 2배 / 여신강림 상태에서 회피율/치명타 25% 증가' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '여신강림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 여신강림 발동', effects: [{type: 'field_buff', id: 'goddess_descent'}] },
-            { name: '루나블레이드', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '암흑 상태의 적에게 대미지 2배', effects: [{type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '여신강림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 여신강림 발동', effects: [{ type: 'field_buff', id: 'goddess_descent' }] },
+            { name: '루나블레이드', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '암흑 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0 }] }
         ]
     },
     {
@@ -711,9 +711,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 530, atk: 150, matk: 135, def: 75, mdef: 75 },
         trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{type: 'buff', id: 'evasion', duration: 1}] },
-            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~12배율)', effects: [{type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 12.0}] },
-            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{type: 'turn_modulo_dmg', mod: 4, mult: 2.0}, {type: 'force_crit_chance', val: 40}] }
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~12배율)', effects: [{ type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 12.0 }] },
+            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{ type: 'turn_modulo_dmg', mod: 4, mult: 2.0 }, { type: 'force_crit_chance', val: 40 }] }
         ]
     },
     {
@@ -721,9 +721,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 620, atk: 120, matk: 100, def: 85, mdef: 65 },
         trait: { type: 'behemoth_liberated_trait', val: 1.5, desc: '적이 디버프 3개 이상일 때 대미지 1.5배 / 스킬 사용 시 20% 확률로 적에게 스턴 부여' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '월드브레이커', type: 'phy', tier: 3, cost: 30, val: 4.0, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{type: 'self_debuff', id: 'stun', duration: 1}, {type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0}] },
-            { name: '제로그라비티', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '다음 턴에 공격 (적에게 걸린 디버프 1종당 0.5배율 추가)', effects: [{type: 'delayed_attack_debuff_scale', turns: 1, multPerDebuff: 0.5}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '월드브레이커', type: 'phy', tier: 3, cost: 30, val: 4.0, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] },
+            { name: '제로그라비티', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '다음 턴에 공격 (적에게 걸린 디버프 1종당 0.5배율 추가)', effects: [{ type: 'delayed_attack_debuff_scale', turns: 1, multPerDebuff: 0.5 }] }
         ]
     },
     {
@@ -731,9 +731,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 560, atk: 120, matk: 120, def: 75, mdef: 75 },
         trait: { type: 'all_advantage', desc: '이 카드는 모든 적에게 상성 유리 대미지를 준다.' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{type: 'buff', id: 'guard', duration: 1}] },
-            { name: '프리즘브레이커', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '덱에 포함된 속성 수 만큼 추가배율 (조커는 5속성 취급)', effects: [{type: 'count_deck_attr_dmg'}] },
-            { name: '데스티니룰렛', type: 'sup', tier: 2, cost: 20, desc: '랜덤 스킬 발동', effects: [{type: 'random_skill_trigger_from_list'}] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '프리즘브레이커', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '덱에 포함된 속성 수 만큼 추가배율 (조커는 5속성 취급)', effects: [{ type: 'count_deck_attr_dmg' }] },
+            { name: '데스티니룰렛', type: 'sup', tier: 2, cost: 20, desc: '랜덤 스킬 발동', effects: [{ type: 'random_skill_trigger_from_list' }] }
         ]
     },
     {
@@ -741,9 +741,9 @@ const TRANSCENDENCE_CARDS = [
         stats: { hp: 540, atk: 115, matk: 115, def: 95, mdef: 95 },
         trait: { type: 'rabbit_synergy_boost', val: 50, desc: '자신 덱에 있는 토끼의 수 만큼 공격 마공이 50%증가' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{type: 'buff', id: 'barrier', duration: 1}] },
-            { name: '홍련각', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모하여 대미지 2배', effects: [{type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0}] },
-            { name: '천화낙영', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5}, {type: 'clear_target_debuffs'}] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '홍련각', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0 }] },
+            { name: '천화낙영', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{ type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5 }, { type: 'clear_target_debuffs' }] }
         ]
     }
 ];
@@ -756,5 +756,6 @@ const BUFF_NAMES = {
     'sun_bless': '태양의축복', 'moon_bless': '달의축복', 'sanctuary': '성역',
     'goddess_descent': '여신강림', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',
     'star_powder': '스타파우더',
-    'reaper_realm': '사신강림'
+    'reaper_realm': '사신강림',
+    'gale': '질풍'
 };

--- a/card/game.js
+++ b/card/game.js
@@ -94,10 +94,12 @@ const GAME_CONSTANTS = {
         flood: 10,
         curse: 10,
         chaos: 0,
-        draft: 5
+        draft: 5,
+        artifact: 10
     },
     DECK_SIZE: 3,
     MAX_RECORDS: 5,
+    MAX_ARTIFACTS: 4,
     SAGE_BLESSING_PICK_COUNT: 12,
 
     // Costs
@@ -128,7 +130,8 @@ const GAME_CONSTANTS = {
         'earth_bless': { atk: 0.25, matk: 0.25 },
         'twinkle_party': { atk: 0.2, crit: 15 },
         'star_powder': { def: 0.4, mdef: 0.4 },
-        'reaper_realm': { crit: 40 }
+        'reaper_realm': { crit: 40 },
+        'gale': { crit: 20, evasion: 20 }
     }
 };
 
@@ -155,6 +158,34 @@ const GACHA_RATES = {
         challenge: [{ grade: 'legend', threshold: 0.20 }, { grade: 'epic', threshold: 0.45 }, { grade: 'rare', threshold: 0.75 }]
     }
 };
+
+// ─── Artifact Definitions ─────────────────────────────────────────────────────
+
+const ARTIFACT_LIST = [
+    { id: 'nature_blessing', name: '대자연의 축복', desc: '대지의축복 효과 2배' },
+    { id: 'reverse', name: '리버스', desc: '자연속성 카드 사망시 필드버프 대지의축복 부여' },
+    { id: 'milkshake', name: '밀크쉐이크', desc: '스타파우더 효과 2배' },
+    { id: 'buff_overload', name: '버프오버로드', desc: '필드버프 상한 5개로 변경' },
+    { id: 'shadow_ball', name: '섀도우볼', desc: '암흑 효과가 마법방어도 감소하도록 변경' },
+    { id: 'assassin_nail', name: '어쌔신네일', desc: '암흑 효과 2배 적용' },
+    { id: 'veil_of_darkness', name: '베일오브다크니스', desc: '어둠속성 카드 치명타와 회피율 10% 증가' },
+    { id: 'rabbit_hole', name: '래빗홀', desc: '눈토끼, 밤토끼, 은토끼의 치명타와 회피율 20% 증가' },
+    { id: 'lucky_vicky', name: '럭키비키', desc: '치명타 혹은 회피 발생시 마나 10 회복' },
+    { id: 'over_flame', name: '오버플레임', desc: '작열 최대 스택 5, 부여시 2스택씩 부여' },
+    { id: 'over_divine', name: '오버디바인', desc: '디바인 최대 스택 5, 부여시 2스택씩 부여' },
+    { id: 'holy_flame_burst', name: '홀리플레임버스트', desc: '작열/디바인 전소모 스킬의 추가위력 2배' },
+    { id: 'flame_piercing', name: '플레임피어싱', desc: '작열 스택당 적의 방어력 10% 추가 관통' },
+    { id: 'divine_piercing', name: '디바인피어싱', desc: '디바인 스택당 적의 마법방어력 10% 추가 관통' },
+    { id: 'gale_storm', name: '질풍노도', desc: '전투 개시 후 3턴간 필드버프 질풍 부여 (치명타율/회피율 20% 증가)' },
+    { id: 'frozen_body', name: '프로즌바디', desc: '물속성 카드 사망시 적에게 스턴 부여' },
+    { id: 'ice_break', name: '아이스브레이크', desc: '스턴 중인 적에게 대미지 3배' },
+    { id: 'support_boost', name: '서포트부스트', desc: '모든 보조스킬 마나 소비 0' },
+    { id: 'double_attack', name: '더블어택', desc: '일반공격 위력 1.5배' },
+    { id: 'death_roulette', name: '데스룰렛', desc: '모든 스킬 대미지 2배, 스킬 사용시 30% 확률로 사망' },
+    { id: 'shadow_stab', name: '섀도우스탭', desc: '회피율 20%증가, 방어력과 마법방어력 30% 감소' },
+    { id: 'dragon_heart', name: '드래곤하트', desc: '베이비드래곤/레드드래곤/골드드래곤 마공 50% 증가' },
+    { id: 'big_bang', name: '빅뱅', desc: '전설/초월 카드 사망시 물리 3배율 자폭대미지' }
+];
 
 // ─── Game Utilities ───────────────────────────────────────────────────────────
 

--- a/card/index.html
+++ b/card/index.html
@@ -800,7 +800,28 @@
                 style="border-color:#29b6f6; color:#29b6f6;">
                 적용된 축복 확인
             </button>
+            <button id="btn-artifact-check" onclick="RPG.openArtifactCheck()"
+                style="display:none; border-color:#ffd700; color:#ffd700;" class="menu-btn">
+                아티팩트 확인
+            </button>
             <button onclick="document.getElementById('modal-chaos').classList.remove('active')"
+                style="margin-top:10px; width:100%; padding:10px;">닫기</button>
+        </div>
+    </div>
+
+    <div id="modal-artifact-select" class="modal" style="z-index: 210;">
+        <div class="modal-content" style="height:auto; min-height:350px;">
+            <h3 style="color:#ffd700;">아티팩트 선택</h3>
+            <p style="font-size:0.8rem; color:#aaa;">아래 3개 중 1개를 선택하세요. (최대 4개 보유)</p>
+            <div id="artifact-select-list" style="display:flex; flex-direction:column; gap:8px; margin:10px 0;"></div>
+        </div>
+    </div>
+
+    <div id="modal-artifact-check" class="modal" style="z-index: 200;">
+        <div class="modal-content" style="height:auto;">
+            <h3 style="color:#ffd700;">보유 아티팩트</h3>
+            <div id="artifact-check-list" style="text-align:left; font-size:0.85rem; line-height:1.6;"></div>
+            <button onclick="document.getElementById('modal-artifact-check').classList.remove('active')"
                 style="margin-top:10px; width:100%; padding:10px;">닫기</button>
         </div>
     </div>
@@ -1043,6 +1064,7 @@
                         if (!this.state.activeSageBlessing) this.state.activeSageBlessing = [];
                         if (!this.state.mode) this.state.mode = 'origin';
                         if (!this.state.quiz_stats) this.state.quiz_stats = { correct: 0, total: 0 };
+                        if (!this.state.artifacts) this.state.artifacts = [];
 
                         // Load persistent wordbook
                         const vocab = Storage.load(Storage.keys.VOCAB);
@@ -1098,7 +1120,8 @@
                     { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배.\n(성공조건: 30 스테이지)' },
                     { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배.\n(성공조건: 30 스테이지)' },
                     { id: 'chaos', name: '카오스', desc: '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' }
+                    { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+                    { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게!\n(성공조건: 36 스테이지)' }
                 ];
 
                 if (this.tempGameType === 'endless') {
@@ -1176,7 +1199,8 @@
                     wrongWords: [],
                     quiz_stats: { correct: 0, total: 0 },
                     chaosPool: [],
-                    draft: { active: false, round: 0, rerolls: 3, currentOptions: [] }
+                    draft: { active: false, round: 0, rerolls: 3, currentOptions: [] },
+                    artifacts: []
                 };
 
                 // Transfer Pending Transcendence to Active State (Endless Only)
@@ -1333,6 +1357,13 @@
                 if (this.state.greatSageBlessingUses === undefined) this.state.greatSageBlessingUses = 3;
                 document.getElementById('chaos-uses').innerText = this.state.chaosBlessingUses;
                 document.getElementById('sage-uses').innerText = this.state.greatSageBlessingUses;
+
+                // Show artifact check button only in artifact mode
+                const artBtn = document.getElementById('btn-artifact-check');
+                if (artBtn) {
+                    artBtn.style.display = (this.state.mode === 'artifact') ? 'block' : 'none';
+                }
+
                 document.getElementById('modal-chaos').classList.add('active');
             },
             checkActiveChaosBlessings() {
@@ -1922,6 +1953,25 @@
 
                 document.getElementById('battle-log').innerHTML = "";
                 this.log(`전투 개시! 적: ${this.battle.enemy.name}`);
+
+                // Artifact: gale_storm — apply gale field buff for first 3 turns
+                if (this.hasArtifact('gale_storm')) {
+                    this.applyFieldBuff('gale');
+                    this.log('[아티팩트] 질풍노도: 전투 시작 시 질풍 발동!');
+                }
+
+                // Artifact: support_boost — set all sup skill costs to 0
+                if (this.hasArtifact('support_boost')) {
+                    this.battle.players.forEach(p => {
+                        if (p && p.proto && p.proto.skills) {
+                            p.proto.skills.forEach(s => {
+                                if (s.type === 'sup') s.cost = 0;
+                            });
+                        }
+                    });
+                    this.log('[아티팩트] 서포트부스트: 모든 보조스킬 마나 소비 0!');
+                }
+
                 this.renderBattlefield();
                 this.TurnManager.startPlayerTurn();
             },
@@ -2078,8 +2128,13 @@
                     def = Math.floor(def * fieldDef * defMult);
 
                     // Evasion Check
-                    if (Logic.checkEvasion(target, skill.type, b.fieldBuffs)) {
+                    if (Logic.checkEvasion(target, skill.type, b.fieldBuffs, RPG.state.mode, RPG.state.artifacts || [])) {
                         RPG.log(`${target.name} 회피 성공! (${skill.name} 회피)`);
+                        // Artifact: lucky_vicky — mana recovery on evasion
+                        if (RPG.hasArtifact('lucky_vicky')) {
+                            target.mp = Math.min(GAME_CONSTANTS.MAX_MP, target.mp + 10);
+                            RPG.log('[아티팩트] 럭키비키: 회피 성공! 마나 10 회복!');
+                        }
                         this.endEnemyTurn();
                         return;
                     }
@@ -2133,7 +2188,8 @@
                     RPG.battle.fieldBuffs,
                     (msg) => RPG.log(msg),
                     RPG.state.deck,
-                    RPG.battle.turn
+                    RPG.battle.turn,
+                    RPG.state.artifacts || []
                 );
 
                 // Apply results
@@ -2158,21 +2214,31 @@
 
             executeSkill(source, target, skill, isDelayed = false) {
                 if (!isDelayed && !skill.isDelayed) source.mp -= skill.cost;
+
+                // Artifact: double_attack — normal attack 1.5x power
+                let modifiedSkill = skill;
+                if (this.hasArtifact('double_attack') && skill.name === RPG.NORMAL_ATTACK.name) {
+                    modifiedSkill = { ...skill, val: (skill.val || 1.0) * 1.5 };
+                }
+
                 RPG.log(`<b>${source.name}</b>의 <b>${skill.name}</b>!`);
 
                 // Trait: Normal Attack Burn & Divine
                 if (skill.name === RPG.NORMAL_ATTACK.name && source.proto && source.proto.trait && source.proto.trait.type === 'normal_attack_burn_divine') {
-                    target.buffs['burn'] = (target.buffs['burn'] || 0) + 1;
-                    target.buffs['divine'] = (target.buffs['divine'] || 0) + 1;
-                    if (target.buffs['burn'] > 3) target.buffs['burn'] = 3;
-                    if (target.buffs['divine'] > 3) target.buffs['divine'] = 3;
+                    let burnMax = this.hasArtifact('over_flame') ? 5 : 3;
+                    let divineMax = this.hasArtifact('over_divine') ? 5 : 3;
+                    let burnAdd = this.hasArtifact('over_flame') ? 2 : 1;
+                    let divineAdd = this.hasArtifact('over_divine') ? 2 : 1;
+                    target.buffs['burn'] = Math.min((target.buffs['burn'] || 0) + burnAdd, burnMax);
+                    target.buffs['divine'] = Math.min((target.buffs['divine'] || 0) + divineAdd, divineMax);
                     RPG.log("[특성] 일반 공격 추가 효과: 작열, 디바인 부여!");
                 }
 
                 // Trait: Phoenix Normal Attack Burn
                 if (skill.name === RPG.NORMAL_ATTACK.name && source.proto && source.proto.trait && source.proto.trait.type === 'syn_fire_3_crit_burn' && RPG.battle.activeTraits.includes('syn_fire_3_crit_burn')) {
-                    target.buffs['burn'] = (target.buffs['burn'] || 0) + 1;
-                    if (target.buffs['burn'] > 3) target.buffs['burn'] = 3;
+                    let burnMax = this.hasArtifact('over_flame') ? 5 : 3;
+                    let burnAdd = this.hasArtifact('over_flame') ? 2 : 1;
+                    target.buffs['burn'] = Math.min((target.buffs['burn'] || 0) + burnAdd, burnMax);
                     RPG.log("[특성] 피닉스: 일반 공격 시 작열 부여!");
                 }
 
@@ -2193,18 +2259,18 @@
                 }
 
                 // Check for Delayed Attack Effect
-                let delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_attack');
-                if (!delayedEff) delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_attack_field');
-                if (!delayedEff) delayedEff = skill.effects && skill.effects.find(e => e.type === 'delayed_random_attack');
+                let delayedEff = modifiedSkill.effects && modifiedSkill.effects.find(e => e.type === 'delayed_attack');
+                if (!delayedEff) delayedEff = modifiedSkill.effects && modifiedSkill.effects.find(e => e.type === 'delayed_attack_field');
+                if (!delayedEff) delayedEff = modifiedSkill.effects && modifiedSkill.effects.find(e => e.type === 'delayed_random_attack');
 
                 if (delayedEff && !isDelayed) {
                     RPG.log(`종언의 예고가 시작됩니다... (${delayedEff.turns}턴 뒤 발동)`);
-                    RPG.battle.delayedEffects.push({ turn: RPG.battle.turn + delayedEff.turns, source: source, skill: skill });
+                    RPG.battle.delayedEffects.push({ turn: RPG.battle.turn + delayedEff.turns, source: source, skill: modifiedSkill });
                     RPG.TurnManager.endPlayerTurn();
                     return;
                 }
 
-                const dmgResult = this.calcDamage(source, target, skill);
+                const dmgResult = this.calcDamage(source, target, modifiedSkill);
 
                 // Apply Damage
                 if (dmgResult.dmg > 0) {
@@ -2213,8 +2279,22 @@
                     RPG.log(`${dmgResult.isCrit ? 'Critical! ' : ''}적에게 <span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
                 }
 
+                // Artifact: lucky_vicky — mana recovery on crit
+                if (dmgResult.luckyVicky) {
+                    source.mp = Math.min(GAME_CONSTANTS.MAX_MP, source.mp + 10);
+                    RPG.log('[아티팩트] 럭키비키: 치명타 발생! 마나 10 회복!');
+                }
+
+                // Artifact: death_roulette — 30% chance to die on skill use
+                if (this.hasArtifact('death_roulette') && skill.name !== RPG.NORMAL_ATTACK.name && !isDelayed) {
+                    if (Math.random() < 0.3) {
+                        source.hp = 0;
+                        RPG.log('<span style="color:#ff5252">[아티팩트] 데스룰렛: 죽음의 룰렛에 당첨...</span>');
+                    }
+                }
+
                 // Apply Side Effects (Buffs, Debuffs, Field, Suicide, etc.)
-                this.applySkillEffects(source, target, skill);
+                this.applySkillEffects(source, target, modifiedSkill);
 
                 if (target.hp <= 0) { RPG.winBattle(); return; }
                 if (source.hp <= 0 && !source.isDead) { source.isDead = true; RPG.log(`${source.name} 사망!`); }
@@ -2225,7 +2305,7 @@
             calcDamage(source, target, skill) {
                 if (skill.type !== 'phy' && skill.type !== 'mag') return { dmg: 0 };
 
-                // Logic.js returns { dmg, isCrit } and logs via callback
+                // Logic.js returns { dmg, isCrit, luckyVicky } and logs via callback
                 const result = Logic.calculateDamage(
                     source,
                     target,
@@ -2235,7 +2315,8 @@
                     (msg) => RPG.log(msg),
                     RPG.state.mode, // PASS MODE
                     RPG.state.deck, // PASS DECK
-                    RPG.battle.turn // PASS TURN
+                    RPG.battle.turn, // PASS TURN
+                    RPG.state.artifacts || [] // PASS ARTIFACTS
                 );
 
                 if (target.id === 'demon_god') {
@@ -2286,7 +2367,9 @@
 
             applyFieldBuff(id) {
                 if (this.battle.fieldBuffs.some(b => b.name === id)) return RPG.log(`필드버프 [${BUFF_NAMES[id]}] 이미 존재.`);
-                if (this.battle.fieldBuffs.length >= GAME_CONSTANTS.MAX_FIELD_BUFFS) {
+                // Artifact: buff_overload — increase max field buffs to 5
+                let maxBuffs = this.hasArtifact('buff_overload') ? 5 : GAME_CONSTANTS.MAX_FIELD_BUFFS;
+                if (this.battle.fieldBuffs.length >= maxBuffs) {
                     let removed = this.battle.fieldBuffs.shift();
                     RPG.log(`필드버프 [${BUFF_NAMES[removed.name]}] 소멸.`);
                 }
@@ -2541,6 +2624,7 @@
                 if (mode === 'curse' || mode === 'flood') clearStage = 30;
                 if (mode === 'chaos') clearStage = 24;
                 if (mode === 'draft') clearStage = 24;
+                if (mode === 'artifact') clearStage = 36;
                 if (mode === 'origin') clearStage = Infinity;
 
                 if (this.state.gameType === 'endless') clearStage = Infinity;
@@ -2673,6 +2757,29 @@
                                 }
                             );
                         }
+                        else if (this.battle.enemy.id === 'creator_god' && this.state.mode === 'artifact' && (this.state.artifacts || []).length < GAME_CONSTANTS.MAX_ARTIFACTS) {
+                            // Artifact Mode: Quiz → Artifact Selection
+                            this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 아티팩트 획득 기회)",
+                                () => { // Yes
+                                    let allQuizzes = [];
+                                    GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
+                                    let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+
+                                    this.startGrammarQuiz(q,
+                                        () => { // Success - Show artifact selection
+                                            this.openArtifactSelect();
+                                        },
+                                        () => { // Fail
+                                            this.showAlert("오답입니다... 아티팩트를 획득하지 못했습니다.");
+                                            this.toMenu();
+                                        }
+                                    );
+                                },
+                                () => { // No
+                                    this.toMenu();
+                                }
+                            );
+                        }
                         else if (this.battle.enemy.id === 'creator_god') {
                             this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 뽑기권 3장 획득)",
                                 () => { // Yes
@@ -2759,7 +2866,7 @@
             },
 
             getEffectiveStats(char, fieldBuffs) {
-                return Logic.calculateStats(char, fieldBuffs, this.state.mode);
+                return Logic.calculateStats(char, fieldBuffs, this.state.mode, this.state.artifacts || []);
             },
 
             showBattleStat(side, idx) {
@@ -2775,7 +2882,7 @@
                     return `${name}(${val})`;
                 }).join(', ') || '없음';
 
-                const eff = Logic.calculateStats(char, this.battle.fieldBuffs, this.state.mode);
+                const eff = Logic.calculateStats(char, this.battle.fieldBuffs, this.state.mode, this.state.artifacts || []);
 
                 // Use baseStatsWithoutBlessing if available to show Green for blessed stats
                 const getBase = (key, fallback) => {
@@ -3046,6 +3153,67 @@
                 config.correctDelay = 1500;
                 config.wrongDelay = 2000;
                 QuizEngine.show(config);
+            },
+
+            // --- Artifact Helpers ---
+
+            hasArtifact(id) {
+                return (this.state.artifacts || []).includes(id);
+            },
+
+            openArtifactSelect() {
+                const owned = this.state.artifacts || [];
+                const available = ARTIFACT_LIST.filter(a => !owned.includes(a.id));
+                if (available.length === 0) {
+                    this.showAlert("획득 가능한 아티팩트가 없습니다.");
+                    this.toMenu();
+                    return;
+                }
+
+                // Pick 3 random artifacts
+                const shuffled = available.sort(() => Math.random() - 0.5);
+                const choices = shuffled.slice(0, Math.min(3, shuffled.length));
+
+                const list = document.getElementById('artifact-select-list');
+                list.innerHTML = "";
+
+                choices.forEach(art => {
+                    const btn = document.createElement('button');
+                    btn.className = 'menu-btn';
+                    btn.style.borderColor = '#ffd700';
+                    btn.style.color = '#ffd700';
+                    btn.style.textAlign = 'left';
+                    btn.style.padding = '15px';
+                    btn.innerHTML = `<b>${art.name}</b><br><span style="font-size:0.8rem; color:#ccc; font-weight:normal;">${art.desc}</span>`;
+                    btn.onclick = () => {
+                        this.state.artifacts.push(art.id);
+                        document.getElementById('modal-artifact-select').classList.remove('active');
+                        this.showAlert(`아티팩트 획득: ${art.name}!\n${art.desc}`);
+                        this.saveGame();
+                        this.toMenu();
+                    };
+                    list.appendChild(btn);
+                });
+
+                document.getElementById('modal-artifact-select').classList.add('active');
+            },
+
+            openArtifactCheck() {
+                const owned = this.state.artifacts || [];
+                const list = document.getElementById('artifact-check-list');
+                if (owned.length === 0) {
+                    list.innerHTML = '<div style="color:#aaa; text-align:center;">보유한 아티팩트가 없습니다.</div>';
+                } else {
+                    list.innerHTML = owned.map(id => {
+                        const art = ARTIFACT_LIST.find(a => a.id === id);
+                        if (!art) return '';
+                        return `<div style="margin-bottom:8px; padding:8px; background:#333; border-radius:5px; border-left: 3px solid #ffd700;">
+                            <b style="color:#ffd700;">${art.name}</b><br>
+                            <span style="color:#ccc;">${art.desc}</span>
+                        </div>`;
+                    }).join('');
+                }
+                document.getElementById('modal-artifact-check').classList.add('active');
             },
 
             showAlert(msg) {


### PR DESCRIPTION
새로운 도전 모드인 아티팩트 모드를 구현했습니다. 10장의 카드로 시작하여 36 스테이지(창조신)까지 도전하며, 퀴즈를 통해 아티팩트를 획득하여 덱을 강화하는 모드입니다.