### PR TITLE
Exclude event cards from Blessing of Chaos targets

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -2171,6 +2171,7 @@
                 // Apply to 12 random cards
                 let pool = GameUtils.buildCardPool(this.global, {
                     excludeTranscendence: true,
+                    excludeEvent: true,
                     maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
                 });
 
@@ -2207,6 +2208,7 @@
                 // 1. Build Pool
                 let pool = GameUtils.buildCardPool(this.global, {
                     excludeTranscendence: true,
+                    excludeEvent: true,
                     maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
                 });
 

--- a/card/logic.js
+++ b/card/logic.js
@@ -203,6 +203,7 @@ const GameUtils = {
      * @param {boolean} [options.includeTranscendence=false] - Include active transcendence cards
      * @param {string[]} [options.activeTranscendenceCards=[]] - IDs of active transcendence cards
      * @param {boolean} [options.excludeTranscendence=false] - Filter out transcendence grade cards
+     * @param {boolean} [options.excludeEvent=false] - Filter out event grade cards
      * @param {string}  [options.maxGrade] - Max grade filter: 'rare' or 'epic'
      * @returns {Array} Array of card objects
      */
@@ -224,6 +225,11 @@ const GameUtils = {
         // Exclude transcendence grade
         if (options.excludeTranscendence) {
             pool = pool.filter(c => c.grade !== 'transcendence');
+        }
+
+        // Exclude event grade
+        if (options.excludeEvent) {
+            pool = pool.filter(c => c.grade !== 'event');
         }
 
         // Apply max grade filter


### PR DESCRIPTION
The goal was to prevent event-grade cards from being targeted by the random stat boosts provided by the "Blessing of Chaos" (혼돈의 축복) and "Great Sage's Blessing" (대현자의 축복) in the Card RPG module.

I achieved this by:
1.  **Refining the core utility:** I added a new `excludeEvent` parameter to the `GameUtils.buildCardPool` function in `card/logic.js`. When this option is enabled, the function filters out all cards whose `grade` is set to `'event'`.
2.  **Updating the game logic:** I modified the two specific functions in `card/index.html` that handle these blessings—`RPG.applyChaosBlessing` and `RPG.applyGreatSageBlessing`. Both functions now pass `{ excludeEvent: true }` when requesting a card pool from `GameUtils.buildCardPool`.

These changes ensure that event cards remain in the game (e.g., in the inventory if already acquired) but are never selected as targets for these specific random blessing effects. Verification was performed using a Node.js script to confirm the filtering logic in the pool builder.

---
*PR created automatically by Jules for task [3660081882154920959](https://jules.google.com/task/3660081882154920959) started by @romarin0325-cell*