### PR TITLE
Adjust Event Probabilities Based on Game Stage

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -36,9 +36,10 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 
 const GameAPI = {
     async getTutoringContent(apiKey, targetData, type) {
-        // 1. 30% 확률 (The 'Accidental' Event)
+        // 1. 30% 확률 (30스테이지 이상 시 50%) (The 'Accidental' Event)
         const enableEvent = RPG.global.tutoringEventEnabled !== false;
-        const isMisunderstandingMode = enableEvent && Math.random() < 0.3;
+        const prob = (RPG.state.enemyScale >= 30) ? 0.5 : 0.3;
+        const isMisunderstandingMode = enableEvent && Math.random() < prob;
 
         let targetInfo = "";
         if (type === 'collocation') {

--- a/card/index.html
+++ b/card/index.html
@@ -4662,7 +4662,8 @@
                         </div>`
                     );
                 } else {
-                    const triggerSecret = Math.random() < 0.1;
+                    const prob = (this.state.enemyScale >= 30) ? 0.3 : 0.1;
+                    const triggerSecret = Math.random() < prob;
 
                     this.saveGlobalData();
                     this.saveGame();


### PR DESCRIPTION
Modified card/api.js and card/index.html to increase event probabilities when the player reaches stage 30 or higher. Specifically, the 'Private Tutoring' innuendo event probability was increased from 30% to 50%, and the 'Secret Date' trigger probability was increased from 10% to 30%.

---
*PR created automatically by Jules for task [11096152169448387381](https://jules.google.com/task/11096152169448387381) started by @romarin0325-cell*