### PR TITLE
Fix TOEIC practice modal mobile layout and scrolling (Part 6/7)

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -522,15 +522,18 @@
         .toeic-split-container {
             display: flex;
             width: 100%;
-            height: 100%;
+            flex: 1;
+            min-height: 0;
             gap: 10px;
             overflow: hidden;
         }
         .toeic-passage {
             flex: 1;
+            min-height: 0;
             background: #222;
             padding: 10px;
             overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
             border-right: 1px solid #444;
             font-size: 0.9rem;
             line-height: 1.6;
@@ -539,17 +542,27 @@
         }
         .toeic-question {
             flex: 1;
+            min-height: 0;
             display: flex;
             flex-direction: column;
             overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
             padding: 5px;
         }
+
+        #modal-toeic-practice .modal-content {
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
+        }
+
         @media (max-width: 768px) {
             .toeic-split-container {
                 flex-direction: column;
             }
             .toeic-passage {
-                max-height: 40%;
+                flex: 0 0 45%;
+                max-height: none;
                 border-right: none;
                 border-bottom: 1px solid #444;
             }


### PR DESCRIPTION
### Motivation
- Long Part 6/7 passages in the TOEIC practice modal could expand and prevent the question pane from being visible or scrollable on mobile due to nested flex items lacking proper minimum height handling.
- The goal is to make the passage and question panes properly shrink/grow inside the modal so users can scroll long passages and access questions on small viewports.

### Description
- Updated `card/index.html` CSS for the TOEIC practice modal by replacing `height: 100%` on `.toeic-split-container` with `flex: 1` and adding `min-height: 0` to the container and its child panes to fix flex overflow behavior.
- Added `min-height: 0` to `.toeic-passage` and `.toeic-question`, enabled momentum scrolling via `-webkit-overflow-scrolling: touch`, and added `#modal-toeic-practice .modal-content { display: flex; flex-direction: column; min-height: 0; }` to ensure the modal and children layout correctly.
- Replaced the brittle mobile `max-height: 40%` rule with a stable `flex: 0 0 45%` basis for the passage pane under the `@media (max-width: 768px)` rule so passage/question split is more predictable on small screens.

### Testing
- Reviewed the modified CSS blocks in `card/index.html` with `rg`, `sed`, and `nl` to confirm the changes were applied as intended and the TOEIC pane selectors are in the modal scope. (succeeded)
- Started a local static server with `python3 -m http.server 8000` to serve the app for manual/visual validation. (server started)
- Attempted an automated mobile end-to-end screenshot using the Playwright script to validate the fix visually, but the Playwright run timed out in this environment so no screenshot was produced. (failed)
- Verified file diff and staged changes with `git` inspection commands to ensure only the intended CSS adjustments were introduced. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69998826ab28832289ae4d47d8467bda)