### PR TITLE
Fix TOEIC title reverting to long format during gameplay

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -4131,7 +4131,11 @@
 
                 // Update title to reflect current progress
                 const totalQ = session.expandedQuestions.length;
-                document.getElementById('toeic-title').innerText = `${session.set.title} (${session.qIndex + 1}/${totalQ})`;
+                let typeName = "문제";
+                if (session.set.type === 'part5') typeName = "파트5 문제";
+                else if (session.set.type === 'part6') typeName = "파트6 문제";
+                else if (session.set.type === 'part7') typeName = "파트7 문제";
+                document.getElementById('toeic-title').innerText = `${typeName} (${session.qIndex + 1}/${totalQ})`;
             },
 
             checkToeicAnswer(btn, selected, correct) {
@@ -4183,7 +4187,7 @@
                         // Part 5: go directly to next question
                         this._renderToeicQuestionContent();
                         document.getElementById('toeic-title').innerText =
-                            `${session.set.title} (${session.qIndex + 1}/${totalQ})`;
+                            `파트5 문제 (${session.qIndex + 1}/${totalQ})`;
                     } else {
                         // Part 6/7: go back to hub for next question
                         this.backToToeicHub();


### PR DESCRIPTION
This patch fixes an issue where the simplified TOEIC title (e.g., "파트5 문제") would revert to the long, original title string after the first interaction (checking an answer or returning to the hub).

Changes:
- Updated `backToToeicHub` to recalculate and display the simplified title based on the set type.
- Updated `checkToeicAnswer` (Part 5 branch) to explicitly use the simplified title "파트5 문제" when advancing to the next question.

---
*PR created automatically by Jules for task [9451075908967939202](https://jules.google.com/task/9451075908967939202) started by @romarin0325-cell*