### PR TITLE
Update Gemini API endpoint to gemini-3-flash-preview

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1203,7 +1203,7 @@
                 const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
                 // 4. API 호출 (온도는 0.6~0.7 추천: 창의적인 상황 부여 필요)
-                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key=${apiKey}`, {
+                const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({


### PR DESCRIPTION
Updated the Gemini API endpoint in `card/index.html` from `gemini-1.5-flash` to `gemini-3-flash-preview`. Verified the change using grep. The change is a simple URL replacement in the `fetch` call within `GameAPI.getTutoringContent`. This affects the `startTutoringSession` functionality which calls `GameAPI.getTutoringContent`. No other functional changes were made.


---
*PR created automatically by Jules for task [17538514775574648860](https://jules.google.com/task/17538514775574648860) started by @romarin0325-cell*