### PR TITLE
카오스/드래프트 모드 이벤트 카드 풀 포함 기능 구현

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1867,7 +1867,9 @@
                     quiz_stats: { correct: 0, total: 0 },
                     chaosPool: [],
                     draft: { active: false, round: 0, rerolls: 3, currentOptions: [] },
-                    artifacts: []
+                    artifacts: [],
+                    // [목적] 카오스/드래프트 모드에서 해당 런에서만 유효한 이벤트 카드 목록을 초기화
+                    activeEventCards: []
                 };
 
                 // Transfer Pending Transcendence to Active State (Endless Only)
@@ -1882,7 +1884,9 @@
                 if (mode === 'chaos') {
                     let allCards = GameUtils.buildCardPool(this.global, {
                         includeTranscendence: true,
-                        activeTranscendenceCards: this.state.activeTranscendenceCards
+                        activeTranscendenceCards: this.state.activeTranscendenceCards,
+                        // [목적] 해당 런에서 획득한 이벤트 카드를 카오스 모드 시작 풀에 포함
+                        activeEventCards: this.state.activeEventCards
                     });
 
                     allCards.sort(() => Math.random() - 0.5);
@@ -2255,7 +2259,9 @@
 
                         let allCards = GameUtils.buildCardPool(this.global, {
                             includeTranscendence: true,
-                            activeTranscendenceCards: this.state.activeTranscendenceCards
+                            activeTranscendenceCards: this.state.activeTranscendenceCards,
+                            // [목적] 카오스 셔플 시 획득한 이벤트 카드를 풀에 포함
+                            activeEventCards: this.state.activeEventCards
                         });
 
                         allCards.sort(() => Math.random() - 0.5);
@@ -3240,7 +3246,9 @@
             generateDraftOptions() {
                 let pool = GameUtils.buildCardPool(this.global, {
                     includeTranscendence: true,
-                    activeTranscendenceCards: this.state.activeTranscendenceCards
+                    activeTranscendenceCards: this.state.activeTranscendenceCards,
+                    // [목적] 드래프트 선택지에 획득한 이벤트 카드가 등장하도록 함
+                    activeEventCards: this.state.activeEventCards
                 });
 
                 let options = [];
@@ -3383,7 +3391,9 @@
 
                     let allCards = GameUtils.buildCardPool(this.global, {
                         includeTranscendence: true,
-                        activeTranscendenceCards: this.state.activeTranscendenceCards
+                        activeTranscendenceCards: this.state.activeTranscendenceCards,
+                        // [목적] 전투 승리 후 카오스 풀 초기화 시 획득한 이벤트 카드를 포함
+                        activeEventCards: this.state.activeEventCards
                     });
                     allCards.sort(() => Math.random() - 0.5);
 
@@ -4642,9 +4652,27 @@
                     const cardId = dateParams.cardId;
                     const cardName = dateParams.cardName;
 
-                    const alreadyOwned = this.state.inventory.includes(cardId);
-                    if (!alreadyOwned) {
-                        this.state.inventory.push(cardId);
+                    const isPoolMode = ['chaos', 'draft'].includes(this.state.mode);
+                    let rewardDetail = "";
+
+                    if (isPoolMode) {
+                        // [목적] 카오스/드래프트 모드에서는 인벤토리에 즉시 추가하지 않고, 해당 런의 랜덤 풀에 추가하여 랜덤하게 등장하게 함 (해당 런 전용)
+                        if (!this.state.activeEventCards) this.state.activeEventCards = [];
+                        if (!this.state.activeEventCards.includes(cardId)) {
+                            this.state.activeEventCards.push(cardId);
+                            rewardDetail = "(해당 런의 카드 풀에 추가되었습니다. 앞으로 랜덤하게 등장합니다!)";
+                        } else {
+                            rewardDetail = "(이미 카드 풀에 포함되어 있습니다)";
+                        }
+                    } else {
+                        // [목적] 일반 모드에서는 기존 방식대로 인벤토리에 즉시 추가
+                        const alreadyOwned = this.state.inventory.includes(cardId);
+                        if (!alreadyOwned) {
+                            this.state.inventory.push(cardId);
+                            rewardDetail = "(카드가 인벤토리에 추가되었습니다)";
+                        } else {
+                            rewardDetail = "(이미 보유 중이라 추가 지급은 없습니다)";
+                        }
                     }
 
                     this.global.secretDateFlag = false;
@@ -4658,7 +4686,7 @@
                             </div>
                             루미와의 특별한 비밀 데이트가 끝났어요!<br><br>
                             <b style="color:#ffd700; font-size:1.2rem;">🎴 이벤트 카드 획득: ${cardName}</b><br>
-                            <span style="font-size:0.8rem; color:#aaa;">${alreadyOwned ? '(이미 보유 중이라 추가 지급은 없습니다)' : '(카드가 인벤토리에 추가되었습니다)'}</span>
+                            <span style="font-size:0.8rem; color:#aaa;">${rewardDetail}</span>
                         </div>`
                     );
                 } else {

--- a/card/logic.js
+++ b/card/logic.js
@@ -202,6 +202,7 @@ const GameUtils = {
      * @param {Object} [options]
      * @param {boolean} [options.includeTranscendence=false] - Include active transcendence cards
      * @param {string[]} [options.activeTranscendenceCards=[]] - IDs of active transcendence cards
+     * @param {string[]} [options.activeEventCards=[]] - IDs of active event cards for the current run
      * @param {boolean} [options.excludeTranscendence=false] - Filter out transcendence grade cards
      * @param {boolean} [options.excludeEvent=false] - Filter out event grade cards
      * @param {string}  [options.maxGrade] - Max grade filter: 'rare' or 'epic'
@@ -220,6 +221,12 @@ const GameUtils = {
         if (options.includeTranscendence && options.activeTranscendenceCards && options.activeTranscendenceCards.length > 0) {
             const transObjs = TRANSCENDENCE_CARDS.filter(c => options.activeTranscendenceCards.includes(c.id));
             pool = pool.concat(transObjs);
+        }
+
+        // [목적] 카오스/드래프트 모드 등에서 런 도중 획득한 이벤트 카드를 랜덤 풀에 포함시키기 위함
+        if (options.activeEventCards && options.activeEventCards.length > 0) {
+            const eventObjs = CARDS.filter(c => c.grade === 'event' && options.activeEventCards.includes(c.id));
+            pool = pool.concat(eventObjs);
         }
 
         // Exclude transcendence grade


### PR DESCRIPTION
이벤트 등급 카드가 카오스 및 드래프트 모드에서 영구 인벤토리 지급 대신 해당 런의 랜덤 풀에 포함되도록 변경하였습니다.

변경 사항:
1. GameUtils.buildCardPool (logic.js): activeEventCards 옵션을 추가하여 특정 이벤트 카드를 풀에 포함할 수 있도록 개선.
2. RPG.initNewGame (index.html): 매 런 시작 시 activeEventCards 목록 초기화.
3. RPG.finishDate (index.html): 카오스/드래프트 모드에서는 비밀 데이트 보상을 인벤토리 대신 런 전용 이벤트 카드 풀에 추가하도록 수정.
4. buildCardPool 호출부 업데이트 (index.html): 카오스 초기화, 셔플, 드래프트 생성 시 현재 런의 이벤트 카드 목록을 전달하도록 수정.

각 변경 사항에는 [목적] 코멘트를 추가하여 의도를 명시하였습니다.

---
*PR created automatically by Jules for task [3099331253461397694](https://jules.google.com/task/3099331253461397694) started by @romarin0325-cell*