### PR TITLE
Fix missing Gale field buff description in UI

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -3756,7 +3756,9 @@
                     'goddess_descent': '물공/마공 +30%, 방어/마방 +30%',
                     'earth_bless': '물공/마공 +25%',
                     'twinkle_party': '물공 +20%, 치명타율 +15%',
-                    'star_powder': '방어/마방 +40%'
+                    'star_powder': '방어/마방 +40%',
+                    'gale': '치명타율 +20%, 회피율 +20%',
+                    'reaper_realm': '치명타대미지 +40%'
                 };
                 let msg = "";
                 this.battle.fieldBuffs.forEach(b => {


### PR DESCRIPTION
The 'Gale' field buff (질풍) was missing its description entry in the UI's `showFieldBuffInfo` function, causing it to display without details. This change adds the correct description ('치명타율 +20%, 회피율 +20%') to the `buffInfo` object. Additionally, the 'Reaper Realm' (사신강림) description was also added to ensure completeness.

---
*PR created automatically by Jules for task [4547171723690477362](https://jules.google.com/task/4547171723690477362) started by @romarin0325-cell*