### PR TITLE
Fix Transcendence Card Persistence in Chaos and Draft Modes

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -3357,7 +3357,10 @@
                     this.state.inventory = [];
                     this.state.deck = [null, null, null];
 
-                    let allCards = GameUtils.buildCardPool(this.global);
+                    let allCards = GameUtils.buildCardPool(this.global, {
+                        includeTranscendence: true,
+                        activeTranscendenceCards: this.state.activeTranscendenceCards
+                    });
                     allCards.sort(() => Math.random() - 0.5);
 
                     const nextPicks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);


### PR DESCRIPTION
This patch fixes a bug where Transcendence cards (obtained via roulette) would not reappear in the randomized pools for Chaos mode and Draft mode after the first battle or during reshuffles.

Changes:
- In `card/index.html`, the `winBattle` function now correctly passes `includeTranscendence: true` and the list of `activeTranscendenceCards` to `GameUtils.buildCardPool` when resetting the inventory for Chaos mode.
- Confirmed that `generateDraftOptions` (Draft mode) already followed this pattern.
- Removed developer artifacts (log files and verification scripts) from the repository.

---
*PR created automatically by Jules for task [248777811445107634](https://jules.google.com/task/248777811445107634) started by @romarin0325-cell*