### PR TITLE
Refactor TOEIC Part 5 practice to single pass and verify title consistency

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -3985,25 +3985,13 @@
                 let expandedQuestions = [];
                 let expandedShuffled = [];
 
-                if (set.type === 'part5') {
-                    // Part 5: repeat 3 times with reshuffled options
-                    for (let repeat = 0; repeat < 3; repeat++) {
-                        set.questions.forEach(q => {
-                            expandedQuestions.push(q);
-                            const opts = [...q.options];
-                            opts.sort(() => Math.random() - 0.5);
-                            expandedShuffled.push(opts);
-                        });
-                    }
-                } else {
-                    // Part 6/7: single pass
-                    set.questions.forEach(q => {
-                        expandedQuestions.push(q);
-                        const opts = [...q.options];
-                        opts.sort(() => Math.random() - 0.5);
-                        expandedShuffled.push(opts);
-                    });
-                }
+                // All Parts: single pass (Part 5 also 3 questions only)
+                set.questions.forEach(q => {
+                    expandedQuestions.push(q);
+                    const opts = [...q.options];
+                    opts.sort(() => Math.random() - 0.5);
+                    expandedShuffled.push(opts);
+                });
 
                 // Prepare session
                 this.state.currentToeicSession = {


### PR DESCRIPTION
Updated TOEIC Part 5 practice mode to display only the 3 questions of the selected set once, instead of repeating them 3 times. Verified that the title remains simplified ("파트5 문제") to match Part 6/7 behavior.

---
*PR created automatically by Jules for task [10307551606528207985](https://jules.google.com/task/10307551606528207985) started by @romarin0325-cell*