### PR TITLE
Add Rumi variants (Bunny/Maid) excluded from gacha

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -61,6 +61,26 @@ const CARDS = [
         ]
     },
     {
+        id: 'rumi_bunny', name: '루미(바니)', grade: 'legend', element: 'water', role: 'buffer', hide_from_gacha: true,
+        stats: { hp: 500, atk: 90, matk: 120, def: 80, mdef: 90 },
+        trait: { type: 'syn_water_nature', desc: '덱에 물 자연이 있을 경우, 문라이트세레나에 트윙클파티 필드버프 추가발동' },
+        skills: [
+            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{ type: 'field_buff', id: 'star_powder' }] },
+            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] }
+        ]
+    },
+    {
+        id: 'rumi_maid', name: '루미(메이드)', grade: 'legend', element: 'water', role: 'buffer', hide_from_gacha: true,
+        stats: { hp: 500, atk: 90, matk: 120, def: 80, mdef: 90 },
+        trait: { type: 'syn_water_nature', desc: '덱에 물 자연이 있을 경우, 문라이트세레나에 트윙클파티 필드버프 추가발동' },
+        skills: [
+            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{ type: 'field_buff', id: 'star_powder' }] },
+            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] }
+        ]
+    },
+    {
         id: 'jasmine', name: '자스민', grade: 'legend', element: 'light', role: 'buffer',
         stats: { hp: 500, atk: 90, matk: 125, def: 70, mdef: 80 },
         trait: { type: 'cond_divine_3_dmg', val: 2.0, desc: '디바인 3스택 이상인 적에게 대미지 2배' },

--- a/card/index.html
+++ b/card/index.html
@@ -2273,7 +2273,7 @@
                 const grade = GameUtils.resolveGachaGrade(mode, isChallenge);
 
                 // Build Pool
-                let pool = CARDS.filter(c => c.grade === grade);
+                let pool = CARDS.filter(c => c.grade === grade && !c.hide_from_gacha);
 
                 // Add Bonus Cards
                 if (this.global.unlocked_bonus_cards.length > 0) {
@@ -2288,7 +2288,7 @@
                     // If somehow empty, fallback to normal
                     console.error("Empty pool for grade: " + grade);
                     grade = 'normal';
-                    pool = CARDS.filter(c => c.grade === 'normal');
+                    pool = CARDS.filter(c => c.grade === 'normal' && !c.hide_from_gacha);
                 }
 
                 const pick = pool[Math.floor(Math.random() * pool.length)];

--- a/card/logic.js
+++ b/card/logic.js
@@ -206,7 +206,7 @@ const GameUtils = {
      * @returns {Array} Array of card objects
      */
     buildCardPool(globalData, options = {}) {
-        let pool = [...CARDS];
+        let pool = CARDS.filter(c => !c.hide_from_gacha);
 
         // Add unlocked bonus cards
         if (globalData.unlocked_bonus_cards && globalData.unlocked_bonus_cards.length > 0) {

--- a/card_remaster/data.js
+++ b/card_remaster/data.js
@@ -61,6 +61,26 @@ const CARDS = [
         ]
     },
     {
+        id: 'rumi_bunny', name: '루미(바니)', grade: 'legend', element: 'water', role: 'buffer', hide_from_gacha: true,
+        stats: { hp: 500, atk: 90, matk: 120, def: 80, mdef: 90 },
+        trait: { type: 'syn_water_nature', desc: '덱에 물 자연이 있을 경우, 문라이트세레나에 트윙클파티 필드버프 추가발동' },
+        skills: [
+            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{type: 'field_buff', id: 'star_powder'}] },
+            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] }
+        ]
+    },
+    {
+        id: 'rumi_maid', name: '루미(메이드)', grade: 'legend', element: 'water', role: 'buffer', hide_from_gacha: true,
+        stats: { hp: 500, atk: 90, matk: 120, def: 80, mdef: 90 },
+        trait: { type: 'syn_water_nature', desc: '덱에 물 자연이 있을 경우, 문라이트세레나에 트윙클파티 필드버프 추가발동' },
+        skills: [
+            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{type: 'field_buff', id: 'star_powder'}] },
+            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{type: 'field_buff', id: 'moon_bless'}] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{type: 'buff', id: 'magic_guard', duration: 1}] }
+        ]
+    },
+    {
         id: 'jasmine', name: '자스민', grade: 'legend', element: 'light', role: 'buffer',
         stats: { hp: 500, atk: 90, matk: 125, def: 70, mdef: 80 },
         trait: { type: 'cond_divine_3_dmg', val: 2.0, desc: '디바인 3스택 이상인 적에게 대미지 2배' },

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -1015,7 +1015,7 @@ const RPG = {
         if(document.getElementById('ui-tickets')) document.getElementById('ui-tickets').innerText = this.state.tickets;
 
         // Apply to 12 random cards
-        let pool = [...CARDS];
+        let pool = CARDS.filter(c => !c.hide_from_gacha);
         if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
             const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
             pool = pool.concat(bonus);
@@ -1060,7 +1060,7 @@ const RPG = {
         this.state.chaosBlessingUses--;
 
         // 1. Base Pool
-        let pool = [...CARDS];
+        let pool = CARDS.filter(c => !c.hide_from_gacha);
 
         // 2. Add Bonus Cards (if unlocked)
         if (this.global.unlocked_bonus_cards && this.global.unlocked_bonus_cards.length > 0) {
@@ -1252,7 +1252,7 @@ const RPG = {
         }
 
         // Build Pool
-        let pool = CARDS.filter(c => c.grade === grade);
+        let pool = CARDS.filter(c => c.grade === grade && !c.hide_from_gacha);
 
         // Add Bonus Cards
         if (this.global.unlocked_bonus_cards.length > 0) {
@@ -1272,7 +1272,7 @@ const RPG = {
             // If somehow empty, fallback to normal
             console.error("Empty pool for grade: " + grade);
             grade = 'normal';
-            pool = CARDS.filter(c => c.grade === 'normal');
+            pool = CARDS.filter(c => c.grade === 'normal' && !c.hide_from_gacha);
         }
 
         const pick = pool[Math.floor(Math.random() * pool.length)];
@@ -2329,7 +2329,7 @@ const RPG = {
     },
 
     generateDraftOptions() {
-        let pool = [...CARDS];
+        let pool = CARDS.filter(c => !c.hide_from_gacha);
         if (this.global.unlocked_bonus_cards) {
             const bonus = BONUS_CARDS.filter(c => this.global.unlocked_bonus_cards.includes(c.id));
             pool = pool.concat(bonus);


### PR DESCRIPTION
Added two new variants for Rumi - Bunny and Maid. These variants have exact matching stats as the regular Rumi, but are set to be hidden from gacha pools by using a new `hide_from_gacha` flag that is checked wherever card pools are generated.

---
*PR created automatically by Jules for task [7295722327558203876](https://jules.google.com/task/7295722327558203876) started by @romarin0325-cell*