### PR TITLE
Fix CWD-relative path issue in check_syntax.js

### DIFF
--- a/self_created_tools/check_syntax.js
+++ b/self_created_tools/check_syntax.js
@@ -1,7 +1,9 @@
 const fs = require('fs');
+const path = require('path');
 const vm = require('vm');
 
-const code = fs.readFileSync('card/toeic.js', 'utf8');
+const toeicPath = path.join(__dirname, '../card/toeic.js');
+const code = fs.readFileSync(toeicPath, 'utf8');
 const sandbox = {};
 vm.createContext(sandbox);
 


### PR DESCRIPTION
This PR fixes a bug in `self_created_tools/check_syntax.js` where the script would fail to find `card/toeic.js` if executed from a directory other than the project root.

The fix involves using `path.join(__dirname, '../card/toeic.js')` to resolve the file path relative to the script's location, rather than the current working directory.

Verified by running the script from both the root directory and the `self_created_tools` subdirectory.

---
*PR created automatically by Jules for task [3548204255547931318](https://jules.google.com/task/3548204255547931318) started by @romarin0325-cell*