### PR TITLE
card: secret date event cards (5 sets)

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -162,7 +162,10 @@ const DATE_WEATHER_OUTDOOR = ['갑작스러운 소나기', '강한 바람', '좋
 const DATE_KEYWORDS = ['귀여운 실수', '졸음', '미끄러짐', '젖음', '키스', '신남', '끼임', '찢어짐', '고장난지퍼', '완벽한데이트'];
 const SECRET_DATE_SETS = [
     { theme: '저택', outfit: '메이드복', location: 'indoor', keyword: '특제생크림케이크만들기', word: 'love', secret: true, cardId: 'rumi_maid', cardName: '루미(메이드)' },
-    { theme: '스테이지', outfit: '바니걸의상', location: 'indoor', keyword: '형아만을 위한 스테이지 공연', word: 'love', secret: true, cardId: 'rumi_bunny', cardName: '루미(바니)' }
+    { theme: '스테이지', outfit: '바니걸의상', location: 'indoor', keyword: '형아만을 위한 스테이지 공연', word: 'love', secret: true, cardId: 'rumi_bunny', cardName: '루미(바니)' },
+    { theme: '신사', outfit: '무녀복', location: 'outdoor', keyword: '부적달다 넘어져서 안기기', word: 'love', secret: true, cardId: 'rumi_miko', cardName: '루미(무녀)' },
+    { theme: '숲', outfit: '요정옷', location: 'outdoor', keyword: '덩굴얽혀서 부끄러운 포즈', word: 'love', secret: true, cardId: 'rumi_fairy', cardName: '루미(페어리)' },
+    { theme: '결혼식장', outfit: '웨딩드레스', location: 'indoor', keyword: '결혼식', word: 'love', secret: true, cardId: 'rumi_wedding', cardName: '루미(웨딩)' }
 ];
 
 // Add getDateContent to GameAPI

--- a/card/data.js
+++ b/card/data.js
@@ -61,23 +61,53 @@ const CARDS = [
         ]
     },
     {
-        id: 'rumi_bunny', name: '루미(바니)', grade: 'legend', element: 'water', role: 'buffer', hide_from_gacha: true,
-        stats: { hp: 500, atk: 90, matk: 120, def: 80, mdef: 90 },
-        trait: { type: 'syn_water_nature', desc: '덱에 물 자연이 있을 경우, 문라이트세레나에 트윙클파티 필드버프 추가발동' },
+        id: 'rumi_bunny', name: '루미(바니)', grade: 'event', element: 'dark', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 360, atk: 110, matk: 90, def: 65, mdef: 45 },
+        trait: { type: 'party_stat_boost', stat: 'atk', val: 30, desc: '파티 전체 공격력 30%상승' },
         skills: [
-            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{ type: 'field_buff', id: 'star_powder' }] },
-            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '미드나잇쇼', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '암흑, 부식 부여', effects: [{ type: 'debuff', id: 'darkness' }, { type: 'debuff', id: 'corrosion' }] },
+            { name: '커튼콜', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '저주 상태의 적에게 대미지 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'curse', mult: 3.0 }] }
         ]
     },
     {
-        id: 'rumi_maid', name: '루미(메이드)', grade: 'legend', element: 'water', role: 'buffer', hide_from_gacha: true,
-        stats: { hp: 500, atk: 90, matk: 120, def: 80, mdef: 90 },
-        trait: { type: 'syn_water_nature', desc: '덱에 물 자연이 있을 경우, 문라이트세레나에 트윙클파티 필드버프 추가발동' },
+        id: 'rumi_maid', name: '루미(메이드)', grade: 'event', element: 'nature', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 370, atk: 85, matk: 80, def: 80, mdef: 55 },
+        trait: { type: 'party_stat_boost', stat: 'def', val: 30, desc: '파티 전체 방어력 30%상승' },
         skills: [
-            { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{ type: 'field_buff', id: 'star_powder' }] },
-            { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] }
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '특제생크림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 대지의축복, 스타파우더 부여', effects: [{ type: 'field_buff', id: 'earth_bless' }, { type: 'field_buff', id: 'star_powder' }] },
+            { name: '달콤한유혹', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '약화, 저주 부여', effects: [{ type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'curse' }] }
+        ]
+    },
+    {
+        id: 'rumi_miko', name: '루미(무녀)', grade: 'event', element: 'fire', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 355, atk: 85, matk: 110, def: 55, mdef: 65 },
+        trait: { type: 'party_stat_boost', stat: 'matk', val: 30, desc: '파티 전체 마법공격력 30%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '파마부', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열, 침묵 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'silence' }] },
+            { name: '화염부', type: 'sup', tier: 3, cost: 30, desc: '필드버프 태양의축복 발동', effects: [{ type: 'field_buff', id: 'sun_bless' }] }
+        ]
+    },
+    {
+        id: 'rumi_fairy', name: '루미(페어리)', grade: 'event', element: 'light', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 360, atk: 80, matk: 90, def: 55, mdef: 80 },
+        trait: { type: 'party_stat_boost', stat: 'mdef', val: 30, desc: '파티 전체 마법방어력 30%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '요정의장난', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 약화 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'weak' }] },
+            { name: '요정의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 성역, 스타파우더 부여', effects: [{ type: 'field_buff', id: 'sanctuary' }, { type: 'field_buff', id: 'star_powder' }] }
+        ]
+    },
+    {
+        id: 'rumi_wedding', name: '루미(웨딩)', grade: 'event', element: 'water', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 360, atk: 95, matk: 95, def: 65, mdef: 65 },
+        trait: { type: 'party_stat_boost', stat: ['atk', 'matk', 'def', 'mdef'], val: 15, desc: '파티 전체 공격/마공 방어/마방 15%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '하트샤워', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '디바인, 침묵 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'silence' }] },
+            { name: '순백의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 운명의서약 부여', effects: [{ type: 'field_buff', id: 'destiny_oath' }] }
         ]
     },
     {
@@ -774,7 +804,7 @@ const BUFF_NAMES = {
     'magic_guard': '매직가드', 'guard': '가드',
     'defProtocolPhy': '방어프로토콜(물리)', 'defProtocolMag': '방어프로토콜(마법)',
     'sun_bless': '태양의축복', 'moon_bless': '달의축복', 'sanctuary': '성역',
-    'goddess_descent': '여신강림', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',
+    'goddess_descent': '여신강림', 'destiny_oath': '운명의서약', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',
     'star_powder': '스타파우더',
     'reaper_realm': '사신강림',
     'gale': '질풍'

--- a/card/index.html
+++ b/card/index.html
@@ -160,6 +160,27 @@
             color: #bdbdbd;
         }
 
+        @keyframes glow-event {
+            0% {
+                box-shadow: 0 0 5px #ff80ab;
+            }
+
+            50% {
+                box-shadow: 0 0 15px #ff80ab;
+            }
+
+            100% {
+                box-shadow: 0 0 5px #ff80ab;
+            }
+        }
+
+        .card-item.event {
+            border-color: #ff80ab;
+            color: #ff80ab;
+            animation: glow-event 2s infinite;
+            background: #2a1a22;
+        }
+
         @keyframes glow-gold {
             0% {
                 box-shadow: 0 0 5px #ffd700;
@@ -2673,7 +2694,7 @@
 
                                 // Get all available buff keys
                                 const allBuffs = Object.keys(GAME_CONSTANTS.FIELD_BUFF_STATS)
-                                    .filter(buffId => buffId !== 'gale');
+                                    .filter(buffId => buffId !== 'gale' && buffId !== 'destiny_oath');
 
                                 // Select unique random buffs
                                 let pool = [...allBuffs].sort(() => 0.5 - Math.random());
@@ -3679,6 +3700,7 @@
                     'moon_bless': '마공 +30%, 회피율 +15%',
                     'sanctuary': '마공 +30%, 마방 +30%',
                     'goddess_descent': '물공/마공 +30%, 방어/마방 +30%',
+                    'destiny_oath': '물공/마공 +30%, 방어/마방 +30%',
                     'earth_bless': '물공/마공 +25%',
                     'twinkle_party': '물공 +20%, 치명타율 +15%',
                     'star_powder': '방어/마방 +40%',
@@ -4503,10 +4525,13 @@
                 // Check secret date flag first
                 if (this.global.secretDateFlag) {
                     const secretSet = SECRET_DATE_SETS[Math.floor(Math.random() * SECRET_DATE_SETS.length)];
+                    const weather = (secretSet.location === 'outdoor')
+                        ? DATE_WEATHER_OUTDOOR[Math.floor(Math.random() * DATE_WEATHER_OUTDOOR.length)]
+                        : '실내';
                     return {
                         theme: secretSet.theme,
                         outfit: secretSet.outfit,
-                        weather: '실내',
+                        weather: weather,
                         keyword: secretSet.keyword,
                         word: secretSet.word,
                         secret: true,
@@ -4615,7 +4640,8 @@
                     const cardId = dateParams.cardId;
                     const cardName = dateParams.cardName;
 
-                    if (!this.state.inventory.includes(cardId)) {
+                    const alreadyOwned = this.state.inventory.includes(cardId);
+                    if (!alreadyOwned) {
                         this.state.inventory.push(cardId);
                     }
 
@@ -4630,7 +4656,7 @@
                             </div>
                             루미와의 특별한 비밀 데이트가 끝났어요!<br><br>
                             <b style="color:#ffd700; font-size:1.2rem;">🎴 이벤트 카드 획득: ${cardName}</b><br>
-                            <span style="font-size:0.8rem; color:#aaa;">(카드가 인벤토리에 추가되었습니다)</span>
+                            <span style="font-size:0.8rem; color:#aaa;">${alreadyOwned ? '(이미 보유 중이라 추가 지급은 없습니다)' : '(카드가 인벤토리에 추가되었습니다)'}</span>
                         </div>`
                     );
                 } else {

--- a/card/logic.js
+++ b/card/logic.js
@@ -127,6 +127,7 @@ const GAME_CONSTANTS = {
         'moon_bless': { matk: 0.3, evasion: 15 },
         'sanctuary': { matk: 0.3, mdef: 0.3 },
         'goddess_descent': { atk: 0.3, matk: 0.3, def: 0.3, mdef: 0.3 },
+        'destiny_oath': { atk: 0.3, matk: 0.3, def: 0.3, mdef: 0.3 },
         'earth_bless': { atk: 0.25, matk: 0.25 },
         'twinkle_party': { atk: 0.2, crit: 15 },
         'star_powder': { def: 0.4, mdef: 0.4 },
@@ -1068,6 +1069,10 @@ const Logic = {
                         mult += 4.0;
                         logMsg.push("여신(4.0배)");
                         break;
+                    case 'destiny_oath': // 운명의서약: 10배율
+                        mult += 10.0;
+                        logMsg.push("서약(10.0배)");
+                        break;
                     case 'reaper_realm': // 사신강림: 마방 50% 관통 + 1배율
                         {
                             let ignore = Math.floor(tgtStats.mdef * 0.5);
@@ -1188,6 +1193,23 @@ const Logic = {
                 p.matk = Math.floor(p.matk * (1 + boost));
             }
         }
+
+        // Party-wide Stat Boost Traits (Event)
+        const partyBoost = { atk: 0, matk: 0, def: 0, mdef: 0 };
+        activeCards.forEach(c => {
+            const tr = c.trait;
+            if (tr && tr.type === 'party_stat_boost') {
+                const stats = Array.isArray(tr.stat) ? tr.stat : [tr.stat];
+                stats.forEach(s => {
+                    if (partyBoost[s] !== undefined) partyBoost[s] += (tr.val || 0);
+                });
+            }
+        });
+
+        if (partyBoost.atk) p.atk = Math.floor(p.atk * (1 + partyBoost.atk / 100));
+        if (partyBoost.matk) p.matk = Math.floor(p.matk * (1 + partyBoost.matk / 100));
+        if (partyBoost.def) p.def = Math.floor(p.def * (1 + partyBoost.def / 100));
+        if (partyBoost.mdef) p.mdef = Math.floor(p.mdef * (1 + partyBoost.mdef / 100));
 
         // Artifact: dragon_heart — dragon cards matk +50%
         const artifacts = (typeof RPG !== 'undefined' && RPG.state && RPG.state.artifacts) ? RPG.state.artifacts : [];


### PR DESCRIPTION
## 변경 요약
- 실전마법연습 비밀 데이트 보상 이벤트 카드 5종(메이드/바니/무녀/페어리/웨딩) 추가
- 이벤트 카드 등급 `event`(핑크 프레임) 표시 + 가챠 풀에서 제외(`hide_from_gacha`)
- 카드 스탯/속성/스킬/특성 반영
- 신규 특성 로직: 이벤트 카드 배치 시 파티 3장 전체 스탯(atk/matk/def/mdef) % 증가 적용
- 신규 필드버프 `운명의서약(destiny_oath)` 추가 + 만화경 랜덤 풀에서 제외
- 루미(꿈의형태)가 `운명의서약` 소모 시 추가 10배율 적용
- `운명의서약` 툴팁에서 “여신강림과 동일” 문구 제거

## 테스트
- `npm run verify` 통과

## 수동 확인(권장)
- 비밀 데이트가 5세트 중 랜덤으로 진행되고, 종료 시 카드 1장 지급
- 동일 런에서 같은 이벤트 카드 재등장 시 “이미 보유(추가 지급 없음)” 안내
- 전투 시작 스탯에서 파티 3장 모두 특성 버프 적용
- `운명의서약` 툴팁: “물공/마공 +30%, 방어/마방 +30%”