### PR TITLE
Add AGENTS.md and deterministic `npm run verify` loop for card frontend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Priority
+Functional correctness of the browser app is more important than refactoring or style polish.
+
+## Mandatory checks
+Before opening a PR or marking the task done, run:
+- npm run verify
+
+## Hard rules
+- Do not say the task is complete if verify fails.
+- Do not open a PR if verify fails.
+- Prefer the smallest diff that restores working behavior.
+- If UI behavior cannot be fully verified, state exactly what remains unverified.
+- For frontend tasks, use image inputs/output when helpful and compare against the requested behavior.

--- a/card/AGENTS.override.md
+++ b/card/AGENTS.override.md
@@ -1,0 +1,15 @@
+# AGENTS.override.md
+
+## Scope
+These rules apply to everything under `card/`.
+
+## Priority
+- Prioritize browser-visible correctness in `card/` first.
+- Keep diffs minimal and avoid unrelated refactors.
+
+## Mandatory checks
+Run from repo root before completion:
+- npm run verify
+
+## Verification note
+If a change cannot be fully verified by `npm run verify`, explicitly list what is still unverified.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "scripts": {
+    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/toeic.js && node --check card/api.js",
+    "test:smoke": "node scripts/verify_card_smoke.js",
+    "verify": "npm run lint && npm run test:smoke"
+  },
   "dependencies": {
     "playwright": "^1.57.0"
   }

--- a/scripts/verify_card_smoke.js
+++ b/scripts/verify_card_smoke.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+function mustContain(filePath, snippets) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  for (const snippet of snippets) {
+    if (!content.includes(snippet)) {
+      throw new Error(`${filePath} is missing expected snippet: ${snippet}`);
+    }
+  }
+}
+
+function run() {
+  const cardRoot = path.join(process.cwd(), 'card');
+
+  mustContain(path.join(cardRoot, 'index.html'), [
+    'id="modal-toeic-practice"',
+    'id="toeic-review-hub"',
+    'initNewGame(mode =',
+    'startToeicPractice()',
+    'finishToeicSession()',
+    'openToeicReview()'
+  ]);
+
+  mustContain(path.join(cardRoot, 'logic.js'), ['const Storage']);
+  mustContain(path.join(cardRoot, 'data.js'), ['const CARDS']);
+  mustContain(path.join(cardRoot, 'toeic.js'), ['const TOEIC_DATA']);
+
+  console.log('Card smoke verification passed.');
+}
+
+try {
+  run();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
### Motivation
- Provide a deterministic, repo-local verification entrypoint so Codex/Codex web agents can validate frontend changes before opening PRs. 
- Apply stronger, local agent guidance for the `card/` area so browser-visible correctness is prioritized and diffs stay minimal.

### Description
- Add a root `AGENTS.md` that mandates `npm run verify` and enforces functional correctness before marking tasks done. 
- Add `card/AGENTS.override.md` to apply stricter, card-specific verification and prioritization rules. 
- Add npm scripts (`lint`, `test:smoke`, `verify`) to `package.json` so verification is a single reproducible command (`npm run verify`). 
- Add `scripts/verify_card_smoke.js`, a lightweight smoke check that asserts presence of TOEIC modal/review anchors and key data/function symbols used by the card UI.

### Testing
- Running `python3 verify_frontend.py` failed due to missing Playwright Python dependency (`ModuleNotFoundError: No module named 'playwright'`).
- Attempting `npx playwright install chromium` failed due to remote browser download returning HTTP 403 from the CDN. 
- After replacing the Playwright UI run with a file-based smoke check, `npm run verify` (which runs the `node --check` lints and `node scripts/verify_card_smoke.js`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5aca617c08322b33b7decc435880a)