### PR TITLE
Fix TOEIC data errors and formatting inconsistencies

### DIFF
--- a/card/toeic.js
+++ b/card/toeic.js
@@ -2,7 +2,7 @@ const TOEIC_DATA = [
   {
     "id": 1,
     "type": "part5",
-    "title": "1강 (Part 5) — 시제/상: 프로젝트 진행 보고 (3문항) ",
+    "title": "1강 (Part 5) — 시제/상: 프로젝트 진행 보고 (3문항)",
     "questions": [
       {
         "id": "1-1",
@@ -42,7 +42,7 @@ const TOEIC_DATA = [
   {
     "id": 2,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 1) ",
+    "title": "2강 (Part 7) — Part 7 Multiple Passages (Set 1)",
     "questions": [
       {
         "id": "2-1",
@@ -100,12 +100,12 @@ const TOEIC_DATA = [
         "answer": "Bring a government-issued photo ID and be escorted beyond the lobby after checking in"
       }
     ],
-    "passage": "2강 \nPart 7 Multiple Passages (Set 1) \n \nQuestions 1–5 refer to the following notice and e-mail. \n \nDocument 1: NOTICE \n \nRIVERSIDE TOWER — HEADQUARTERS \nVisitor Access Policy Update \nDate: February 24, 2026 \nEffective: March 2, 2026 \n \nTo improve building security and reduce lobby congestion, Riverside Tower is updating its visitor access procedures. All employees hosting nonemployees must follow the steps below. \n \n1) Pre-registration (Required) \n \nA host must register each visitor using the Visitor Portal. \n \nRegistration must be completed by 3:00 p.m. at least one business day before the visit. \n \nVisitors who are not pre-registered may experience delays and may be asked to reschedule. \n \n2) Check-in and Identification \n \nVisitors must check in at the Lobby Visitor Desk. \n \nA government-issued photo ID is required to receive a badge. \n \nThe visitor badge must be worn visibly at all times. \n \n3) Escort and Access Areas \n \nVisitors may wait in the lobby seating area only. \n \nAccess beyond the lobby requires a host escort. \n \nVisitors are not permitted in employee-only areas (mailroom, storage rooms, or IT work areas). \n \n4) Vendor and Catering Deliveries \n \nDelivery personnel must enter through the Loading Dock (South Entrance). \n \nIf a delivery requires access beyond the lobby, the employee who arranged the delivery must meet the vendor and escort them as needed. \n \nFor large deliveries (carts or multiple boxes), hosts should schedule a loading dock window in advance. \n \n5) Parking Passes (Limited Availability) \n \nVisitor parking is limited and is not guaranteed. \n \nHosts may request parking passes through Facilities two business days in advance. \n \nThank you for helping us maintain a safe and efficient workplace. \n \nDocument 2: E-mail \n \nSubject: Visitor access for March 5 client workshop \nFrom: Mina Park <mpark@riversidetower.com \n> \nTo: Jordan Lee <jlee@riversidetower.com \n> \nDate: February 26, 2026 \n \nHi Jordan, \n \nI’m hosting a client workshop for Northwind Analytics on Thursday, March 5 from 9:30 a.m. to 12:00 p.m. in Training Room 14B. We expect 18 attendees, plus one presenter. \n \nI saw the new notice about visitor access. A few questions: \n \nIf all guests go directly to the training room, do I still need to meet them in the lobby? \n \nWe’re planning to have breakfast delivered around 9:00 a.m. Can the catering company bring it up to the 14th floor? \n \nTwo guests asked about parking—do we have a way to reserve spots? \n \nThanks, \nMina \n \nSubject: Re: Visitor access for March 5 client workshop \nFrom: Jordan Lee <jlee@riversidetower.com \n> \nTo: Mina Park <mpark@riversidetower.com \n> \nDate: February 26, 2026 \n \nHi Mina, \n \nYes—please plan to meet your guests in the lobby. Even if they’re heading straight to a training room, visitors need to check in and must be escorted beyond the lobby. \n \nTo keep things smooth, please do the following by Tuesday, March 3: \n \nSubmit the full names of all attendees through the Visitor Portal (including the presenter). \n \nRemind guests to bring a government-issued photo ID. \n \nSend me the catering company name and estimated arrival time. \n \nFor the breakfast delivery: vendors must use the South Entrance loading dock. If they need to access the 14th floor, someone from your team will need to meet them at the dock and escort them upstairs. \n \nRegarding parking: we can request a small number of passes, but availability is limited. If you want to try, send the names of the two guests who asked today and I’ll submit the request to Facilities. \n \nBest, \nJordan \n \nQuestions"
+    "passage": "Questions 1–5 refer to the following notice and e-mail. \n \nDocument 1: NOTICE \n \nRIVERSIDE TOWER — HEADQUARTERS \nVisitor Access Policy Update \nDate: February 24, 2026 \nEffective: March 2, 2026 \n \nTo improve building security and reduce lobby congestion, Riverside Tower is updating its visitor access procedures. All employees hosting nonemployees must follow the steps below. \n \n1) Pre-registration (Required) \n \nA host must register each visitor using the Visitor Portal. \n \nRegistration must be completed by 3:00 p.m. at least one business day before the visit. \n \nVisitors who are not pre-registered may experience delays and may be asked to reschedule. \n \n2) Check-in and Identification \n \nVisitors must check in at the Lobby Visitor Desk. \n \nA government-issued photo ID is required to receive a badge. \n \nThe visitor badge must be worn visibly at all times. \n \n3) Escort and Access Areas \n \nVisitors may wait in the lobby seating area only. \n \nAccess beyond the lobby requires a host escort. \n \nVisitors are not permitted in employee-only areas (mailroom, storage rooms, or IT work areas). \n \n4) Vendor and Catering Deliveries \n \nDelivery personnel must enter through the Loading Dock (South Entrance). \n \nIf a delivery requires access beyond the lobby, the employee who arranged the delivery must meet the vendor and escort them as needed. \n \nFor large deliveries (carts or multiple boxes), hosts should schedule a loading dock window in advance. \n \n5) Parking Passes (Limited Availability) \n \nVisitor parking is limited and is not guaranteed. \n \nHosts may request parking passes through Facilities two business days in advance. \n \nThank you for helping us maintain a safe and efficient workplace. \n \nDocument 2: E-mail \n \nSubject: Visitor access for March 5 client workshop \nFrom: Mina Park <mpark@riversidetower.com \n> \nTo: Jordan Lee <jlee@riversidetower.com \n> \nDate: February 26, 2026 \n \nHi Jordan, \n \nI’m hosting a client workshop for Northwind Analytics on Thursday, March 5 from 9:30 a.m. to 12:00 p.m. in Training Room 14B. We expect 18 attendees, plus one presenter. \n \nI saw the new notice about visitor access. A few questions: \n \nIf all guests go directly to the training room, do I still need to meet them in the lobby? \n \nWe’re planning to have breakfast delivered around 9:00 a.m. Can the catering company bring it up to the 14th floor? \n \nTwo guests asked about parking—do we have a way to reserve spots? \n \nThanks, \nMina \n \nSubject: Re: Visitor access for March 5 client workshop \nFrom: Jordan Lee <jlee@riversidetower.com \n> \nTo: Mina Park <mpark@riversidetower.com \n> \nDate: February 26, 2026 \n \nHi Mina, \n \nYes—please plan to meet your guests in the lobby. Even if they’re heading straight to a training room, visitors need to check in and must be escorted beyond the lobby. \n \nTo keep things smooth, please do the following by Tuesday, March 3: \n \nSubmit the full names of all attendees through the Visitor Portal (including the presenter). \n \nRemind guests to bring a government-issued photo ID. \n \nSend me the catering company name and estimated arrival time. \n \nFor the breakfast delivery: vendors must use the South Entrance loading dock. If they need to access the 14th floor, someone from your team will need to meet them at the dock and escort them upstairs. \n \nRegarding parking: we can request a small number of passes, but availability is limited. If you want to try, send the names of the two guests who asked today and I’ll submit the request to Facilities. \n \nBest, \nJordan \n \nQuestions"
   },
   {
     "id": 3,
     "type": "part6",
-    "title": "3강 (Part 6) 배송 지연 안내 + 대체품 제안 고객 이메일 (지문 1개 + 4문항) ",
+    "title": "3강 (Part 6) — 배송 지연 안내 + 대체품 제안 고객 이메일 (지문 1개 + 4문항)",
     "questions": [
       {
         "id": "3-1",
@@ -152,15 +152,15 @@ const TOEIC_DATA = [
         "answer": "[3]"
       }
     ],
-    "passage": "3강 \n3강 (Part 6) 배송 지연 안내 + 대체품 제안 고객 이메일 (지문 1개 + 4문항) \n \nDirections: Read the text below and choose the best answer for each blank. \n \nSubject: Update on Your Order and Available Options \n \nDear Ms. Patel, \n \nThank you for your recent purchase from Wexford Office Supply. I am writing regarding your order (No. WS-18427) for 24 units of the MX-900 wireless keyboards, which was scheduled to ship on February 18. \n \nUnfortunately, our carrier has informed us that severe weather conditions in the Kansai region have temporarily disrupted outbound freight operations. As a result, the shipment has been delayed, and the revised estimated delivery date is now February 26. We understand that this may cause inconvenience, (1) _______ if the items are needed for an upcoming installation or an employee onboarding schedule. [1] \n \nTo minimize the impact on your operations, we can offer two alternatives. First, we can send 24 units of the MX-880 model, which is currently in stock and can be dispatched today. The MX-880 has the same layout and compatibility as the MX-900, (2) _______ it does include the dedicated shortcut keys for video conferencing. If this option works for you, we will apply a 10% discount to reflect the difference in features. [2] \n \nSecond, if you prefer to keep the MX-900 model, we can arrange partial delivery: 10 units will be shipped from our Tokyo warehouse immediately, and the remaining 14 units will follow once the freight restrictions are lifted. Please note that this split shipment would require two separate tracking numbers and may arrive (3) _______ different days. In addition, the second shipment may be handed off to a different local carrier depending on route availability. [3] \n \nPlease let us know which option you would like to choose by 2 p.m. tomorrow, so we can update the order and confirm the shipping arrangement. We apologize again for the delay and appreciate your patience. [4] \n \nSincerely, \nHiro Tanaka \nCustomer Support Representative \nWexford Office Supply"
+    "passage": "Directions: Read the text below and choose the best answer for each blank. \n \nSubject: Update on Your Order and Available Options \n \nDear Ms. Patel, \n \nThank you for your recent purchase from Wexford Office Supply. I am writing regarding your order (No. WS-18427) for 24 units of the MX-900 wireless keyboards, which was scheduled to ship on February 18. \n \nUnfortunately, our carrier has informed us that severe weather conditions in the Kansai region have temporarily disrupted outbound freight operations. As a result, the shipment has been delayed, and the revised estimated delivery date is now February 26. We understand that this may cause inconvenience, (1) _______ if the items are needed for an upcoming installation or an employee onboarding schedule. [1] \n \nTo minimize the impact on your operations, we can offer two alternatives. First, we can send 24 units of the MX-880 model, which is currently in stock and can be dispatched today. The MX-880 has the same layout and compatibility as the MX-900, (2) _______ it does include the dedicated shortcut keys for video conferencing. If this option works for you, we will apply a 10% discount to reflect the difference in features. [2] \n \nSecond, if you prefer to keep the MX-900 model, we can arrange partial delivery: 10 units will be shipped from our Tokyo warehouse immediately, and the remaining 14 units will follow once the freight restrictions are lifted. Please note that this split shipment would require two separate tracking numbers and may arrive (3) _______ different days. In addition, the second shipment may be handed off to a different local carrier depending on route availability. [3] \n \nPlease let us know which option you would like to choose by 2 p.m. tomorrow, so we can update the order and confirm the shipping arrangement. We apologize again for the delay and appreciate your patience. [4] \n \nSincerely, \nHiro Tanaka \nCustomer Support Representative \nWexford Office Supply"
   },
   {
     "id": 4,
     "type": "part5",
-    "title": "4강 (Part 5) — 전치사 결합/고정표현/혼동어 (3문항) ",
+    "title": "4강 (Part 5) — 전치사 결합/고정표현/혼동어 (3문항)",
     "questions": [
       {
-        "id": "4-4",
+        "id": "4-1",
         "question": "(collocation: comply with)\nAll employees must comply _______ the updated security guidelines.",
         "options": [
           "to",
@@ -171,7 +171,7 @@ const TOEIC_DATA = [
         "answer": "with"
       },
       {
-        "id": "4-5",
+        "id": "4-2",
         "question": "(고정표현: in accordance with)\nThe report was prepared in accordance _______ the procedures outlined in the manual.",
         "options": [
           "to",
@@ -182,7 +182,7 @@ const TOEIC_DATA = [
         "answer": "with"
       },
       {
-        "id": "4-6",
+        "id": "4-3",
         "question": "(confusable: ensure vs assure)\nPlease _______ that the meeting room is reserved for Friday afternoon.",
         "options": [
           "assure",
@@ -197,10 +197,10 @@ const TOEIC_DATA = [
   {
     "id": 5,
     "type": "part5",
-    "title": "5강 (Part 5) — 대명사/한정사/수량표현 (3문항) ",
+    "title": "5강 (Part 5) — 대명사/한정사/수량표현 (3문항)",
     "questions": [
       {
-        "id": "5-7",
+        "id": "5-1",
         "question": "(each + 단수동사 / 수일치 함정)\nEach of the new interns _______ required to complete the orientation by Monday.",
         "options": [
           "are",
@@ -211,7 +211,7 @@ const TOEIC_DATA = [
         "answer": "is"
       },
       {
-        "id": "5-8",
+        "id": "5-2",
         "question": "(this/these 지시 대상 + 문맥 정확성)\nThe finance department reviewed the invoices and flagged several errors. _______ issues must be corrected before payment is processed.",
         "options": [
           "This",
@@ -222,7 +222,7 @@ const TOEIC_DATA = [
         "answer": "These"
       },
       {
-        "id": "5-9",
+        "id": "5-3",
         "question": "(few/a few 의미 차이 + 수량표현)\nOnly _______ employees volunteered to work overtime, so the manager was able to keep the original deadline.",
         "options": [
           "a few",
@@ -237,10 +237,10 @@ const TOEIC_DATA = [
   {
     "id": 6,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 2) ",
+    "title": "6강 (Part 7) — Part 7 Multiple Passages (Set 2)",
     "questions": [
       {
-        "id": "6-6",
+        "id": "6-1",
         "question": "According to the invoice, when is payment due?",
         "options": [
           "March 16, 2026",
@@ -251,7 +251,7 @@ const TOEIC_DATA = [
         "answer": "April 9, 2026"
       },
       {
-        "id": "6-7",
+        "id": "6-2",
         "question": "What is the main purpose of Olivia Chen’s e-mail?",
         "options": [
           "To request a refund for chairs that were returned",
@@ -262,7 +262,7 @@ const TOEIC_DATA = [
         "answer": "To ask for a corrected invoice that matches the purchase agreement"
       },
       {
-        "id": "6-8",
+        "id": "6-3",
         "question": "If the invoice is revised as Olivia requests, what should the line total for the AT-4 chairs be?",
         "options": [
           "$1,490.00",
@@ -273,7 +273,7 @@ const TOEIC_DATA = [
         "answer": "$1,788.00"
       },
       {
-        "id": "6-9",
+        "id": "6-4",
         "question": "What will Mark Rivera most likely do next?",
         "options": [
           "Cancel the order because the freight charge is disputed",
@@ -284,7 +284,7 @@ const TOEIC_DATA = [
         "answer": "Send a revised invoice that removes the assembly fee and corrects the quantity"
       },
       {
-        "id": "6-10",
+        "id": "6-5",
         "question": "In Olivia Chen’s e-mail, the word “waived” is closest in meaning to",
         "options": [
           "postponed",
@@ -295,12 +295,12 @@ const TOEIC_DATA = [
         "answer": "eliminated"
       }
     ],
-    "passage": "6강 \nPart 7 Multiple Passages (Set 2) \n \nQuestions 6–10 refer to the following invoice and e-mail. \n \nDocument 1: INVOICE \n \nHARBORPRINT SOLUTIONS \n2400 West Briar Ave., Suite 310, Seattle, WA 98109 \nTel: (206) 555-0148 | billing@harborprint.com \n \nINVOICE \n \nInvoice No.: HP-260310-184 \n \nInvoice Date: March 10, 2026 \n \nPO No.: EV-4479 \n \nBill To: Eastview Consulting Group \n18F, Eastview Plaza, 88 Haneul-ro, Seoul \nAttn: Accounts Payable \n \nShip To: Eastview Consulting Group — Training Center \n3F, Eastview Plaza, 88 Haneul-ro, Seoul \n \nPayment Terms: 2/10, Net 30 \n(A 2% discount is applied to the item subtotal only if payment is received within 10 calendar days of the invoice date.) \nDue Date: April 9, 2026 \n \nDescription of Charges \nItem\tDescription\tQty\tUnit Price\tLine Total \nAT-4\tErgonomic Task Chair (Model AT-4), graphite\t14\t149.00\t2,086.00 \nSV-AP\tAssembly & Placement Service (on-site)\t1\t180.00\t180.00 \nFR-G\tFreight — Ground Delivery\t1\t95.00\t95.00 \n \nItem Subtotal: 2,086.00 \nService Subtotal: 180.00 \nFreight: 95.00 \nTax (8.25%): 186.95 \nTOTAL AMOUNT DUE: 2,547.95 \n \nNotes \n \nPlease reference Invoice No. HP-260310-184 on all remittances. \n \nFreight covers delivery to the designated receiving area. Escorting items beyond the receiving area may require on-site coordination. \n \nQuestions about this invoice should be directed to billing@harborprint.com \n with the invoice number in the subject line. \n \nDocument 2: E-mail \n \nSubject: Discrepancy on Invoice HP-260310-184 (PO EV-4479) \nFrom: Olivia Chen <olivia.chen@eastviewcg.com \n> \nTo: Mark Rivera <mark.rivera@harborprint.com \n> \nDate: March 12, 2026 \n \nHi Mark, \n \nThanks for sending the invoice for the chair order. Before we process payment, I noticed a couple of issues that don’t match our purchase documentation. \n \nQuantity: Our PO EV-4479 is for 12 AT-4 chairs, but the invoice shows 14. \n \nService charge: The quote you provided (Quote Q-7741) stated that assembly would be waived because this order is for our new training center opening. However, the invoice includes an Assembly & Placement Service fee of $180.00. \n \nCould you please send a revised invoice reflecting: \n \n12 chairs at the agreed unit price, and \n \nremoval of the assembly fee \n \nWe run our payment batch early next week, so receiving the corrected invoice by Monday, March 16 would help us avoid delaying payment. \n \nAlso, please confirm whether the freight charge will remain the same after the adjustments. \n \nThank you, \nOlivia Chen \nAccounts Payable | Eastview Consulting Group \n \nSubject: Re: Discrepancy on Invoice HP-260310-184 (PO EV-4479) \nFrom: Mark Rivera <mark.rivera@harborprint.com \n> \nTo: Olivia Chen <olivia.chen@eastviewcg.com \n> \nDate: March 12, 2026 \n \nHi Olivia, \n \nThank you for catching that—sorry about the confusion. \n \nYou are correct: PO EV-4479 is for 12 chairs, and the assembly charge should not have been included. I’ll issue a revised invoice today that updates the quantity to 12 and removes the service line. \n \nThe freight charge will remain unchanged, since it’s based on the delivery appointment and handling requirements rather than the chair count. \n \nPlease disregard Invoice HP-260310-184 once you receive the revised version. If you need the updated invoice to reference the original PO and quote number on your side, I can add those details to the notes section. \n \nBest regards, \nMark Rivera \nSales Coordinator | HarborPrint Solutions \n \nQuestions"
+    "passage": "Questions 6–10 refer to the following invoice and e-mail. \n \nDocument 1: INVOICE \n \nHARBORPRINT SOLUTIONS \n2400 West Briar Ave., Suite 310, Seattle, WA 98109 \nTel: (206) 555-0148 | billing@harborprint.com \n \nINVOICE \n \nInvoice No.: HP-260310-184 \n \nInvoice Date: March 10, 2026 \n \nPO No.: EV-4479 \n \nBill To: Eastview Consulting Group \n18F, Eastview Plaza, 88 Haneul-ro, Seoul \nAttn: Accounts Payable \n \nShip To: Eastview Consulting Group — Training Center \n3F, Eastview Plaza, 88 Haneul-ro, Seoul \n \nPayment Terms: 2/10, Net 30 \n(A 2% discount is applied to the item subtotal only if payment is received within 10 calendar days of the invoice date.) \nDue Date: April 9, 2026 \n \nDescription of Charges \nItem\tDescription\tQty\tUnit Price\tLine Total \nAT-4\tErgonomic Task Chair (Model AT-4), graphite\t14\t149.00\t2,086.00 \nSV-AP\tAssembly & Placement Service (on-site)\t1\t180.00\t180.00 \nFR-G\tFreight — Ground Delivery\t1\t95.00\t95.00 \n \nItem Subtotal: 2,086.00 \nService Subtotal: 180.00 \nFreight: 95.00 \nTax (8.25%): 186.95 \nTOTAL AMOUNT DUE: 2,547.95 \n \nNotes \n \nPlease reference Invoice No. HP-260310-184 on all remittances. \n \nFreight covers delivery to the designated receiving area. Escorting items beyond the receiving area may require on-site coordination. \n \nQuestions about this invoice should be directed to billing@harborprint.com \n with the invoice number in the subject line. \n \nDocument 2: E-mail \n \nSubject: Discrepancy on Invoice HP-260310-184 (PO EV-4479) \nFrom: Olivia Chen <olivia.chen@eastviewcg.com \n> \nTo: Mark Rivera <mark.rivera@harborprint.com \n> \nDate: March 12, 2026 \n \nHi Mark, \n \nThanks for sending the invoice for the chair order. Before we process payment, I noticed a couple of issues that don’t match our purchase documentation. \n \nQuantity: Our PO EV-4479 is for 12 AT-4 chairs, but the invoice shows 14. \n \nService charge: The quote you provided (Quote Q-7741) stated that assembly would be waived because this order is for our new training center opening. However, the invoice includes an Assembly & Placement Service fee of $180.00. \n \nCould you please send a revised invoice reflecting: \n \n12 chairs at the agreed unit price, and \n \nremoval of the assembly fee \n \nWe run our payment batch early next week, so receiving the corrected invoice by Monday, March 16 would help us avoid delaying payment. \n \nAlso, please confirm whether the freight charge will remain the same after the adjustments. \n \nThank you, \nOlivia Chen \nAccounts Payable | Eastview Consulting Group \n \nSubject: Re: Discrepancy on Invoice HP-260310-184 (PO EV-4479) \nFrom: Mark Rivera <mark.rivera@harborprint.com \n> \nTo: Olivia Chen <olivia.chen@eastviewcg.com \n> \nDate: March 12, 2026 \n \nHi Olivia, \n \nThank you for catching that—sorry about the confusion. \n \nYou are correct: PO EV-4479 is for 12 chairs, and the assembly charge should not have been included. I’ll issue a revised invoice today that updates the quantity to 12 and removes the service line. \n \nThe freight charge will remain unchanged, since it’s based on the delivery appointment and handling requirements rather than the chair count. \n \nPlease disregard Invoice HP-260310-184 once you receive the revised version. If you need the updated invoice to reference the original PO and quote number on your side, I can add those details to the notes section. \n \nBest regards, \nMark Rivera \nSales Coordinator | HarborPrint Solutions \n \nQuestions"
   },
   {
     "id": 7,
     "type": "part5",
-    "title": "7강 (Part 5) — 수동/사역(passive & causative) (3문항) ",
+    "title": "7강 (Part 5) — 수동/사역(passive & causative) (3문항)",
     "questions": [
       {
         "id": "7-1",
@@ -340,7 +340,7 @@ const TOEIC_DATA = [
   {
     "id": 8,
     "type": "part6",
-    "title": "8강 (Part 6) 신입/부서 대상 오리엔테이션 안내 공지 (지문 1개 + 4문항) ",
+    "title": "8강 (Part 6) — 신입/부서 대상 오리엔테이션 안내 공지 (지문 1개 + 4문항)",
     "questions": [
       {
         "id": "8-1",
@@ -387,15 +387,15 @@ const TOEIC_DATA = [
         "answer": "[4]"
       }
     ],
-    "passage": "8강 \n8강 (Part 6) 신입/부서 대상 오리엔테이션 안내 공지 (지문 1개 + 4문항) \n \nDirections: Read the text below and choose the best answer for each blank. \n \nSubject: New Employee Orientation: March Schedule and Required Materials \n \nWelcome to Northbridge Solutions. \n \nAll new employees joining the company in March are required to attend the New Employee Orientation Program. This program introduces core workplace policies, explains how to access internal tools, and provides an overview of department-specific procedures. Attendance is mandatory for all full-time hires and is strongly recommended for contract staff who will be on-site more than three days per week. [1] \n \nThe orientation will be held on Tuesday, March 3, from 9:30 a.m. to 4:30 p.m. in Conference Room B on the 12th floor. Please arrive by 9:15 a.m. to complete check-in and receive your temporary building access badge. Late arrivals may be asked to join the afternoon session instead, (1) _______ the morning portion includes required safety training. [2] \n \nPrior to the orientation, participants must review the attached “Getting Started” guide and complete the short online compliance module. The module takes approximately 20 minutes and must be finished by 6 p.m. on Friday, February 27. You will receive an automated confirmation email after completion; please save (2) _______ for your records. [3] \n \nDuring the program, you will receive a printed packet containing a building map, a list of emergency contacts, and an IT support directory. Please bring a laptop if possible. If you do not yet have a company-issued device, you may bring your personal laptop, (3) _______ it can connect to a standard Wi-Fi network and has a modern web browser installed. Headphones are also recommended, since part of the session includes short training videos. [4] \n \nIf you have any questions about the schedule or materials, please contact Human Resources at hr@northbridge.example \n. \n \nThank you, \nHuman Resources Department \nNorthbridge Solutions"
+    "passage": "Directions: Read the text below and choose the best answer for each blank. \n \nSubject: New Employee Orientation: March Schedule and Required Materials \n \nWelcome to Northbridge Solutions. \n \nAll new employees joining the company in March are required to attend the New Employee Orientation Program. This program introduces core workplace policies, explains how to access internal tools, and provides an overview of department-specific procedures. Attendance is mandatory for all full-time hires and is strongly recommended for contract staff who will be on-site more than three days per week. [1] \n \nThe orientation will be held on Tuesday, March 3, from 9:30 a.m. to 4:30 p.m. in Conference Room B on the 12th floor. Please arrive by 9:15 a.m. to complete check-in and receive your temporary building access badge. Late arrivals may be asked to join the afternoon session instead, (1) _______ the morning portion includes required safety training. [2] \n \nPrior to the orientation, participants must review the attached “Getting Started” guide and complete the short online compliance module. The module takes approximately 20 minutes and must be finished by 6 p.m. on Friday, February 27. You will receive an automated confirmation email after completion; please save (2) _______ for your records. [3] \n \nDuring the program, you will receive a printed packet containing a building map, a list of emergency contacts, and an IT support directory. Please bring a laptop if possible. If you do not yet have a company-issued device, you may bring your personal laptop, (3) _______ it can connect to a standard Wi-Fi network and has a modern web browser installed. Headphones are also recommended, since part of the session includes short training videos. [4] \n \nIf you have any questions about the schedule or materials, please contact Human Resources at hr@northbridge.example \n. \n \nThank you, \nHuman Resources Department \nNorthbridge Solutions"
   },
   {
     "id": 9,
     "type": "part5",
-    "title": "9강 (Part 5) — 접속사/절 구조(원인·대조·조건) (3문항) ",
+    "title": "9강 (Part 5) — 접속사/절 구조(원인·대조·조건) (3문항)",
     "questions": [
       {
-        "id": "9-4",
+        "id": "9-1",
         "question": "(because/so/therefore 구분)\nThe shipment was delayed _______ a severe storm disrupted port operations.",
         "options": [
           "because",
@@ -406,7 +406,7 @@ const TOEIC_DATA = [
         "answer": "because"
       },
       {
-        "id": "9-5",
+        "id": "9-2",
         "question": "(although/however 대조 구조)\n_______ the new software is expensive, it reduces processing time significantly.",
         "options": [
           "However",
@@ -417,7 +417,7 @@ const TOEIC_DATA = [
         "answer": "Although"
       },
       {
-        "id": "9-6",
+        "id": "9-3",
         "question": "(부사 위치: only / 문법 함정)\nThe marketing team will _______ release the report to department heads, not to external partners.",
         "options": [
           "only",
@@ -432,10 +432,10 @@ const TOEIC_DATA = [
   {
     "id": 10,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 3) ",
+    "title": "10강 (Part 7) — Part 7 Multiple Passages (Set 3)",
     "questions": [
       {
-        "id": "10-11",
+        "id": "10-1",
         "question": "According to the itinerary, what time does Sofia Kim’s flight arrive in Singapore on April 14?",
         "options": [
           "06:50 a.m.",
@@ -446,7 +446,7 @@ const TOEIC_DATA = [
         "answer": "10:20 a.m."
       },
       {
-        "id": "10-12",
+        "id": "10-2",
         "question": "Why did Sofia Kim write to Ethan Walsh?",
         "options": [
           "To ask him to change her return flight to an earlier departure",
@@ -457,7 +457,7 @@ const TOEIC_DATA = [
         "answer": "To request help arranging early check‑in and reserving a meeting room"
       },
       {
-        "id": "10-13",
+        "id": "10-3",
         "question": "Based on the hotel notice, what will most likely happen if Sofia arrives before her room is ready?",
         "options": [
           "She will be required to pay for an extra night immediately",
@@ -468,7 +468,7 @@ const TOEIC_DATA = [
         "answer": "She can leave her luggage with the concierge until check‑in is available"
       },
       {
-        "id": "10-14",
+        "id": "10-4",
         "question": "What should Ethan Walsh do to meet the hotel’s requirement for reserving a meeting room at 8:00 a.m. on April 15?",
         "options": [
           "Submit a completed booking form no later than 48 hours before the meeting begins",
@@ -479,7 +479,7 @@ const TOEIC_DATA = [
         "answer": "Submit a completed booking form no later than 48 hours before the meeting begins"
       },
       {
-        "id": "10-15",
+        "id": "10-5",
         "question": "If Sofia receives early check‑in at 11:30 a.m., how much will she most likely be charged for it?",
         "options": [
           "SGD 0",
@@ -490,15 +490,15 @@ const TOEIC_DATA = [
         "answer": "SGD 35"
       }
     ],
-    "passage": "10강 \nPart 7 Multiple Passages (Set 3) \n \nQuestions 11–15 refer to the following itinerary, hotel notice, and e-mail. \n \nDocument 1: Itinerary \n \nSKYLINK TRAVEL — Corporate Itinerary \nTraveler: Sofia Kim (Sales) \nCompany: Eastview Consulting Group \nTrip Purpose: Client workshop support (Meridian Systems) \nDestination: Singapore \nIssue Date: April 7, 2026 \nTrip Dates: April 14–16, 2026 \nTraveler Phone: +82-10-5555-1842 \n \nFlights (Ticketed) \n \nOutbound \n \nFlight: SL 218 \n \nRoute: Seoul (ICN) → Singapore (SIN) \n \nDeparture: Tue, Apr 14 — 06:50 (ICN) \n \nArrival: Tue, Apr 14 — 10:20 (SIN) \n \nSeat: 18C \n \nRecord Locator: K9Q7LM \n \nReturn \n \nFlight: SL 219 \n \nRoute: Singapore (SIN) → Seoul (ICN) \n \nDeparture: Thu, Apr 16 — 17:40 (SIN) \n \nArrival: Fri, Apr 17 — 01:05 (ICN) \n \nSeat: 21A \n \nHotel (Confirmed) \n \nMarina Bay View Hotel \n12 Seabreeze Road, Singapore 018912 \n \nCheck-in: Tue, Apr 14 \n \nCheck-out: Thu, Apr 16 \n \nNights: 2 \n \nRoom Type: Standard Queen (Non-smoking) \n \nConfirmation No.: MBV-448210 \n \nRate: SGD 228/night + taxes \n \nIncluded: Wi‑Fi, breakfast \n \nGround Transportation \n \nAirport Transfer (Pre-arranged) \n \nProvider: CityRide Transport \n \nPickup: Tue, Apr 14 — 10:50 (SIN Arrivals) \n \nMeeting Point: Terminal 3, Door 3, “CityRide” sign \n \nDestination: Marina Bay View Hotel \n \nReservation: CR-77106 \n \nNotes \n \nFor flight changes, contact SkyLink Corporate Desk (24/7): +65-6800-2211. \n \nHotel rate is guaranteed for the reserved dates only; extensions are subject to availability. \n \nDocument 2: Hotel Notice \n \nMARINA BAY VIEW HOTEL \nGuest Services Notice: Early Check‑in & Meeting Room Requests \nEffective: April 1, 2026 \n \nTo better manage peak arrival times, the hotel has updated its early check‑in policy. \n \nCheck‑in / Check‑out \n \nStandard check‑in: 3:00 p.m. \n \nStandard check‑out: 11:00 a.m. \n \nEarly Check‑in \n \n11:00 a.m. – 2:00 p.m.: Early check‑in may be available for a SGD 35 fee (subject to room availability). \n \nBefore 11:00 a.m.: Early check‑in is treated as an additional night stay and may require a full night’s charge (subject to availability). \n \nIf a room is not ready, complimentary luggage storage is available at the concierge desk. \n \nMeeting Room Requests \n \nMeeting room reservations require a completed booking form and must be submitted at least 48 hours before the requested start time. \n \nRequests under 48 hours may be declined due to limited availability. \n \nBooking confirmations will be sent by e‑mail once the request is approved. \n \nThank you for your cooperation. \n \nDocument 3: E-mail \n \nSubject: Singapore trip — early check-in and meeting room \nFrom: Sofia Kim <sofia.kim@eastviewcg.com \n> \nTo: Ethan Walsh <ethan.walsh@eastviewcg.com \n> \nDate: April 8, 2026 \n \nHi Ethan, \n \nThe client just moved the workshop prep session earlier than expected. Since my flight lands at 10:20 a.m. on April 14, I’m hoping to get into the hotel room before lunch so I can change and review materials. \n \nCould you request early check‑in around 11:30 a.m. at the Marina Bay View Hotel (confirmation MBV‑448210)? \n \nAlso, the client wants a short meeting on April 15 from 8:00 to 9:30 a.m. near the hotel. If the hotel has a small meeting room, can we reserve one for that time? \n \nThanks, \nSofia \n \nSubject: Re: Singapore trip — early check-in and meeting room \nFrom: Ethan Walsh <ethan.walsh@eastviewcg.com \n> \nTo: Sofia Kim <sofia.kim@eastviewcg.com \n> \nDate: April 8, 2026 \n \nHi Sofia, \n \nGot it. I’ll contact the hotel today. \n \nFor early check‑in: I’ll request 11:30 a.m. specifically. If they can’t accommodate it, they should be able to store your luggage until the standard check‑in time. \n \nFor the meeting room: I can submit a request for 8:00–9:30 a.m. on April 15, but the hotel requires requests at least 48 hours in advance and a completed booking form. I’ll send the form to you once I get it from Guest Services. \n \nI’ll update you as soon as I hear back. \n \nBest, \nEthan \n \nQuestions"
+    "passage": "Questions 11–15 refer to the following itinerary, hotel notice, and e-mail. \n \nDocument 1: Itinerary \n \nSKYLINK TRAVEL — Corporate Itinerary \nTraveler: Sofia Kim (Sales) \nCompany: Eastview Consulting Group \nTrip Purpose: Client workshop support (Meridian Systems) \nDestination: Singapore \nIssue Date: April 7, 2026 \nTrip Dates: April 14–16, 2026 \nTraveler Phone: +82-10-5555-1842 \n \nFlights (Ticketed) \n \nOutbound \n \nFlight: SL 218 \n \nRoute: Seoul (ICN) → Singapore (SIN) \n \nDeparture: Tue, Apr 14 — 06:50 (ICN) \n \nArrival: Tue, Apr 14 — 10:20 (SIN) \n \nSeat: 18C \n \nRecord Locator: K9Q7LM \n \nReturn \n \nFlight: SL 219 \n \nRoute: Singapore (SIN) → Seoul (ICN) \n \nDeparture: Thu, Apr 16 — 17:40 (SIN) \n \nArrival: Fri, Apr 17 — 01:05 (ICN) \n \nSeat: 21A \n \nHotel (Confirmed) \n \nMarina Bay View Hotel \n12 Seabreeze Road, Singapore 018912 \n \nCheck-in: Tue, Apr 14 \n \nCheck-out: Thu, Apr 16 \n \nNights: 2 \n \nRoom Type: Standard Queen (Non-smoking) \n \nConfirmation No.: MBV-448210 \n \nRate: SGD 228/night + taxes \n \nIncluded: Wi‑Fi, breakfast \n \nGround Transportation \n \nAirport Transfer (Pre-arranged) \n \nProvider: CityRide Transport \n \nPickup: Tue, Apr 14 — 10:50 (SIN Arrivals) \n \nMeeting Point: Terminal 3, Door 3, “CityRide” sign \n \nDestination: Marina Bay View Hotel \n \nReservation: CR-77106 \n \nNotes \n \nFor flight changes, contact SkyLink Corporate Desk (24/7): +65-6800-2211. \n \nHotel rate is guaranteed for the reserved dates only; extensions are subject to availability. \n \nDocument 2: Hotel Notice \n \nMARINA BAY VIEW HOTEL \nGuest Services Notice: Early Check‑in & Meeting Room Requests \nEffective: April 1, 2026 \n \nTo better manage peak arrival times, the hotel has updated its early check‑in policy. \n \nCheck‑in / Check‑out \n \nStandard check‑in: 3:00 p.m. \n \nStandard check‑out: 11:00 a.m. \n \nEarly Check‑in \n \n11:00 a.m. – 2:00 p.m.: Early check‑in may be available for a SGD 35 fee (subject to room availability). \n \nBefore 11:00 a.m.: Early check‑in is treated as an additional night stay and may require a full night’s charge (subject to availability). \n \nIf a room is not ready, complimentary luggage storage is available at the concierge desk. \n \nMeeting Room Requests \n \nMeeting room reservations require a completed booking form and must be submitted at least 48 hours before the requested start time. \n \nRequests under 48 hours may be declined due to limited availability. \n \nBooking confirmations will be sent by e‑mail once the request is approved. \n \nThank you for your cooperation. \n \nDocument 3: E-mail \n \nSubject: Singapore trip — early check-in and meeting room \nFrom: Sofia Kim <sofia.kim@eastviewcg.com \n> \nTo: Ethan Walsh <ethan.walsh@eastviewcg.com \n> \nDate: April 8, 2026 \n \nHi Ethan, \n \nThe client just moved the workshop prep session earlier than expected. Since my flight lands at 10:20 a.m. on April 14, I’m hoping to get into the hotel room before lunch so I can change and review materials. \n \nCould you request early check‑in around 11:30 a.m. at the Marina Bay View Hotel (confirmation MBV‑448210)? \n \nAlso, the client wants a short meeting on April 15 from 8:00 to 9:30 a.m. near the hotel. If the hotel has a small meeting room, can we reserve one for that time? \n \nThanks, \nSofia \n \nSubject: Re: Singapore trip — early check-in and meeting room \nFrom: Ethan Walsh <ethan.walsh@eastviewcg.com \n> \nTo: Sofia Kim <sofia.kim@eastviewcg.com \n> \nDate: April 8, 2026 \n \nHi Sofia, \n \nGot it. I’ll contact the hotel today. \n \nFor early check‑in: I’ll request 11:30 a.m. specifically. If they can’t accommodate it, they should be able to store your luggage until the standard check‑in time. \n \nFor the meeting room: I can submit a request for 8:00–9:30 a.m. on April 15, but the hotel requires requests at least 48 hours in advance and a completed booking form. I’ll send the form to you once I get it from Guest Services. \n \nI’ll update you as soon as I hear back. \n \nBest, \nEthan \n \nQuestions"
   },
   {
     "id": 11,
     "type": "part5",
-    "title": "11강 (Part 5) — 비즈니스 빈출 동사 어휘 (3문항) ",
+    "title": "11강 (Part 5) — 비즈니스 빈출 동사 어휘 (3문항)",
     "questions": [
       {
-        "id": "11-7",
+        "id": "11-1",
         "question": "(문맥상 자연스러운 동사 선택: postpone)\nDue to the speaker’s illness, the company decided to _______ the seminar until next week.",
         "options": [
           "postpone",
@@ -509,7 +509,7 @@ const TOEIC_DATA = [
         "answer": "postpone"
       },
       {
-        "id": "11-8",
+        "id": "11-2",
         "question": "(동사-명사 결합: submit an application)\nApplicants must _______ an online application by March 15.",
         "options": [
           "submit",
@@ -520,7 +520,7 @@ const TOEIC_DATA = [
         "answer": "submit"
       },
       {
-        "id": "11-9",
+        "id": "11-3",
         "question": "(confusable words: raise vs rise)\nThe company plans to _______ prices slightly to cover increased material costs.",
         "options": [
           "raise",
@@ -535,7 +535,7 @@ const TOEIC_DATA = [
   {
     "id": 12,
     "type": "part6",
-    "title": "12강 (Part 6) — 시설 점검/출입 제한 내부 메모 (지문 1개 + 4문항) ",
+    "title": "12강 (Part 6) — 시설 점검/출입 제한 내부 메모 (지문 1개 + 4문항)",
     "questions": [
       {
         "id": "12-1",
@@ -582,15 +582,15 @@ const TOEIC_DATA = [
         "answer": "[2]"
       }
     ],
-    "passage": "12강 \n12강 (Part 6) — 시설 점검/출입 제한 내부 메모 (지문 1개 + 4문항) \n \nDirections: Read the text below and choose the best answer for each blank. \n \nINTERNAL MEMO \n \nTo: All Employees \nFrom: Facilities Management Office \nDate: February 21 \nSubject: Building Maintenance and Temporary Access Restrictions \n \nTo ensure a safe and reliable work environment, Facilities Management will conduct scheduled maintenance on the main electrical panel and the emergency power system next week. The work will be performed by an external contractor and will require limited access to several areas on Floors 3 through 5. [1] \n \nThe maintenance is scheduled (1) _______ 8:00 p.m. on Tuesday, February 24, to 6:00 a.m. on Wednesday, February 25. During this period, the east stairwell and two service elevators will be taken out of operation. Temporary signage will be posted to redirect foot traffic, and security staff will be stationed near the elevator lobby to assist employees leaving after evening meetings. [2] \n \nAccess to the server room (Room 4B) will be restricted throughout the maintenance window. Only employees who have been pre-approved by the IT Security team will be allowed (2) _______. If your work requires entry, submit a request to IT Security no later than 3 p.m. on Monday, February 23. Requests received after this deadline may not be processed in time, and access will not be granted. [3] \n \nPlease note that the cafeteria on the 3rd floor will be closed during the maintenance window (3) _______ noise and safety concerns. Vending machines near the west lobby will remain available. If you need to retrieve personal items from the cafeteria refrigerators, please do so before 7:30 p.m. on Tuesday. The contractor will also test emergency lighting and alarms at multiple points during the night. These tests may trigger short audible alerts lasting less than 30 seconds. Do not evacuate unless an alarm sounds continuously for more than one minute or unless you receive an announcement from Security. [4] \n \nThank you for your cooperation. If you have questions, contact Facilities Management at extension 4021."
+    "passage": "Directions: Read the text below and choose the best answer for each blank. \n \nINTERNAL MEMO \n \nTo: All Employees \nFrom: Facilities Management Office \nDate: February 21 \nSubject: Building Maintenance and Temporary Access Restrictions \n \nTo ensure a safe and reliable work environment, Facilities Management will conduct scheduled maintenance on the main electrical panel and the emergency power system next week. The work will be performed by an external contractor and will require limited access to several areas on Floors 3 through 5. [1] \n \nThe maintenance is scheduled (1) _______ 8:00 p.m. on Tuesday, February 24, to 6:00 a.m. on Wednesday, February 25. During this period, the east stairwell and two service elevators will be taken out of operation. Temporary signage will be posted to redirect foot traffic, and security staff will be stationed near the elevator lobby to assist employees leaving after evening meetings. [2] \n \nAccess to the server room (Room 4B) will be restricted throughout the maintenance window. Only employees who have been pre-approved by the IT Security team will be allowed (2) _______. If your work requires entry, submit a request to IT Security no later than 3 p.m. on Monday, February 23. Requests received after this deadline may not be processed in time, and access will not be granted. [3] \n \nPlease note that the cafeteria on the 3rd floor will be closed during the maintenance window (3) _______ noise and safety concerns. Vending machines near the west lobby will remain available. If you need to retrieve personal items from the cafeteria refrigerators, please do so before 7:30 p.m. on Tuesday. The contractor will also test emergency lighting and alarms at multiple points during the night. These tests may trigger short audible alerts lasting less than 30 seconds. Do not evacuate unless an alarm sounds continuously for more than one minute or unless you receive an announcement from Security. [4] \n \nThank you for your cooperation. If you have questions, contact Facilities Management at extension 4021."
   },
   {
     "id": 13,
     "type": "part5",
-    "title": "13강 (Part 5) — 수식어(형용사/부사)와 위치 (3문항) ",
+    "title": "13강 (Part 5) — 수식어(형용사/부사)와 위치 (3문항)",
     "questions": [
       {
-        "id": "13-10",
+        "id": "13-1",
         "question": "(형용사 vs 부사 선택)\nThe consultant spoke _______ about the risks involved in the merger.",
         "options": [
           "frank",
@@ -601,7 +601,7 @@ const TOEIC_DATA = [
         "answer": "frankly"
       },
       {
-        "id": "13-11",
+        "id": "13-2",
         "question": "(분사형 형용사: interested/interesting)\nEmployees are _______ in attending the training session on data privacy.",
         "options": [
           "interesting",
@@ -612,7 +612,7 @@ const TOEIC_DATA = [
         "answer": "interested"
       },
       {
-        "id": "13-12",
+        "id": "13-3",
         "question": "(수식어 위치로 의미 달라짐 / only 함정)\nThe manager discussed the proposal with the team _______.",
         "options": [
           "only yesterday",
@@ -627,10 +627,10 @@ const TOEIC_DATA = [
   {
     "id": 14,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 4) ",
+    "title": "14강 (Part 7) — Part 7 Multiple Passages (Set 4)",
     "questions": [
       {
-        "id": "14-16",
+        "id": "14-1",
         "question": "What discount code did Brighton Creative Studio use?",
         "options": [
           "SPRING5",
@@ -641,7 +641,7 @@ const TOEIC_DATA = [
         "answer": "SPRING15"
       },
       {
-        "id": "14-17",
+        "id": "14-2",
         "question": "Why will the 15% discount not reduce the $160.00 assembly charge?",
         "options": [
           "Because assembly is provided by a third-party vendor and cannot be billed online",
@@ -652,7 +652,7 @@ const TOEIC_DATA = [
         "answer": "Because the discount applies only to merchandise item prices, not services"
       },
       {
-        "id": "14-18",
+        "id": "14-3",
         "question": "What is the merchandise subtotal after the discount?",
         "options": [
           "$1,494.00",
@@ -663,7 +663,7 @@ const TOEIC_DATA = [
         "answer": "$1,269.90"
       },
       {
-        "id": "14-19",
+        "id": "14-4",
         "question": "When are the chairs most likely to arrive?",
         "options": [
           "May 20",
@@ -674,7 +674,7 @@ const TOEIC_DATA = [
         "answer": "May 28"
       },
       {
-        "id": "14-20",
+        "id": "14-5",
         "question": "How many Rewards points should Hana Reed expect to earn from this order?",
         "options": [
           "1,269 points",
@@ -685,12 +685,12 @@ const TOEIC_DATA = [
         "answer": "1,269 points"
       }
     ],
-    "passage": "14강 \nPart 7 Multiple Passages (Set 4) \n \nQuestions 16–20 refer to the following promotion, order confirmation, and e-mail. \n \nDocument 1: Promotion (Advertisement) \n \nMETRODESK OFFICE SUPPLY \nSpring Workspace Upgrade Event \nValid: May 1–May 15, 2026 (11:59 p.m. local time) \n \nRefresh your workspace with limited-time savings on select ergonomic items. \n \nOffer \n \n15% OFF select ergonomic furniture and accessories \n \nUse code: SPRING15 at checkout \n \nDiscount applies to merchandise item prices only (before tax) \n \nFree Shipping \n \nFree standard shipping on orders of $500 or more after discounts \n \nApplies to standard shipping only (expedited shipping not included) \n \nExclusions \n \nDiscount does not apply to: \n \nAssembly/installation services \n \nShipping charges \n \nTaxes \n \nGift cards and clearance items \n \nCannot be combined with other promo codes. \n \nRewards Points (MetroDesk Members) \n \nEarn 1 point per $1 spent on discounted merchandise subtotal. \n \nPoints are awarded as whole points; cents are not rounded up. \n \nService fees, shipping, and taxes do not earn points. \n \nPoints are posted within 3 business days after the order ships. \n \nReturns \n \nMost items can be returned within 30 days of delivery. \n \nOpened or assembled items may be subject to a 10% restocking fee. \n \nDocument 2: Order Confirmation \n \nMETRODESK OFFICE SUPPLY — Order Confirmation \nOrder No.: MD-582041 \nOrder Date: May 14, 2026 \nCustomer: Brighton Creative Studio \nShipping Method: Standard (Free) \n \nItems \n \nFlexRise Standing Desk 48\" (FR-48) \n \nQty: 2 \n \nUnit Price: $399.00 \n \nLine Total: $798.00 \n \nStatus: In stock \n \nErgoSeat Pro Chair (ESP) \n \nQty: 3 \n \nUnit Price: $189.00 \n \nLine Total: $567.00 \n \nStatus: Back-ordered (estimated ship May 24) \n \nDual Monitor Arm (DMA) \n \nQty: 1 \n \nUnit Price: $129.00 \n \nLine Total: $129.00 \n \nStatus: In stock \n \nMerchandise Subtotal (before discount): $1,494.00 \nPromo Code Applied: SPRING15 (15% off merchandise) \nDiscount: -$224.10 \nMerchandise Subtotal (after discount): $1,269.90 \n \nAssembly & Placement Service: $160.00 \nStandard Shipping: $0.00 \nSales Tax (8.75% on discounted merchandise): $111.12 \n \nTotal Charged: $1,541.02 \n \nShipment Schedule (Estimated) \n \nShipment A (Desks + Monitor Arm): ships May 16, arrives May 20 \n \nShipment B (Chairs): ships May 24, arrives May 28 \n \nDocument 3: E-mail \n \nSubject: Questions about MD-582041 — discount and split delivery \nFrom: Hana Reed <hana@brightoncreative.com \n> \nTo: support@metrodesk.com \n \nDate: May 14, 2026 \n \nHello, \n \nI placed order MD-582041 today and used the SPRING15 code. Thank you—everything looks mostly correct, but I have two questions: \n \nThe assembly service shows $160.00. Shouldn’t the 15% discount apply to that as well? \n \nThe confirmation shows two shipments and the chairs arriving later. We’re setting up for a team move next week—can everything arrive by May 20? \n \nAlso, we’re MetroDesk Rewards members. Can you confirm how many points this order will earn? \n \nBest, \nHana Reed \n \nSubject: Re: Questions about MD-582041 — discount and split delivery \nFrom: MetroDesk Support <support@metrodesk.com \n> \nTo: Hana Reed <hana@brightoncreative.com \n> \nDate: May 14, 2026 \n \nHi Hana, \n \nThanks for reaching out. \n \nThe Spring Workspace Upgrade discount applies to merchandise only. Assembly/placement services are excluded, so the $160.00 service fee is correct. \n \nThe chairs are currently back-ordered, which is why the order is split. We can’t guarantee arrival by May 20 for the chairs. If the later delivery won’t work, you may cancel the chair line item before it ships. \n \nRegarding Rewards points: points are earned on the discounted merchandise subtotal only (excluding service fees, shipping, and tax). Points post after shipments go out. \n \nPlease let us know if you’d like to cancel the chair line. \n \nKind regards, \nMetroDesk Support Team \n \nQuestions"
+    "passage": "Questions 16–20 refer to the following promotion, order confirmation, and e-mail. \n \nDocument 1: Promotion (Advertisement) \n \nMETRODESK OFFICE SUPPLY \nSpring Workspace Upgrade Event \nValid: May 1–May 15, 2026 (11:59 p.m. local time) \n \nRefresh your workspace with limited-time savings on select ergonomic items. \n \nOffer \n \n15% OFF select ergonomic furniture and accessories \n \nUse code: SPRING15 at checkout \n \nDiscount applies to merchandise item prices only (before tax) \n \nFree Shipping \n \nFree standard shipping on orders of $500 or more after discounts \n \nApplies to standard shipping only (expedited shipping not included) \n \nExclusions \n \nDiscount does not apply to: \n \nAssembly/installation services \n \nShipping charges \n \nTaxes \n \nGift cards and clearance items \n \nCannot be combined with other promo codes. \n \nRewards Points (MetroDesk Members) \n \nEarn 1 point per $1 spent on discounted merchandise subtotal. \n \nPoints are awarded as whole points; cents are not rounded up. \n \nService fees, shipping, and taxes do not earn points. \n \nPoints are posted within 3 business days after the order ships. \n \nReturns \n \nMost items can be returned within 30 days of delivery. \n \nOpened or assembled items may be subject to a 10% restocking fee. \n \nDocument 2: Order Confirmation \n \nMETRODESK OFFICE SUPPLY — Order Confirmation \nOrder No.: MD-582041 \nOrder Date: May 14, 2026 \nCustomer: Brighton Creative Studio \nShipping Method: Standard (Free) \n \nItems \n \nFlexRise Standing Desk 48\" (FR-48) \n \nQty: 2 \n \nUnit Price: $399.00 \n \nLine Total: $798.00 \n \nStatus: In stock \n \nErgoSeat Pro Chair (ESP) \n \nQty: 3 \n \nUnit Price: $189.00 \n \nLine Total: $567.00 \n \nStatus: Back-ordered (estimated ship May 24) \n \nDual Monitor Arm (DMA) \n \nQty: 1 \n \nUnit Price: $129.00 \n \nLine Total: $129.00 \n \nStatus: In stock \n \nMerchandise Subtotal (before discount): $1,494.00 \nPromo Code Applied: SPRING15 (15% off merchandise) \nDiscount: -$224.10 \nMerchandise Subtotal (after discount): $1,269.90 \n \nAssembly & Placement Service: $160.00 \nStandard Shipping: $0.00 \nSales Tax (8.75% on discounted merchandise): $111.12 \n \nTotal Charged: $1,541.02 \n \nShipment Schedule (Estimated) \n \nShipment A (Desks + Monitor Arm): ships May 16, arrives May 20 \n \nShipment B (Chairs): ships May 24, arrives May 28 \n \nDocument 3: E-mail \n \nSubject: Questions about MD-582041 — discount and split delivery \nFrom: Hana Reed <hana@brightoncreative.com \n> \nTo: support@metrodesk.com \n \nDate: May 14, 2026 \n \nHello, \n \nI placed order MD-582041 today and used the SPRING15 code. Thank you—everything looks mostly correct, but I have two questions: \n \nThe assembly service shows $160.00. Shouldn’t the 15% discount apply to that as well? \n \nThe confirmation shows two shipments and the chairs arriving later. We’re setting up for a team move next week—can everything arrive by May 20? \n \nAlso, we’re MetroDesk Rewards members. Can you confirm how many points this order will earn? \n \nBest, \nHana Reed \n \nSubject: Re: Questions about MD-582041 — discount and split delivery \nFrom: MetroDesk Support <support@metrodesk.com \n> \nTo: Hana Reed <hana@brightoncreative.com \n> \nDate: May 14, 2026 \n \nHi Hana, \n \nThanks for reaching out. \n \nThe Spring Workspace Upgrade discount applies to merchandise only. Assembly/placement services are excluded, so the $160.00 service fee is correct. \n \nThe chairs are currently back-ordered, which is why the order is split. We can’t guarantee arrival by May 20 for the chairs. If the later delivery won’t work, you may cancel the chair line item before it ships. \n \nRegarding Rewards points: points are earned on the discounted merchandise subtotal only (excluding service fees, shipping, and tax). Points post after shipments go out. \n \nPlease let us know if you’d like to cancel the chair line. \n \nKind regards, \nMetroDesk Support Team \n \nQuestions"
   },
   {
     "id": 15,
     "type": "part5",
-    "title": "15강 (Part 5) — 관계사/관계절 (3문항) ",
+    "title": "15강 (Part 5) — 관계사/관계절 (3문항)",
     "questions": [
       {
         "id": "15-1",
@@ -730,7 +730,7 @@ const TOEIC_DATA = [
   {
     "id": 16,
     "type": "part6",
-    "title": "16강 (Part 6) — 사내 설문/피드백 요청 이메일 (지문 1개 + 4문항) ",
+    "title": "16강 (Part 6) — 사내 설문/피드백 요청 이메일 (지문 1개 + 4문항)",
     "questions": [
       {
         "id": "16-1",
@@ -777,12 +777,12 @@ const TOEIC_DATA = [
         "answer": "[2]"
       }
     ],
-    "passage": "16강 \n16강 (Part 6) — 사내 설문/피드백 요청 이메일 (지문 1개 + 4문항) \n \nDirections: Read the text below and choose the best answer for each blank. \n \nSubject: Request for Feedback on the Updated Expense Reimbursement Process \n \nDear Colleagues, \n \nAs part of our ongoing effort to improve internal services, the Finance Operations team is collecting feedback on the updated expense reimbursement process introduced at the beginning of this quarter. Since the launch, we have received several questions about receipt uploads, approval timing, and the status notifications employees receive after submitting a claim. Your input will help us identify which steps are clear and which steps require additional guidance or system improvements. [1] \n \nThe survey consists of 10 questions and should take no more than five minutes to complete. It covers topics such as how easy it was to locate the correct expense category, whether the mobile upload function worked as expected, and how quickly you received a decision from your approver. Please answer as honestly as possible—even if you have not submitted many claims yet—so that we can understand a wide range of experiences across departments. [2] \n \nTo participate, click the survey link below and submit your responses (1) _______ 5 p.m. on Friday, February 27. The link will remain active until the deadline, but responses received after that time may not be included in the first review report. We plan to share a brief summary of the results with department managers in early March, along with any immediate changes we can implement. [3] \n \nSurvey link: (Internal Portal → Finance → Expense Feedback) \n \nIf you experienced a technical problem—for example, you could not attach a receipt or the page froze while loading—please include a short description in the final comment box. You may also attach a screenshot. Our support team will review these reports separately (2) _______ the survey responses, since technical issues often require direct follow-up. Your input will be used to (3) _______ future updates to the reimbursement guidelines. [4] \n \nThank you in advance for your time and cooperation. If you have questions about the survey, contact Finance Operations at financeops@company.example \n. \n \nSincerely, \nFinance Operations"
+    "passage": "Directions: Read the text below and choose the best answer for each blank. \n \nSubject: Request for Feedback on the Updated Expense Reimbursement Process \n \nDear Colleagues, \n \nAs part of our ongoing effort to improve internal services, the Finance Operations team is collecting feedback on the updated expense reimbursement process introduced at the beginning of this quarter. Since the launch, we have received several questions about receipt uploads, approval timing, and the status notifications employees receive after submitting a claim. Your input will help us identify which steps are clear and which steps require additional guidance or system improvements. [1] \n \nThe survey consists of 10 questions and should take no more than five minutes to complete. It covers topics such as how easy it was to locate the correct expense category, whether the mobile upload function worked as expected, and how quickly you received a decision from your approver. Please answer as honestly as possible—even if you have not submitted many claims yet—so that we can understand a wide range of experiences across departments. [2] \n \nTo participate, click the survey link below and submit your responses (1) _______ 5 p.m. on Friday, February 27. The link will remain active until the deadline, but responses received after that time may not be included in the first review report. We plan to share a brief summary of the results with department managers in early March, along with any immediate changes we can implement. [3] \n \nSurvey link: (Internal Portal → Finance → Expense Feedback) \n \nIf you experienced a technical problem—for example, you could not attach a receipt or the page froze while loading—please include a short description in the final comment box. You may also attach a screenshot. Our support team will review these reports separately (2) _______ the survey responses, since technical issues often require direct follow-up. Your input will be used to (3) _______ future updates to the reimbursement guidelines. [4] \n \nThank you in advance for your time and cooperation. If you have questions about the survey, contact Finance Operations at financeops@company.example \n. \n \nSincerely, \nFinance Operations"
   },
   {
     "id": 17,
     "type": "part5",
-    "title": "17강 (Part 5) — 보고서/정책/규정 어휘 (3문항) ",
+    "title": "17강 (Part 5) — 보고서/정책/규정 어휘 (3문항)",
     "questions": [
       {
         "id": "17-1",
@@ -822,10 +822,10 @@ const TOEIC_DATA = [
   {
     "id": 18,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 5) ",
+    "title": "18강 (Part 7) — Part 7 Multiple Passages (Set 5)",
     "questions": [
       {
-        "id": "18-21",
+        "id": "18-1",
         "question": "According to the job posting, which task is part of the Client Support Coordinator’s responsibilities?",
         "options": [
           "Negotiating supplier contracts for medical equipment",
@@ -836,7 +836,7 @@ const TOEIC_DATA = [
         "answer": "Preparing a weekly report summarizing open cases and resolutions"
       },
       {
-        "id": "18-22",
+        "id": "18-2",
         "question": "What did Grace Han ask Daniel Ortiz to do by Thursday, June 4?",
         "options": [
           "Send a revised cover letter and two professional references",
@@ -847,7 +847,7 @@ const TOEIC_DATA = [
         "answer": "Confirm the interview time and provide a phone number"
       },
       {
-        "id": "18-23",
+        "id": "18-3",
         "question": "Where should Daniel Ortiz enter the building on the day of his interview?",
         "options": [
           "The Main Entrance at Central Plaza",
@@ -858,7 +858,7 @@ const TOEIC_DATA = [
         "answer": "The South Entrance on Pine Street"
       },
       {
-        "id": "18-24",
+        "id": "18-4",
         "question": "According to the visitor instructions, what must Daniel present in order to receive a visitor badge?",
         "options": [
           "A printed copy of his resume",
@@ -869,7 +869,7 @@ const TOEIC_DATA = [
         "answer": "A government-issued photo ID"
       },
       {
-        "id": "18-25",
+        "id": "18-5",
         "question": "Based on the e-mail and the visitor instructions, who will most likely escort Daniel beyond the lobby?",
         "options": [
           "A Summit One Building security officer",
@@ -880,15 +880,15 @@ const TOEIC_DATA = [
         "answer": "Grace Han"
       }
     ],
-    "passage": "18강 \nPart 7 Multiple Passages (Set 5) \n \nQuestions 21–25 refer to the following job posting, e-mail, and visitor instructions. \n \nDocument 1: Job Posting \n \nNORTHGATE MEDICAL SUPPLIES \nPosition: Client Support Coordinator (Full-time) \nLocation: Northgate Headquarters — Summit One Building (Seoul) \nDepartment: Client Operations \nPosting Date: May 25, 2026 \nApplication Deadline: Wednesday, June 3, 2026 (5:00 p.m.) \n \nNorthgate Medical Supplies supports clinics and hospitals with recurring orders of medical equipment and consumables. The Client Operations team serves as the main point of contact for customers after a purchase is placed, ensuring accurate delivery schedules and clear communication. \n \nKey Responsibilities \n \nRespond to customer inquiries by e-mail and phone regarding order status, delivery windows, and product availability \n \nCreate and update customer cases in the client support portal and route issues to Logistics or Billing as needed \n \nConfirm shipment details with internal teams and notify customers of any schedule changes \n \nPrepare a short weekly summary report of open cases and resolutions \n \nCoordinate with Sales to schedule product orientation calls for new clinic accounts \n \nRequirements \n \nStrong written communication in English (professional e-mail writing) \n \nAbility to organize multiple requests under time constraints \n \nExperience with office productivity tools (spreadsheets, calendars) \n \nCustomer service or administrative experience preferred (healthcare industry experience is a plus) \n \nWork Schedule and Compensation \n \nMonday–Friday, 9:00 a.m.–6:00 p.m. \n \nSalary depends on experience; standard benefits package included \n \nThis role is based on-site. Occasional remote work may be approved after the onboarding period. \n \nHow to Apply \n \nPlease submit (1) a resume and (2) a short cover e-mail describing your relevant experience to: \nrecruiting@northgatemed.com \n \nSubject line: Client Support Coordinator — [Your Name] \n \nOnly candidates selected for interviews will be contacted. \n \nDocument 2: E-mail \n \nSubject: Interview invitation — Client Support Coordinator \nFrom: Grace Han <grace.han@northgatemed.com \n> \nTo: Daniel Ortiz <daniel.ortiz@email.com \n> \nDate: June 2, 2026 \n \nHello Daniel, \n \nThank you for applying for the Client Support Coordinator position. We would like to invite you to an on-site interview at our headquarters. \n \nProposed interview time: \n \nMonday, June 8 at 10:30 a.m. (approximately 60 minutes) \n \nTo confirm, please reply by Thursday, June 4 with: \n \nConfirmation that you can attend at 10:30 a.m., and \n \nA phone number where we can reach you on the morning of the interview. \n \nWhat to bring: \n \nA government-issued photo ID (required for building access) \n \nA copy of your resume (printed or on your device) \n \nThe interview will include a short discussion about how you handle customer requests and prioritize tasks. \n \nBest regards, \nGrace Han \nRecruiting Coordinator | Northgate Medical Supplies \n \nSubject: Re: Interview invitation — Client Support Coordinator \nFrom: Daniel Ortiz <daniel.ortiz@email.com \n> \nTo: Grace Han <grace.han@northgatemed.com \n> \nDate: June 3, 2026 \n \nHi Grace, \n \nThank you for the invitation. Monday, June 8 at 10:30 a.m. works for me. You can reach me at 010-8822-1940. \n \nOne quick question: I plan to arrive by taxi. Is visitor parking required, or can the driver drop me off at the main entrance? \n \nThanks again, \nDaniel \n \nSubject: Re: Interview invitation — Client Support Coordinator \nFrom: Grace Han <grace.han@northgatemed.com \n> \nTo: Daniel Ortiz <daniel.ortiz@email.com \n> \nDate: June 3, 2026 \n \nHi Daniel, \n \nGreat—thank you for confirming. \n \nFor drop-off, it’s best to use the South Entrance this week due to construction near the main entrance. Your driver can drop you off there. \n \nWhen you arrive, please check in at the Lobby A Visitor Desk. After you receive a badge, I will meet you in the lobby and escort you to the interview room. \n \nSee you Monday, \nGrace \n \nDocument 3: Visitor Instructions \n \nSUMMIT ONE BUILDING — VISITOR CHECK-IN GUIDE \nUpdated: May 30, 2026 \n \nWelcome to Summit One Building. To maintain safety and reduce delays, all visitors must follow the procedures below. \n \nEntrance and Check-in \n \nVisitors must enter through the South Entrance (Pine Street). \n \nThe Main Entrance (Central Plaza) may have restricted access due to seasonal construction and crowd control. \n \nAll visitors must check in at the Lobby A Visitor Desk before proceeding to elevators. \n \nIdentification and Badges \n \nA government-issued photo ID is required to receive a visitor badge. \n \nBadges must be worn visibly at all times. \n \nVisitors who do not have an ID may be asked to reschedule their appointment. \n \nEscort Policy \n \nVisitors may wait only in the designated lobby seating area. \n \nAccess beyond the lobby requires an escort from the hosting company. \n \nSecurity staff will not escort visitors to tenant offices. \n \nVisitor Parking (Limited) \n \nVisitor parking is limited and not guaranteed. \n \nTenants may request a small number of visitor passes two business days in advance. \n \nWithout a pass, visitors should use public transportation or be dropped off at the South Entrance. \n \nProhibited Items and Screening \n \nLarge packages and delivery carts are not permitted through Lobby A. \n \nSecurity may conduct random bag checks. \n \nPlease allow extra time during peak hours (9:00–10:30 a.m.). \n \nThank you for your cooperation. \n \nQuestions"
+    "passage": "Questions 21–25 refer to the following job posting, e-mail, and visitor instructions. \n \nDocument 1: Job Posting \n \nNORTHGATE MEDICAL SUPPLIES \nPosition: Client Support Coordinator (Full-time) \nLocation: Northgate Headquarters — Summit One Building (Seoul) \nDepartment: Client Operations \nPosting Date: May 25, 2026 \nApplication Deadline: Wednesday, June 3, 2026 (5:00 p.m.) \n \nNorthgate Medical Supplies supports clinics and hospitals with recurring orders of medical equipment and consumables. The Client Operations team serves as the main point of contact for customers after a purchase is placed, ensuring accurate delivery schedules and clear communication. \n \nKey Responsibilities \n \nRespond to customer inquiries by e-mail and phone regarding order status, delivery windows, and product availability \n \nCreate and update customer cases in the client support portal and route issues to Logistics or Billing as needed \n \nConfirm shipment details with internal teams and notify customers of any schedule changes \n \nPrepare a short weekly summary report of open cases and resolutions \n \nCoordinate with Sales to schedule product orientation calls for new clinic accounts \n \nRequirements \n \nStrong written communication in English (professional e-mail writing) \n \nAbility to organize multiple requests under time constraints \n \nExperience with office productivity tools (spreadsheets, calendars) \n \nCustomer service or administrative experience preferred (healthcare industry experience is a plus) \n \nWork Schedule and Compensation \n \nMonday–Friday, 9:00 a.m.–6:00 p.m. \n \nSalary depends on experience; standard benefits package included \n \nThis role is based on-site. Occasional remote work may be approved after the onboarding period. \n \nHow to Apply \n \nPlease submit (1) a resume and (2) a short cover e-mail describing your relevant experience to: \nrecruiting@northgatemed.com \n \nSubject line: Client Support Coordinator — [Your Name] \n \nOnly candidates selected for interviews will be contacted. \n \nDocument 2: E-mail \n \nSubject: Interview invitation — Client Support Coordinator \nFrom: Grace Han <grace.han@northgatemed.com \n> \nTo: Daniel Ortiz <daniel.ortiz@email.com \n> \nDate: June 2, 2026 \n \nHello Daniel, \n \nThank you for applying for the Client Support Coordinator position. We would like to invite you to an on-site interview at our headquarters. \n \nProposed interview time: \n \nMonday, June 8 at 10:30 a.m. (approximately 60 minutes) \n \nTo confirm, please reply by Thursday, June 4 with: \n \nConfirmation that you can attend at 10:30 a.m., and \n \nA phone number where we can reach you on the morning of the interview. \n \nWhat to bring: \n \nA government-issued photo ID (required for building access) \n \nA copy of your resume (printed or on your device) \n \nThe interview will include a short discussion about how you handle customer requests and prioritize tasks. \n \nBest regards, \nGrace Han \nRecruiting Coordinator | Northgate Medical Supplies \n \nSubject: Re: Interview invitation — Client Support Coordinator \nFrom: Daniel Ortiz <daniel.ortiz@email.com \n> \nTo: Grace Han <grace.han@northgatemed.com \n> \nDate: June 3, 2026 \n \nHi Grace, \n \nThank you for the invitation. Monday, June 8 at 10:30 a.m. works for me. You can reach me at 010-8822-1940. \n \nOne quick question: I plan to arrive by taxi. Is visitor parking required, or can the driver drop me off at the main entrance? \n \nThanks again, \nDaniel \n \nSubject: Re: Interview invitation — Client Support Coordinator \nFrom: Grace Han <grace.han@northgatemed.com \n> \nTo: Daniel Ortiz <daniel.ortiz@email.com \n> \nDate: June 3, 2026 \n \nHi Daniel, \n \nGreat—thank you for confirming. \n \nFor drop-off, it’s best to use the South Entrance this week due to construction near the main entrance. Your driver can drop you off there. \n \nWhen you arrive, please check in at the Lobby A Visitor Desk. After you receive a badge, I will meet you in the lobby and escort you to the interview room. \n \nSee you Monday, \nGrace \n \nDocument 3: Visitor Instructions \n \nSUMMIT ONE BUILDING — VISITOR CHECK-IN GUIDE \nUpdated: May 30, 2026 \n \nWelcome to Summit One Building. To maintain safety and reduce delays, all visitors must follow the procedures below. \n \nEntrance and Check-in \n \nVisitors must enter through the South Entrance (Pine Street). \n \nThe Main Entrance (Central Plaza) may have restricted access due to seasonal construction and crowd control. \n \nAll visitors must check in at the Lobby A Visitor Desk before proceeding to elevators. \n \nIdentification and Badges \n \nA government-issued photo ID is required to receive a visitor badge. \n \nBadges must be worn visibly at all times. \n \nVisitors who do not have an ID may be asked to reschedule their appointment. \n \nEscort Policy \n \nVisitors may wait only in the designated lobby seating area. \n \nAccess beyond the lobby requires an escort from the hosting company. \n \nSecurity staff will not escort visitors to tenant offices. \n \nVisitor Parking (Limited) \n \nVisitor parking is limited and not guaranteed. \n \nTenants may request a small number of visitor passes two business days in advance. \n \nWithout a pass, visitors should use public transportation or be dropped off at the South Entrance. \n \nProhibited Items and Screening \n \nLarge packages and delivery carts are not permitted through Lobby A. \n \nSecurity may conduct random bag checks. \n \nPlease allow extra time during peak hours (9:00–10:30 a.m.). \n \nThank you for your cooperation. \n \nQuestions"
   },
   {
     "id": 19,
     "type": "part5",
-    "title": "19강 (Part 5) — 전치사/전치사구(문법+결합) (3문항) ",
+    "title": "19강 (Part 5) — 전치사/전치사구(문법+결합) (3문항)",
     "questions": [
       {
-        "id": "19-4",
+        "id": "19-1",
         "question": "(in/at/on 시간)\nThe audit will begin _______ 9:00 a.m. on Monday.",
         "options": [
           "in",
@@ -899,7 +899,7 @@ const TOEIC_DATA = [
         "answer": "at"
       },
       {
-        "id": "19-5",
+        "id": "19-2",
         "question": "(because vs because of / 접속사 자리 함정)\nThe meeting was canceled _______ the project manager was out of town.",
         "options": [
           "because",
@@ -910,7 +910,7 @@ const TOEIC_DATA = [
         "answer": "because"
       },
       {
-        "id": "19-6",
+        "id": "19-3",
         "question": "(전치사 결합: be interested in)\nMany candidates are interested _______ applying for the internship program.",
         "options": [
           "to",
@@ -925,7 +925,7 @@ const TOEIC_DATA = [
   {
     "id": 20,
     "type": "part6",
-    "title": "20강 (Part 6) 수정본 — 환불 안내 이메일 (지문 1개 + 4문항) ",
+    "title": "20강 (Part 6) — 환불 안내 이메일 (지문 1개 + 4문항)",
     "questions": [
       {
         "id": "20-1",
@@ -972,15 +972,15 @@ const TOEIC_DATA = [
         "answer": "[2]"
       }
     ],
-    "passage": "20강 (Part 6) 수정본 — 환불 안내 이메일 (지문 1개 + 4문항) \n \nDirections: Read the text below and choose the best answer for each blank. \n \nSubject: Update on Your Refund Request (Order #NB-77104) \n \nDear Mr. Lewis, \n \nThank you for contacting Northbay Retail Support regarding your refund request for Order #NB-77104. We appreciate you bringing this matter to our attention, and we apologize for the inconvenience you experienced. \n \nAfter reviewing your account, we confirmed that the item you received (Model TR-55 headset) does not match the product listed on your order confirmation. This type of error is uncommon, but it can occur when packaging labels are printed incorrectly during high-volume processing. [1] \n \nTo resolve the issue, we have created a return authorization for your order. A prepaid shipping label will be sent to you in a separate email within the next hour. Please print the label, attach it to the package, and drop the parcel off at any Yamato Transport location. If you no longer have the original box, you may use another sturdy box, as long as the item is (1) _______ packed to prevent damage in transit. [2] \n \nOnce the package is scanned by the carrier, the return will be tracked automatically in our system. You can check the status in your online account under “My Orders.” We will issue the refund to your original payment method (credit card) within 3–5 business days after we receive and inspect the returned item. (2) _______ you paid using a debit card, the posting time may depend on your bank’s processing schedule. [3] \n \nIf you would prefer an exchange instead of a refund, please reply to this email and let us know. We can ship the correct item as soon as we receive confirmation that the return is in transit. (3) _______ , if the product is currently out of stock, we will notify you immediately and offer alternative options. [4] \n \nThank you again for your patience. If you have any questions, please contact us by replying to this message. \n \nSincerely, \nCustomer Support Team \nNorthbay Retail"
+    "passage": "Directions: Read the text below and choose the best answer for each blank. \n \nSubject: Update on Your Refund Request (Order #NB-77104) \n \nDear Mr. Lewis, \n \nThank you for contacting Northbay Retail Support regarding your refund request for Order #NB-77104. We appreciate you bringing this matter to our attention, and we apologize for the inconvenience you experienced. \n \nAfter reviewing your account, we confirmed that the item you received (Model TR-55 headset) does not match the product listed on your order confirmation. This type of error is uncommon, but it can occur when packaging labels are printed incorrectly during high-volume processing. [1] \n \nTo resolve the issue, we have created a return authorization for your order. A prepaid shipping label will be sent to you in a separate email within the next hour. Please print the label, attach it to the package, and drop the parcel off at any Yamato Transport location. If you no longer have the original box, you may use another sturdy box, as long as the item is (1) _______ packed to prevent damage in transit. [2] \n \nOnce the package is scanned by the carrier, the return will be tracked automatically in our system. You can check the status in your online account under “My Orders.” We will issue the refund to your original payment method (credit card) within 3–5 business days after we receive and inspect the returned item. (2) _______ you paid using a debit card, the posting time may depend on your bank’s processing schedule. [3] \n \nIf you would prefer an exchange instead of a refund, please reply to this email and let us know. We can ship the correct item as soon as we receive confirmation that the return is in transit. (3) _______ , if the product is currently out of stock, we will notify you immediately and offer alternative options. [4] \n \nThank you again for your patience. If you have any questions, please contact us by replying to this message. \n \nSincerely, \nCustomer Support Team \nNorthbay Retail"
   },
   {
     "id": 21,
     "type": "part5",
-    "title": "21강 (Part 5) — 동명사/부정사(gerund vs infinitive) (3문항) ",
+    "title": "21강 (Part 5) — 동명사/부정사(gerund vs infinitive) (3문항)",
     "questions": [
       {
-        "id": "21-7",
+        "id": "21-1",
         "question": "(동명사만: avoid + V-ing)\nTo reduce delays, please avoid _______ requests at the last minute.",
         "options": [
           "submit",
@@ -991,7 +991,7 @@ const TOEIC_DATA = [
         "answer": "submitting"
       },
       {
-        "id": "21-8",
+        "id": "21-2",
         "question": "(둘 다 가능하나 의미/형태 함정 최소화: plan to + V)\nThe regional office plans _______ additional staff during the peak season.",
         "options": [
           "hiring",
@@ -1002,7 +1002,7 @@ const TOEIC_DATA = [
         "answer": "to hire"
       },
       {
-        "id": "21-9",
+        "id": "21-3",
         "question": "(품사/형태 함정: be responsible for + V-ing / 명사)\nMs. Ortiz is responsible for _______ the weekly performance report.",
         "options": [
           "prepare",
@@ -1017,10 +1017,10 @@ const TOEIC_DATA = [
   {
     "id": 22,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 6) ",
+    "title": "22강 (Part 7) — Part 7 Multiple Passages (Set 6)",
     "questions": [
       {
-        "id": "22-26",
+        "id": "22-1",
         "question": "According to the schedule, what is the registration deadline for Session A?",
         "options": [
           "July 9",
@@ -1031,7 +1031,7 @@ const TOEIC_DATA = [
         "answer": "July 10"
       },
       {
-        "id": "22-27",
+        "id": "22-2",
         "question": "Why did Jae-min Cho contact the Training Desk?",
         "options": [
           "To request a refund for a workshop fee",
@@ -1042,7 +1042,7 @@ const TOEIC_DATA = [
         "answer": "To ask whether he can attend remotely and whether seats are available"
       },
       {
-        "id": "22-28",
+        "id": "22-3",
         "question": "Which session will Jae-min most likely choose?",
         "options": [
           "Session A (July 14)",
@@ -1053,7 +1053,7 @@ const TOEIC_DATA = [
         "answer": "Session A (July 14)"
       },
       {
-        "id": "22-29",
+        "id": "22-4",
         "question": "What will Jae-min receive after he registers for a session?",
         "options": [
           "A visitor parking pass for Summit One Building",
@@ -1064,7 +1064,7 @@ const TOEIC_DATA = [
         "answer": "A confirmation e-mail with a portal practice link"
       },
       {
-        "id": "22-30",
+        "id": "22-5",
         "question": "What must participants do by 5:00 p.m. the day before their session?",
         "options": [
           "Submit a report to their supervisor",
@@ -1075,12 +1075,12 @@ const TOEIC_DATA = [
         "answer": "Complete an online readiness check"
       }
     ],
-    "passage": "22강 \nPart 7 Multiple Passages (Set 6) \n \nQuestions 26–30 refer to the following workshop schedule and e-mails. \n \nDocument 1: Workshop Schedule \n \nNORTHGATE MEDICAL SUPPLIES — Client Portal Workshops \nLocation: Summit One Building, Room 8C (On-site only) \nWhat to bring: Laptop + charger \nPre-work: Complete the online Readiness Check by 5:00 p.m. the day before your session. \n \nSession\tDate\tTime\tRegistration Deadline\tSeats \nA\tTue, July 14\t2:00–4:00 p.m.\tFri, July 10\t20 \nB\tWed, July 15\t9:00–11:00 a.m.\tSat, July 11\t20 \nC\tFri, July 17\t1:00–3:00 p.m.\tMon, July 13\t20 \n \nNotes \n \nSeats are assigned on a first-come, first-served basis. \n \nA confirmation e-mail with the portal practice link will be sent after registration. \n \nIf a session is full, employees may join a waitlist. \n \nDocument 2: E-mail \n \nSubject: Portal workshop registration — question about remote option \nFrom: Jae-min Cho <jaemin.cho@northgatemed.com \n> \nTo: Training Desk <training@northgatemed.com \n> \nDate: July 9, 2026 \n \nHello, \n \nI’d like to attend a Client Portal Workshop next week, but I will be traveling out of town on July 15 in the morning. \n \nDo you still have seats available for any session? \n \nIs there a way to join remotely, or is it on-site only? \n \nThanks, \nJae-min Cho \nClient Operations \n \nDocument 3: E-mail \n \nSubject: Re: Portal workshop registration — question about remote option \nFrom: Training Desk <training@northgatemed.com \n> \nTo: Jae-min Cho <jaemin.cho@northgatemed.com \n> \nDate: July 9, 2026 \n \nHi Jae-min, \n \nThanks for checking. \n \nAll sessions are on-site only this month. However, a recording will be posted on the intranet after the final session. \n \nAs of today: \n \nSession A (July 14) has a few seats remaining. \n \nSession B (July 15) has seats available. \n \nSession C (July 17) is full. \n \nIf you register for Session A or B, you’ll receive a confirmation e-mail with the practice link and the Readiness Check instructions. Please remember to complete the Readiness Check by 5:00 p.m. the day before your session. \n \nBest, \nTraining Desk \n \nQuestions"
+    "passage": "Questions 26–30 refer to the following workshop schedule and e-mails. \n \nDocument 1: Workshop Schedule \n \nNORTHGATE MEDICAL SUPPLIES — Client Portal Workshops \nLocation: Summit One Building, Room 8C (On-site only) \nWhat to bring: Laptop + charger \nPre-work: Complete the online Readiness Check by 5:00 p.m. the day before your session. \n \nSession\tDate\tTime\tRegistration Deadline\tSeats \nA\tTue, July 14\t2:00–4:00 p.m.\tFri, July 10\t20 \nB\tWed, July 15\t9:00–11:00 a.m.\tSat, July 11\t20 \nC\tFri, July 17\t1:00–3:00 p.m.\tMon, July 13\t20 \n \nNotes \n \nSeats are assigned on a first-come, first-served basis. \n \nA confirmation e-mail with the portal practice link will be sent after registration. \n \nIf a session is full, employees may join a waitlist. \n \nDocument 2: E-mail \n \nSubject: Portal workshop registration — question about remote option \nFrom: Jae-min Cho <jaemin.cho@northgatemed.com \n> \nTo: Training Desk <training@northgatemed.com \n> \nDate: July 9, 2026 \n \nHello, \n \nI’d like to attend a Client Portal Workshop next week, but I will be traveling out of town on July 15 in the morning. \n \nDo you still have seats available for any session? \n \nIs there a way to join remotely, or is it on-site only? \n \nThanks, \nJae-min Cho \nClient Operations \n \nDocument 3: E-mail \n \nSubject: Re: Portal workshop registration — question about remote option \nFrom: Training Desk <training@northgatemed.com \n> \nTo: Jae-min Cho <jaemin.cho@northgatemed.com \n> \nDate: July 9, 2026 \n \nHi Jae-min, \n \nThanks for checking. \n \nAll sessions are on-site only this month. However, a recording will be posted on the intranet after the final session. \n \nAs of today: \n \nSession A (July 14) has a few seats remaining. \n \nSession B (July 15) has seats available. \n \nSession C (July 17) is full. \n \nIf you register for Session A or B, you’ll receive a confirmation e-mail with the practice link and the Readiness Check instructions. Please remember to complete the Readiness Check by 5:00 p.m. the day before your session. \n \nBest, \nTraining Desk \n \nQuestions"
   },
   {
     "id": 23,
     "type": "part5",
-    "title": "23강 (Part 5) — 빈출 형용사 어휘 (난이도: 쉬움) (3문항) ",
+    "title": "23강 (Part 5) — 빈출 형용사 어휘 (난이도: 쉬움) (3문항)",
     "questions": [
       {
         "id": "23-1",
@@ -1120,7 +1120,7 @@ const TOEIC_DATA = [
   {
     "id": 24,
     "type": "part6",
-    "title": "24강 (Part 6) — 행사 등록 안내(등록 방법/마감/좌석 제한) (지문 1개 + 4문항) ",
+    "title": "24강 (Part 6) — 행사 등록 안내(등록 방법/마감/좌석 제한) (지문 1개 + 4문항)",
     "questions": [
       {
         "id": "24-1",
@@ -1162,20 +1162,20 @@ const TOEIC_DATA = [
           "[1]",
           "[2]",
           "[3]",
-          "[4] \n: (1) A / (2) B / (3) A / (4) B"
+          "[4]"
         ],
         "answer": "[2]"
       }
     ],
-    "passage": "24강 \n24강 (Part 6) — 행사 등록 안내(등록 방법/마감/좌석 제한) (지문 1개 + 4문항) \n \nDirections: Read the text below and choose the best answer for each blank. \n \nSubject: Registration Open: April Client Workshop (Limited Seating) \n \nDear Clients, \n \nThank you for your continued partnership with Greenridge Consulting. We are pleased to invite you to our April Client Workshop, a half-day session focused on practical strategies for improving workflow efficiency and reducing administrative bottlenecks. The workshop will include short presentations, guided discussions, and a live demonstration of our new reporting dashboard. [1] \n \nThe event will be held on Thursday, April 9, from 1:00 p.m. to 5:00 p.m. at the Greenridge Training Center (2F, Room 204). Check-in will begin at 12:30 p.m., and light refreshments will be provided. Because seating is limited, registration will be accepted on a first-come, first-served basis. (1) _______ you would like to attend, please complete the registration form no later than Friday, March 27. [2] \n \nTo register, click the link below and enter your contact information. You will be asked to select one of the available discussion tracks and indicate any dietary restrictions. After you submit the form, you will receive an automated confirmation message within a few minutes. If you do not receive a confirmation, check your spam folder _______ contact us at events@greenridge.example \n. [3] \n \nOn the day of the workshop, please bring a business card for check-in. Also, note that photographs may be taken during the event for internal documentation purposes. (2) _______ you prefer not to appear in any photos, please inform our staff at the registration desk upon arrival. [4] \n \nWe look forward to seeing you in April. \n \nSincerely, \nEvents Team \nGreenridge Consulting"
+    "passage": "Directions: Read the text below and choose the best answer for each blank. \n \nSubject: Registration Open: April Client Workshop (Limited Seating) \n \nDear Clients, \n \nThank you for your continued partnership with Greenridge Consulting. We are pleased to invite you to our April Client Workshop, a half-day session focused on practical strategies for improving workflow efficiency and reducing administrative bottlenecks. The workshop will include short presentations, guided discussions, and a live demonstration of our new reporting dashboard. [1] \n \nThe event will be held on Thursday, April 9, from 1:00 p.m. to 5:00 p.m. at the Greenridge Training Center (2F, Room 204). Check-in will begin at 12:30 p.m., and light refreshments will be provided. Because seating is limited, registration will be accepted on a first-come, first-served basis. (1) _______ you would like to attend, please complete the registration form no later than Friday, March 27. [2] \n \nTo register, click the link below and enter your contact information. You will be asked to select one of the available discussion tracks and indicate any dietary restrictions. After you submit the form, you will receive an automated confirmation message within a few minutes. If you do not receive a confirmation, check your spam folder _______ contact us at events@greenridge.example \n. [3] \n \nOn the day of the workshop, please bring a business card for check-in. Also, note that photographs may be taken during the event for internal documentation purposes. (2) _______ you prefer not to appear in any photos, please inform our staff at the registration desk upon arrival. [4] \n \nWe look forward to seeing you in April. \n \nSincerely, \nEvents Team \nGreenridge Consulting"
   },
   {
     "id": 25,
     "type": "part5",
-    "title": "25강 (Part 5) — 주어-동사 수일치 (3문항) ",
+    "title": "25강 (Part 5) — 주어-동사 수일치 (3문항)",
     "questions": [
       {
-        "id": "25-4",
+        "id": "25-1",
         "question": "(긴 주어 + 단수 동사)\nThe list of approved vendors _______ on the company intranet.",
         "options": [
           "are posted",
@@ -1186,7 +1186,7 @@ const TOEIC_DATA = [
         "answer": "is posted"
       },
       {
-        "id": "25-5",
+        "id": "25-2",
         "question": "(each/every 수일치 함정)\nEach of the applicants _______ required to submit two references.",
         "options": [
           "are",
@@ -1197,7 +1197,7 @@ const TOEIC_DATA = [
         "answer": "is"
       },
       {
-        "id": "25-6",
+        "id": "25-3",
         "question": "(불가산/집합 명사: equipment)\nAll of the laboratory equipment _______ inspected once a month.",
         "options": [
           "are",
@@ -1212,10 +1212,10 @@ const TOEIC_DATA = [
   {
     "id": 26,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 7) ",
+    "title": "26강 (Part 7) — Part 7 Multiple Passages (Set 7)",
     "questions": [
       {
-        "id": "26-31",
+        "id": "26-1",
         "question": "According to the workshop schedule, what is the registration deadline for Session B?",
         "options": [
           "Friday, July 17",
@@ -1226,7 +1226,7 @@ const TOEIC_DATA = [
         "answer": "Monday, July 20"
       },
       {
-        "id": "26-32",
+        "id": "26-2",
         "question": "Why did Eun-ji Kim send an e-mail to the Training Desk?",
         "options": [
           "To request a refund for a workshop fee",
@@ -1237,7 +1237,7 @@ const TOEIC_DATA = [
         "answer": "To ask whether a nonemployee can attend and which entrance to use"
       },
       {
-        "id": "26-33",
+        "id": "26-3",
         "question": "Based on the notice and the e-mail, where should Eun-ji enter the building on July 22?",
         "options": [
           "The Main Entrance at Central Plaza",
@@ -1248,7 +1248,7 @@ const TOEIC_DATA = [
         "answer": "The South Entrance on Pine Street"
       },
       {
-        "id": "26-34",
+        "id": "26-4",
         "question": "If Eun-ji’s colleague will enter the building on Wednesday, July 22, by what time must Eun-ji pre-register the colleague?",
         "options": [
           "Monday, July 20 at 3:00 p.m.",
@@ -1259,7 +1259,7 @@ const TOEIC_DATA = [
         "answer": "Tuesday, July 21 at 3:00 p.m."
       },
       {
-        "id": "26-35",
+        "id": "26-5",
         "question": "If Eun-ji attends Session B, by when must she complete the Readiness Check?",
         "options": [
           "Monday, July 20 at 5:00 p.m.",
@@ -1270,15 +1270,15 @@ const TOEIC_DATA = [
         "answer": "Tuesday, July 21 at 5:00 p.m."
       }
     ],
-    "passage": "26강 \nPart 7 Multiple Passages (Set 7) \n \nQuestions 31–35 refer to the following building notice, workshop schedule, and e-mail. \n \nDocument 1: Building Notice \n \nSUMMIT ONE BUILDING — ENTRANCE UPDATE \nDates: July 21–22, 2026 \n \nDue to paving work near Central Plaza, the Main Entrance will be closed on Tuesday, July 21 and Wednesday, July 22. Please follow the updated access procedures below. \n \nAll visitors and employees must enter through the South Entrance (Pine Street). \n \nVisitors must check in at the Lobby A Visitor Desk and present a government-issued photo ID to receive a badge. \n \nTenant hosts must pre-register visitors by 3:00 p.m. at least one business day before the visit. \n \nElevator service may be slower during this period. Please allow an extra 15 minutes when arriving for appointments. \n \nThank you for your cooperation. \n \nDocument 2: Workshop Schedule \n \nNORTHGATE MEDICAL SUPPLIES — Client Portal Advanced Workshop \nLocation: Summit One Building, Room 8C (On-site) \nBring: Laptop + charger \nPre-work: Complete the Readiness Check by 5:00 p.m. the day before your session. \n \nSession\tDate\tTime\tRegistration Deadline\tSeats \nA\tTue, July 21\t10:00–11:30 a.m.\tFri, July 17\t18 \nB\tWed, July 22\t3:00–4:30 p.m.\tMon, July 20\t18 \nC\tThu, July 23\t9:00–10:30 a.m.\tTue, July 21\t18 \n \nNotes: \n \nA confirmation e-mail with the practice link is sent after registration. \n \nArrive on time; late arrivals may be asked to rebook. \n \nDocument 3: E-mail \n \nSubject: Workshop registration + visitor question (Session B) \nFrom: Eun-ji Kim <eunji.kim@northgatemed.com \n> \nTo: Training Desk <training@northgatemed.com \n> \nDate: July 19, 2026 \n \nHello, \n \nI’d like to register for Session B (July 22, 3:00–4:30 p.m.). \n \nTwo quick questions: \n \nA colleague from a partner company will be in the area that day. Can they sit in to observe the workshop? \n \nI heard the Main Entrance may be closed next week—where should we enter? \n \nThank you, \nEun-ji Kim \nClient Operations \n \nSubject: Re: Workshop registration + visitor question (Session B) \nFrom: Training Desk <training@northgatemed.com \n> \nTo: Eun-ji Kim <eunji.kim@northgatemed.com \n> \nDate: July 19, 2026 \n \nHi Eun-ji, \n \nYou can register for Session B as long as seats are still available. \n \nRegarding your questions: \n \nThe workshop is for Northgate employees only, so your colleague may not attend the session. They may wait in the lobby seating area. \n \nFor July 21–22, please use the South Entrance and check in at Lobby A. \n \nIf your colleague will enter the building, please pre-register them by 3:00 p.m. the business day before and remind them to bring a government-issued photo ID. \n \nBest, \nTraining Desk \n \nQuestions"
+    "passage": "Questions 31–35 refer to the following building notice, workshop schedule, and e-mail. \n \nDocument 1: Building Notice \n \nSUMMIT ONE BUILDING — ENTRANCE UPDATE \nDates: July 21–22, 2026 \n \nDue to paving work near Central Plaza, the Main Entrance will be closed on Tuesday, July 21 and Wednesday, July 22. Please follow the updated access procedures below. \n \nAll visitors and employees must enter through the South Entrance (Pine Street). \n \nVisitors must check in at the Lobby A Visitor Desk and present a government-issued photo ID to receive a badge. \n \nTenant hosts must pre-register visitors by 3:00 p.m. at least one business day before the visit. \n \nElevator service may be slower during this period. Please allow an extra 15 minutes when arriving for appointments. \n \nThank you for your cooperation. \n \nDocument 2: Workshop Schedule \n \nNORTHGATE MEDICAL SUPPLIES — Client Portal Advanced Workshop \nLocation: Summit One Building, Room 8C (On-site) \nBring: Laptop + charger \nPre-work: Complete the Readiness Check by 5:00 p.m. the day before your session. \n \nSession\tDate\tTime\tRegistration Deadline\tSeats \nA\tTue, July 21\t10:00–11:30 a.m.\tFri, July 17\t18 \nB\tWed, July 22\t3:00–4:30 p.m.\tMon, July 20\t18 \nC\tThu, July 23\t9:00–10:30 a.m.\tTue, July 21\t18 \n \nNotes: \n \nA confirmation e-mail with the practice link is sent after registration. \n \nArrive on time; late arrivals may be asked to rebook. \n \nDocument 3: E-mail \n \nSubject: Workshop registration + visitor question (Session B) \nFrom: Eun-ji Kim <eunji.kim@northgatemed.com \n> \nTo: Training Desk <training@northgatemed.com \n> \nDate: July 19, 2026 \n \nHello, \n \nI’d like to register for Session B (July 22, 3:00–4:30 p.m.). \n \nTwo quick questions: \n \nA colleague from a partner company will be in the area that day. Can they sit in to observe the workshop? \n \nI heard the Main Entrance may be closed next week—where should we enter? \n \nThank you, \nEun-ji Kim \nClient Operations \n \nSubject: Re: Workshop registration + visitor question (Session B) \nFrom: Training Desk <training@northgatemed.com \n> \nTo: Eun-ji Kim <eunji.kim@northgatemed.com \n> \nDate: July 19, 2026 \n \nHi Eun-ji, \n \nYou can register for Session B as long as seats are still available. \n \nRegarding your questions: \n \nThe workshop is for Northgate employees only, so your colleague may not attend the session. They may wait in the lobby seating area. \n \nFor July 21–22, please use the South Entrance and check in at Lobby A. \n \nIf your colleague will enter the building, please pre-register them by 3:00 p.m. the business day before and remind them to bring a government-issued photo ID. \n \nBest, \nTraining Desk \n \nQuestions"
   },
   {
     "id": 27,
     "type": "part5",
-    "title": "27강 (Part 5) — 빈출 부사 어휘/부사 위치 (3문항) ",
+    "title": "27강 (Part 5) — 빈출 부사 어휘/부사 위치 (3문항)",
     "questions": [
       {
-        "id": "27-7",
+        "id": "27-1",
         "question": "(promptly 의미)\nPlease respond _______ to the client’s inquiry to avoid delays.",
         "options": [
           "promptly",
@@ -1289,7 +1289,7 @@ const TOEIC_DATA = [
         "answer": "promptly"
       },
       {
-        "id": "27-8",
+        "id": "27-2",
         "question": "(부사 위치: 문장/동사 앞 자연스러움)\nThe receptionist _______ forwarded your message to the supervisor.",
         "options": [
           "promptly",
@@ -1300,7 +1300,7 @@ const TOEIC_DATA = [
         "answer": "promptly"
       },
       {
-        "id": "27-9",
+        "id": "27-3",
         "question": "(부사 vs 형용사 혼동: quick/quickly)\nThe technician completed the installation _______.",
         "options": [
           "quick",
@@ -1315,7 +1315,7 @@ const TOEIC_DATA = [
   {
     "id": 28,
     "type": "part6",
-    "title": "28강 (Part 6) 수정본 — 주문 확인 + 인보이스/결제 안내 (지문 1개 + 4문항) ",
+    "title": "28강 (Part 6) — 주문 확인 + 인보이스/결제 안내 (지문 1개 + 4문항)",
     "questions": [
       {
         "id": "28-1",
@@ -1362,15 +1362,15 @@ const TOEIC_DATA = [
         "answer": "[2]"
       }
     ],
-    "passage": "28강 \n28강 (Part 6) 수정본 — 주문 확인 + 인보이스/결제 안내 (지문 1개 + 4문항) \n \nDirections: Read the text below and choose the best answer for each blank. \n \nSubject: Order Confirmation and Payment Instructions (Invoice Attached) \n \nDear Ms. Rivera, \n \nThank you for your order with Alderbrook Industrial Supplies. This email confirms that we have received your purchase request and created an invoice for processing. Your order number is AI-50319, and the invoice is attached as a PDF for your records. Please review the item details carefully, including quantities, unit prices, and shipping address information, to ensure everything is correct. [1] \n \nPayment for this order is due within ten business days of the invoice date. You may pay by bank transfer or credit card. If you choose a bank transfer, please use the bank account information listed on the invoice and include your order number in the transfer reference field. This helps our accounting team match your payment to the correct account (1) _______ avoid delays in shipping. [2] \n \nOnce payment is received, your order will be released for fulfillment. Standard shipping usually takes three to five business days, depending on your location and carrier capacity. However, during peak periods, delivery times may be longer than usual. If you have a specific delivery requirement, please notify us in advance so we can provide an (2) _______ estimate. [3] \n \nPlease note that orders will not be shipped until payment has been confirmed. If your company requires an internal purchase order (PO) number, you may reply to this email with the PO number (3) _______ we can add it to your invoice record. In addition, if any information on the invoice needs to be corrected, please inform us as soon as possible. Requests received after processing has begun may require a revised invoice and could postpone shipment. [4] \n \nThank you again for your business. If you have any questions regarding payment, shipping, or the attached invoice, please contact our Billing Department at billing@alderbrook.example \n. \n \nSincerely, \nBilling Department \nAlderbrook Industrial Supplies"
+    "passage": "Directions: Read the text below and choose the best answer for each blank. \n \nSubject: Order Confirmation and Payment Instructions (Invoice Attached) \n \nDear Ms. Rivera, \n \nThank you for your order with Alderbrook Industrial Supplies. This email confirms that we have received your purchase request and created an invoice for processing. Your order number is AI-50319, and the invoice is attached as a PDF for your records. Please review the item details carefully, including quantities, unit prices, and shipping address information, to ensure everything is correct. [1] \n \nPayment for this order is due within ten business days of the invoice date. You may pay by bank transfer or credit card. If you choose a bank transfer, please use the bank account information listed on the invoice and include your order number in the transfer reference field. This helps our accounting team match your payment to the correct account (1) _______ avoid delays in shipping. [2] \n \nOnce payment is received, your order will be released for fulfillment. Standard shipping usually takes three to five business days, depending on your location and carrier capacity. However, during peak periods, delivery times may be longer than usual. If you have a specific delivery requirement, please notify us in advance so we can provide an (2) _______ estimate. [3] \n \nPlease note that orders will not be shipped until payment has been confirmed. If your company requires an internal purchase order (PO) number, you may reply to this email with the PO number (3) _______ we can add it to your invoice record. In addition, if any information on the invoice needs to be corrected, please inform us as soon as possible. Requests received after processing has begun may require a revised invoice and could postpone shipment. [4] \n \nThank you again for your business. If you have any questions regarding payment, shipping, or the attached invoice, please contact our Billing Department at billing@alderbrook.example \n. \n \nSincerely, \nBilling Department \nAlderbrook Industrial Supplies"
   },
   {
     "id": 29,
     "type": "part5",
-    "title": "29강 (Part 5) — 품사 선택(파생어) 중심 (3문항) ",
+    "title": "29강 (Part 5) — 품사 선택(파생어) 중심 (3문항)",
     "questions": [
       {
-        "id": "29-10",
+        "id": "29-1",
         "question": "(-tion 명사)\nCustomer _______ is measured through an online survey sent after each purchase.",
         "options": [
           "satisfy",
@@ -1381,7 +1381,7 @@ const TOEIC_DATA = [
         "answer": "satisfaction"
       },
       {
-        "id": "29-11",
+        "id": "29-2",
         "question": "(-ment 명사 / 구조로 판단)\nThe proposed budget includes an _______ for staff training and software licenses.",
         "options": [
           "allocate",
@@ -1392,7 +1392,7 @@ const TOEIC_DATA = [
         "answer": "allocation"
       },
       {
-        "id": "29-12",
+        "id": "29-3",
         "question": "(-ly 부사 / 의미는 비슷해도 품사로 걸러내기)\nThe new procedure must be followed _______ to prevent processing errors.",
         "options": [
           "strict",
@@ -1407,10 +1407,10 @@ const TOEIC_DATA = [
   {
     "id": 30,
     "type": "part7",
-    "title": "Part 7 Multiple Passages (Set 8) — (이번 세트는 정답 분포를 의도적으로 다양화) ",
+    "title": "30강 (Part 7) — Part 7 Multiple Passages (Set 8)",
     "questions": [
       {
-        "id": "30-36",
+        "id": "30-1",
         "question": "According to the training notice, what must participants do to receive a Certificate of Completion?",
         "options": [
           "Check in at the Reception Desk at least 40 minutes early",
@@ -1421,7 +1421,7 @@ const TOEIC_DATA = [
         "answer": "Attend the entire session and complete the quiz by 6:00 p.m. the same day"
       },
       {
-        "id": "30-37",
+        "id": "30-2",
         "question": "Why did Kenji Nakamura contact the Training Desk?",
         "options": [
           "To ask whether arriving late will affect certificate eligibility and to ask about parking and the quiz",
@@ -1432,7 +1432,7 @@ const TOEIC_DATA = [
         "answer": "To ask whether arriving late will affect certificate eligibility and to ask about parking and the quiz"
       },
       {
-        "id": "30-38",
+        "id": "30-3",
         "question": "Why does the Training Desk suggest that Kenji switch to Session A?",
         "options": [
           "Because Session B has been canceled due to low enrollment",
@@ -1443,7 +1443,7 @@ const TOEIC_DATA = [
         "answer": "Because arriving late to Session B would make him ineligible for the certificate"
       },
       {
-        "id": "30-39",
+        "id": "30-4",
         "question": "To receive a visitor parking pass for the August 4 training, by what time must Kenji send his license plate number?",
         "options": [
           "Thursday, July 30 at 12:00 p.m.",
@@ -1454,7 +1454,7 @@ const TOEIC_DATA = [
         "answer": "Friday, July 31 at 12:00 p.m."
       },
       {
-        "id": "30-40",
+        "id": "30-5",
         "question": "In the reply, the word “eligible” is closest in meaning to",
         "options": [
           "familiar",
@@ -1465,6 +1465,6 @@ const TOEIC_DATA = [
         "answer": "qualified"
       }
     ],
-    "passage": "30강 \nPart 7 Multiple Passages (Set 8) — (이번 세트는 정답 분포를 의도적으로 다양화) \n \nQuestions 36–40 refer to the following training notice and e-mails. \n \nDocument 1: Training Notice \n \nHARBORTECH ANALYTICS — Client Data Privacy Refresher (On-site) \nLocation: HarborTech HQ, Room 5D \nDate: Tuesday, August 4, 2026 \nSessions: \n \nSession A: 9:00–11:00 a.m. \n \nSession B: 2:00–4:00 p.m. \n \nCheck-in: Opens 40 minutes before each session at the Reception Desk. \nID: Contractors and visitors must present a government-issued photo ID to receive a badge. \n \nCertificate of Completion: \nCertificates are issued only to participants who \n \nattend the entire session, and \n \ncomplete the online Quiz by 6:00 p.m. on the same day. \n \nVisitor Parking (Limited): \nParking passes must be requested by 12:00 p.m. two business days before the training date. \nWithout a pass, attendees should use public transportation or be dropped off. \n \nDocument 2: E-mail \n \nSubject: Privacy Refresher (Aug 4) — arrival time and certificate \nFrom: Kenji Nakamura <kenji.n@partnerco.com \n> \nTo: Training Desk <training@harbortech.com \n> \nDate: July 29, 2026 \n \nHello, \n \nI registered for Session B (2:00–4:00 p.m.) on August 4. I may be tied up on a client call and might arrive around 2:30 p.m. \n \nIf I arrive at 2:30, can I still receive the Certificate of Completion? \n \nDo I need a parking pass, or can I park on-site without one? \n \nWhen will I receive the link for the Quiz? \n \nThank you, \nKenji Nakamura \n \nDocument 3: E-mail \n \nSubject: Re: Privacy Refresher (Aug 4) — arrival time and certificate \nFrom: Training Desk <training@harbortech.com \n> \nTo: Kenji Nakamura <kenji.n@partnerco.com \n> \nDate: July 29, 2026 \n \nHi Kenji, \n \nThanks for your message. \n \nCertificate: To be eligible, you must attend the session from the beginning to the end. If you arrive at 2:30, you may still attend, but you will not qualify for the certificate. If you need the certificate, please switch to Session A or plan to arrive by 2:00 p.m. for Session B. \n \nParking: Visitor parking is limited. If you need a pass for August 4, please send your license plate number by Friday, July 31 at 12:00 p.m. \n \nQuiz: The quiz link will be sent by e-mail after the session and must be completed by 6:00 p.m. on August 4. \n \nBest regards, \nTraining Desk \n \nQuestions"
+    "passage": "Questions 36–40 refer to the following training notice and e-mails. \n \nDocument 1: Training Notice \n \nHARBORTECH ANALYTICS — Client Data Privacy Refresher (On-site) \nLocation: HarborTech HQ, Room 5D \nDate: Tuesday, August 4, 2026 \nSessions: \n \nSession A: 9:00–11:00 a.m. \n \nSession B: 2:00–4:00 p.m. \n \nCheck-in: Opens 40 minutes before each session at the Reception Desk. \nID: Contractors and visitors must present a government-issued photo ID to receive a badge. \n \nCertificate of Completion: \nCertificates are issued only to participants who \n \nattend the entire session, and \n \ncomplete the online Quiz by 6:00 p.m. on the same day. \n \nVisitor Parking (Limited): \nParking passes must be requested by 12:00 p.m. two business days before the training date. \nWithout a pass, attendees should use public transportation or be dropped off. \n \nDocument 2: E-mail \n \nSubject: Privacy Refresher (Aug 4) — arrival time and certificate \nFrom: Kenji Nakamura <kenji.n@partnerco.com \n> \nTo: Training Desk <training@harbortech.com \n> \nDate: July 29, 2026 \n \nHello, \n \nI registered for Session B (2:00–4:00 p.m.) on August 4. I may be tied up on a client call and might arrive around 2:30 p.m. \n \nIf I arrive at 2:30, can I still receive the Certificate of Completion? \n \nDo I need a parking pass, or can I park on-site without one? \n \nWhen will I receive the link for the Quiz? \n \nThank you, \nKenji Nakamura \n \nDocument 3: E-mail \n \nSubject: Re: Privacy Refresher (Aug 4) — arrival time and certificate \nFrom: Training Desk <training@harbortech.com \n> \nTo: Kenji Nakamura <kenji.n@partnerco.com \n> \nDate: July 29, 2026 \n \nHi Kenji, \n \nThanks for your message. \n \nCertificate: To be eligible, you must attend the session from the beginning to the end. If you arrive at 2:30, you may still attend, but you will not qualify for the certificate. If you need the certificate, please switch to Session A or plan to arrive by 2:00 p.m. for Session B. \n \nParking: Visitor parking is limited. If you need a pass for August 4, please send your license plate number by Friday, July 31 at 12:00 p.m. \n \nQuiz: The quiz link will be sent by e-mail after the session and must be completed by 6:00 p.m. on August 4. \n \nBest regards, \nTraining Desk \n \nQuestions"
   }
 ];


### PR DESCRIPTION
This patch addresses several data issues in `card/toeic.js`:
1.  **Critical Bug Fix (Lecture 24):** Fixed a corrupted option in Question 24-4 that exposed the answer key.
2.  **Title Formatting:**
    - Standardized Part 7 titles (added prefixes, ensured separators).
    - Removed internal memos (e.g., "수정본", developer comments).
    - Added missing separators in Lectures 3 and 8.
3.  **Question ID Renumbering:** Reset question IDs to `{LectureID}-{Index+1}` format for all lectures to ensure consistent indexing.
4.  **Passage Cleanup:** Removed redundant headers (e.g., "3강", titles) from the `passage` fields to prevent duplication in the UI.

Changes were verified using a custom Python script and frontend verification via Playwright.

---
*PR created automatically by Jules for task [3331385409070068587](https://jules.google.com/task/3331385409070068587) started by @romarin0325-cell*