### PR TITLE
Show grammar lecture prompt after archive-mode quiz failure

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -3378,6 +3378,7 @@
                     let allQuizzes = [];
                     GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
                     let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+                    this.state.lastArchiveQuizLectureId = q.lecture_id;
 
                     this.startGrammarQuiz(q,
                         () => { // Success
@@ -3562,7 +3563,21 @@
                             );
                         }
                     } else {
-                        this.toMenu();
+                        if (quizResult === false && this.state.lastArchiveQuizLectureId) {
+                            const lectureId = this.state.lastArchiveQuizLectureId;
+                            this.showConfirm(`오답입니다... 관련 문법 강좌(${lectureId}강)를 확인하시겠습니까?`,
+                                () => {
+                                    this.showLecture(lectureId, () => {
+                                        this.toMenu();
+                                    });
+                                },
+                                () => {
+                                    this.toMenu();
+                                }
+                            );
+                        } else {
+                            this.toMenu();
+                        }
                     }
                 });
             },


### PR DESCRIPTION
### Motivation

- In archive mode the mandatory grammar quiz redirected directly to the result modal on failure and did not offer the same "view related lecture" confirm flow available in other modes, so users could not open the lecture after a wrong answer.

### Description

- Save the lecture id for the chosen archive quiz to `this.state.lastArchiveQuizLectureId` when the mandatory archive quiz is started in `card/index.html`.
- After the battle result modal closes, if `quizResult === false` and `lastArchiveQuizLectureId` is set, show the existing "관련 문법 강좌 확인" confirm popup and open the lecture modal on confirm, then return to menu (cancel returns to menu).
- This change is scoped to `card/index.html` and preserves existing behavior for correct answers and non-archive modes.

### Testing

- Ran `npm run verify` (which runs `npm run lint` and `node scripts/verify_card_smoke.js`) and it passed.
- Committed the change to `card/index.html` and created the PR for review.
- Attempted automated UI verification with Playwright to capture the confirm dialog, but Chromium crashed with a SIGSEGV in the execution environment so visual confirmation / screenshot could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a790a947a883228aef8c991f6bd549)