### PR TITLE
모바일: 아티팩트 모드(챌린지/엔드리스) 혼돈의 축복 모달 레이아웃 개선

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -472,6 +472,42 @@
             margin: 5px 0 !important;
             margin-bottom: 8px !important;
         }
+
+        @media (max-width: 768px) {
+            #modal-chaos.artifact-mobile-compact {
+                justify-content: flex-start;
+                padding: 8px 0;
+            }
+
+            #modal-chaos.artifact-mobile-compact .modal-content {
+                min-height: auto !important;
+                max-height: calc(100vh - 16px);
+                overflow-y: auto;
+                padding-top: 8px;
+            }
+
+            #modal-chaos.artifact-mobile-compact .chaos-title {
+                margin: 4px 0 8px 0;
+            }
+
+            #modal-chaos.artifact-mobile-compact .chaos-desc {
+                margin: 4px 0 8px 0;
+                line-height: 1.35;
+            }
+
+            #modal-chaos.artifact-mobile-compact .chaos-uses {
+                margin-bottom: 6px !important;
+            }
+
+            #modal-chaos.artifact-mobile-compact .menu-btn {
+                margin-bottom: 7px;
+                padding: 10px;
+            }
+
+            #modal-chaos.artifact-mobile-compact .chaos-close-btn {
+                margin-top: 6px !important;
+            }
+        }
     </style>
 </head>
 
@@ -791,9 +827,9 @@
 
     <div id="modal-chaos" class="modal">
         <div class="modal-content" style="height:auto; min-height: 550px;">
-            <h3>혼돈의 축복</h3>
-            <p style="font-size:0.8rem; color:#aaa;">전투 시 무작위 카드에게 강력한 축복을 내립니다.<br>(전투 종료 시 사라짐, 최대 3회)</p>
-            <div style="margin-bottom:10px; font-weight:bold; color:#ffd700;">
+            <h3 class="chaos-title">혼돈의 축복</h3>
+            <p class="chaos-desc" style="font-size:0.8rem; color:#aaa;">전투 시 무작위 카드에게 강력한 축복을 내립니다.<br>(전투 종료 시 사라짐, 최대 3회)</p>
+            <div class="chaos-uses" style="margin-bottom:10px; font-weight:bold; color:#ffd700;">
                 혼돈의 축복: <span id="chaos-uses">3</span>회 / 대현자의 축복: <span id="sage-uses">3</span>회
             </div>
             <button class="menu-btn" onclick="RPG.activateChaos('normal')">
@@ -820,7 +856,7 @@
                 아티팩트 확인
             </button>
             <button onclick="document.getElementById('modal-chaos').classList.remove('active')"
-                style="margin-top:10px; width:100%; padding:10px;">닫기</button>
+                style="margin-top:10px; width:100%; padding:10px;" class="chaos-close-btn">닫기</button>
         </div>
     </div>
 
@@ -1731,13 +1767,18 @@ const QuizEngine = {
                 document.getElementById('chaos-uses').innerText = this.state.chaosBlessingUses;
                 document.getElementById('sage-uses').innerText = this.state.greatSageBlessingUses;
 
+                const chaosModal = document.getElementById('modal-chaos');
+                const isArtifactMobileLayout = this.state.mode === 'artifact' &&
+                    (this.state.gameType === 'challenge' || this.state.gameType === 'endless');
+                chaosModal.classList.toggle('artifact-mobile-compact', isArtifactMobileLayout);
+
                 // Show artifact check button only in artifact mode
                 const artBtn = document.getElementById('btn-artifact-check');
                 if (artBtn) {
                     artBtn.style.display = (this.state.mode === 'artifact') ? 'block' : 'none';
                 }
 
-                document.getElementById('modal-chaos').classList.add('active');
+                chaosModal.classList.add('active');
             },
             checkActiveChaosBlessings() {
                 if (!this.state.chaosBuffs || this.state.chaosBuffs.length === 0) {


### PR DESCRIPTION
### Motivation
- 모바일 화면에서 아티팩트 모드(특히 챌린지 및 엔드리스 진입 시)에서 `혼돈의 축복` 모달이 화면을 벗어나 닫기 버튼이 보이지 않는 문제를 해소하기 위한 레이아웃 조정입니다.

### Description
- `@media (max-width: 768px)` 규칙으로 `#modal-chaos.artifact-mobile-compact` 스타일을 추가하여 상단 여백을 줄이고 내부 스크롤(`max-height`, `overflow-y`)을 활성화했습니다.
- 모달 내 요소에 `chaos-title`, `chaos-desc`, `chaos-uses`, `chaos-close-btn` 클래스명을 부여해 모바일 전용 스타일이 정확히 적용되도록 마크업을 조정했습니다.
- `openChaosBlessing()`에서 `state.mode === 'artifact'` 그리고 `state.gameType`이 `challenge` 또는 `endless`일 때만 `artifact-mobile-compact` 클래스를 토글하도록 조건을 추가해 다른 모드에는 영향이 없게 했습니다.

### Testing
- 인라인 스크립트들을 추출하여 `node --check`로 문법 검사를 실행했고 문법 오류는 발견되지 않았습니다 (성공).
- Playwright를 이용한 모바일 스크린샷을 시도했으나 실행 환경의 Chromium 프로세스가 SIGSEGV로 종료되어 시각적 캡처는 실패했습니다 (환경적 오류).
- 변경은 대상 조건(아티팩트 모드 + 챌린지/엔드리스)에서만 동작하도록 구현되어 다른 모드 레이아웃에는 변경이 없습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69993ad734088322925a14f22c4d8f23)