### PR TITLE
Fix Endless mode transcendence pool logic

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1849,13 +1849,13 @@
                     artifacts: []
                 };
 
-                // Transfer Pending Transcendence to Active State (Endless Only)
+                // Transfer Transcendence Cards: Endless gets all, Challenge gets earned
                 if (this.state.gameType === 'endless') {
+                    this.state.activeTranscendenceCards = TRANSCENDENCE_CARDS.map(c => c.id);
+                } else {
                     this.state.activeTranscendenceCards = [...(this.global.pendingTranscendenceCards || [])];
                     this.global.pendingTranscendenceCards = [];
                     this.saveGlobalData();
-                } else {
-                    this.state.activeTranscendenceCards = [];
                 }
 
                 if (mode === 'chaos') {
@@ -3357,7 +3357,10 @@
                     this.state.inventory = [];
                     this.state.deck = [null, null, null];
 
-                    let allCards = GameUtils.buildCardPool(this.global);
+                    let allCards = GameUtils.buildCardPool(this.global, {
+                        includeTranscendence: true,
+                        activeTranscendenceCards: this.state.activeTranscendenceCards
+                    });
                     allCards.sort(() => Math.random() - 0.5);
 
                     const nextPicks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);


### PR DESCRIPTION
This patch fixes the issue where transcendence cards were not correctly handled in Endless mode.

Key changes:
1.  **Game Initialization (`RPG.initNewGame`)**:
    - In **Endless mode**, the `activeTranscendenceCards` pool is now initialized with all 8 available transcendence cards from `TRANSCENDENCE_CARDS`.
    - In **Challenge mode**, it correctly transfers and clears `pendingTranscendenceCards` (earned from the roulette) to the active session.
2.  **Battle Resolution (`RPG.winBattle`)**:
    - In **Chaos mode**, the card pool rebuilding logic now explicitly includes transcendence cards using the `activeTranscendenceCards` state. This ensures they continue to appear randomly in the 15-card pool throughout the session.

These changes satisfy the user requirement for Origin/Artifact modes to start with all transcendence cards in Endless mode, and for Chaos/Draft modes to have them continuously available in the random pool.

---
*PR created automatically by Jules for task [236560445017072346](https://jules.google.com/task/236560445017072346) started by @romarin0325-cell*