### PR TITLE
card: add new bonus card pack

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -658,6 +658,76 @@ const BONUS_CARDS = [
             { name: '제트슬라이드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '기절한 적에게 대미지 5배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 5.0 }] },
             { name: '콜드웨이크', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 혹은 침묵 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['curse', 'silence'] }] }
         ]
+    },
+    {
+        id: 'sakura', name: '사쿠라', grade: 'legend', element: 'fire', role: 'debuffer',
+        stats: { hp: 500, atk: 95, matk: 125, def: 75, mdef: 75 },
+        trait: { type: 'cond_target_elements_dmg', val: 1.5, elements: ['nature', 'dark'], desc: '자연/어둠속성 적에게 대미지 1.5배' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '봉인부', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '부식/약화/침묵/저주/암흑 중 랜덤 2종 부여', effects: [{ type: 'random_debuff', count: 2, pool: ['corrosion', 'weak', 'silence', 'curse', 'darkness'] }] },
+            { name: '폭염부', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '랜덤 디버프 1종 소모, 대미지 2배', effects: [{ type: 'consume_random_debuff_fixed_mult', count: 1, mult: 2.0, pool: ['burn', 'divine', 'corrosion', 'weak', 'silence', 'curse', 'darkness', 'stun'] }] }
+        ]
+    },
+    {
+        id: 'galaxy_whale', name: '은하고래', grade: 'legend', element: 'light', role: 'dealer',
+        stats: { hp: 490, atk: 105, matk: 145, def: 65, mdef: 65 },
+        trait: { type: 'syn_light_3_matk_mdef', desc: '덱에 빛 3장 이상 시 마법공격력/마법방어력 50% 증가' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '슈퍼노바펄스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인 모두 소모, 소모한 개수당 2.0배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'divine', multPerStack: 2.0 }] },
+            { name: '앱솔루트라이트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '어둠속성 적에게 대미지 3배', effects: [{ type: 'dmg_boost', condition: 'target_element', element: 'dark', mult: 3.0, customLog: '[특성] 어둠속성 적에게 추가 피해! (배율 x3.0)' }] }
+        ]
+    },
+    {
+        id: 'jellyfish_princess', name: '젤리피쉬프린세스', grade: 'epic', element: 'water', role: 'debuffer',
+        stats: { hp: 410, atk: 80, matk: 85, def: 75, mdef: 70 },
+        trait: { type: 'on_hit_random_debuff', pool: ['corrosion', 'weak', 'silence', 'curse', 'stun'], desc: '피격 시 부식/약화/침묵/저주/기절 중 랜덤 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '오로라텐타클', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 혹은 부식 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['weak', 'corrosion'] }] },
+            { name: '크리스탈레퀴엠', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '기절 상태의 적에게 대미지 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 3.0 }] }
+        ]
+    },
+    {
+        id: 'eclipse_queen', name: '이클립스퀸', grade: 'epic', element: 'dark', role: 'balancer',
+        stats: { hp: 395, atk: 110, matk: 85, def: 65, mdef: 65 },
+        trait: { type: 'syn_dark_3_party_atk', val: 30, desc: '덱에 어둠 3장 이상 시 파티 전체 공격력 30% 증가' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '섀도우코로나', type: 'phy', tier: 2, cost: 20, val: 2.5, desc: '암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] },
+            { name: '녹턴윙스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'weak', mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'forget_me_not', name: '물망초', grade: 'rare', element: 'nature', role: 'buffer',
+        stats: { hp: 345, atk: 65, matk: 95, def: 55, mdef: 75 },
+        trait: { type: 'death_field_buff', buff: 'earth_bless', desc: '사망 시 필드버프 대지의축복 부여' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '블루메모리', type: 'sup', tier: 2, cost: 20, desc: '디바인 부여 및 약화/침묵 중 하나 추가 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'random_debuff', count: 1, pool: ['weak', 'silence'] }] },
+            { name: '미드나잇가든', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '대지의축복 소모 시 대미지 3배', effects: [{ type: 'consume_field_buff_dmg', buff: 'earth_bless', mult: 3.0 }] }
+        ]
+    },
+    {
+        id: 'aurora', name: '아우로라', grade: 'rare', element: 'water', role: 'looter',
+        stats: { hp: 315, atk: 70, matk: 75, def: 50, mdef: 50 },
+        trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
+        skills: [
+            { name: '리버설', type: 'sup', tier: 2, cost: 20, desc: '저주 부여 및 마법공격 무효', effects: [{ type: 'debuff', id: 'curse' }, { type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '리플렉션', type: 'sup', tier: 2, cost: 20, desc: '저주 부여 및 물리공격 무효', effects: [{ type: 'debuff', id: 'curse' }, { type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '라비린스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '부식 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'corrosion', mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'desert_fox', name: '사막여우', grade: 'normal', element: 'fire', role: 'debuffer',
+        stats: { hp: 300, atk: 80, matk: 75, def: 45, mdef: 50 },
+        trait: { type: 'death_debuff', debuff: 'burn', stack: 3, desc: '사망 시 적에게 작열 3스택 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '황금폭풍', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '작열 1스택 소모 및 약화/부식/저주/침묵 중 랜덤 2종 부여', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 1.0, customLog: '작열 1스택 소모!' }, { type: 'random_debuff', count: 2, pool: ['weak', 'corrosion', 'curse', 'silence'] }] },
+            { name: '모래돌진', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
+        ]
     }
 ];
 

--- a/card/index.html
+++ b/card/index.html
@@ -3064,6 +3064,10 @@
                     if (target.buffs.guard) dmg *= 0.5;
                     dmg = Math.floor(dmg);
                     target.hp -= dmg;
+                    if (dmg > 0) {
+                        target.tookDamageThisTurn = true;
+                        RPG.handleOnHitTraits(target, e);
+                    }
                     RPG.log(`${e.name}의 ${skill.name}! <span class="log-dmg">${dmg}</span> 피해.`);
 
                     // Process Effects (if any)
@@ -3125,6 +3129,20 @@
                     Object.keys(result.killerDebuffs).forEach(k => {
                         killer.buffs[k] = (killer.buffs[k] || 0) + result.killerDebuffs[k];
                         // If specific duration handling is needed, add here. Currently assumed 1 stack.
+                    });
+                }
+            },
+
+            handleOnHitTraits(victim, attacker) {
+                const result = Logic.handleOnHitTraits(
+                    victim,
+                    attacker,
+                    (msg) => RPG.log(msg)
+                );
+
+                if (result.attackerDebuffs && attacker && attacker.buffs) {
+                    Object.keys(result.attackerDebuffs).forEach(k => {
+                        attacker.buffs[k] = (attacker.buffs[k] || 0) + result.attackerDebuffs[k];
                     });
                 }
             },
@@ -3203,6 +3221,7 @@
                     target.hp -= dmgResult.dmg;
                     target.tookDamageThisTurn = true;
                     RPG.log(`${dmgResult.isCrit ? 'Critical! ' : ''}적에게 <span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
+                    RPG.handleOnHitTraits(target, source);
                 }
 
                 // Artifact: lucky_vicky — mana recovery on crit

--- a/card/logic.js
+++ b/card/logic.js
@@ -369,6 +369,13 @@ const DAMAGE_EFFECT_HANDLERS = {
             ctx.mult *= eff.mult;
             matched = true;
         }
+        else if (eff.condition === 'target_element') {
+            const elements = eff.elements || (eff.element ? [eff.element] : []);
+            if (elements.includes(ctx.target.element)) {
+                ctx.mult *= eff.mult;
+                matched = true;
+            }
+        }
 
         if (matched && eff.customLog) {
             ctx.logFn(eff.customLog);
@@ -393,6 +400,19 @@ const DAMAGE_EFFECT_HANDLERS = {
             else ctx.logFn(`${getBuffName(debuff)} ${count}스택 소모! 위력 ${m}배!`);
         }
     },
+    'consume_random_debuff_fixed_mult': (ctx, eff) => {
+        const count = eff.count || 1;
+        const pool = (eff.pool || []).filter(id => (ctx.target.buffs[id] || 0) >= count);
+        if (pool.length === 0) return;
+
+        const pick = pool[Math.floor(Math.random() * pool.length)];
+        ctx.target.buffs[pick] -= count;
+        if (ctx.target.buffs[pick] <= 0) delete ctx.target.buffs[pick];
+        ctx.mult *= eff.mult;
+
+        if (eff.customLog) ctx.logFn(eff.customLog);
+        else ctx.logFn(`${getBuffName(pick)} ${count}스택 랜덤 소모! 대미지 ${eff.mult}배!`);
+    },
     'consume_divine_add_darkness': (ctx, eff) => {
         if ((ctx.target.buffs['divine'] || 0) >= 1) {
             ctx.target.buffs['divine']--;
@@ -402,6 +422,16 @@ const DAMAGE_EFFECT_HANDLERS = {
         } else {
             ctx.logFn("소모할 디바인이 없어 효과가 발동하지 않았습니다.");
         }
+    },
+    'consume_field_buff_dmg': (ctx, eff) => {
+        const idx = ctx.fieldBuffs.findIndex(buff => buff.name === eff.buff);
+        if (idx === -1) return;
+
+        ctx.fieldBuffs.splice(idx, 1);
+        ctx.mult *= eff.mult;
+
+        if (eff.customLog) ctx.logFn(eff.customLog);
+        else ctx.logFn(`필드버프 [${getBuffName(eff.buff)}] 소모! 대미지 ${eff.mult}배!`);
     },
     'remove_field_buff_dmg': (ctx, eff) => {
         if (ctx.fieldBuffs.length > 0) {
@@ -968,6 +998,10 @@ const Logic = {
                 dmgBonus += (t.val - 1.0);
                 logFn(`[특성] ${source.name}: 부식 대상 추가 피해!`);
             }
+            if (t.type === 'cond_target_elements_dmg' && Array.isArray(t.elements) && t.elements.includes(target.element)) {
+                dmgBonus += (t.val - 1.0);
+                logFn(`[특성] ${source.name}: 특정 속성 적에게 추가 피해!`);
+            }
             if (t.type === 'cond_debuff_3_dmg' && Object.keys(target.buffs).length >= 3) {
                 dmgBonus += (t.val - 1.0);
                 logFn("[특성] 디버프 3개 이상 대상 추가 피해!");
@@ -1156,6 +1190,7 @@ const Logic = {
             else if (t.type === 'syn_dark_3_matk' && countEl('dark') >= 3) active = true;
             else if (t.type === 'syn_light_fire_atk' && hasEl('light') && hasEl('fire')) active = true;
             else if (t.type === 'syn_light_dark_matk_mdef' && hasEl('light') && hasEl('dark')) active = true;
+            else if (t.type === 'syn_light_3_matk_mdef' && countEl('light') >= 3) active = true;
             else if (t.type === 'syn_water_nature' && hasEl('water') && hasEl('nature')) active = true;
             else if (t.type === 'syn_nature_3_matk' && countEl('nature') >= 3) active = true;
             else if (t.type === 'syn_night_rabbit' && (deck.includes('night_rabbit') || deck.includes('silver_rabbit') || jokerInDeck)) active = true;
@@ -1164,6 +1199,7 @@ const Logic = {
             else if (t.type === 'syn_water_3_atk_matk' && countEl('water') >= 3) active = true;
             else if (t.type === 'syn_fire_3_crit_burn' && countEl('fire') >= 3) active = true;
             else if (t.type === 'syn_dark_3_matk_boost' && countEl('dark') >= 3) active = true;
+            else if (t.type === 'syn_dark_3_party_atk' && countEl('dark') >= 3) active = true;
             else if (t.type === 'syn_water_2_moon_twinkle' && countEl('water') >= 2) active = true;
 
             if (active) {
@@ -1174,6 +1210,7 @@ const Logic = {
                 if (t.type === 'syn_dark_3_matk') p.matk *= 1.5;
                 if (t.type === 'syn_light_fire_atk') p.atk *= 1.3;
                 if (t.type === 'syn_light_dark_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
+                if (t.type === 'syn_light_3_matk_mdef') { p.matk *= 1.5; p.mdef *= 1.5; }
                 if (t.type === 'syn_night_rabbit') { p.matk *= 1.5; p.mdef *= 1.5; }
                 if (t.type === 'syn_snow_rabbit') { p.atk *= 1.5; p.def *= 1.5; }
                 if (t.type === 'syn_silver_rabbit') { p.atk *= 1.5; p.matk *= 1.5; }
@@ -1221,6 +1258,9 @@ const Logic = {
                 stats.forEach(s => {
                     if (partyBoost[s] !== undefined) partyBoost[s] += (tr.val || 0);
                 });
+            }
+            else if (tr && tr.type === 'syn_dark_3_party_atk' && countEl('dark') >= 3) {
+                partyBoost.atk += (tr.val || 0);
             }
         });
 
@@ -1341,9 +1381,14 @@ const Logic = {
         }
         else if (t.type === 'death_debuff') {
             if (killer) {
-                result.killerDebuffs[t.debuff] = 1;
-                logFn(`[특성] 사망 효과 발동! 적에게 [${getBuffName(t.debuff)}] 부여.`);
+                const stack = t.stack || 1;
+                result.killerDebuffs[t.debuff] = (result.killerDebuffs[t.debuff] || 0) + stack;
+                logFn(`[특성] 사망 효과 발동! 적에게 [${getBuffName(t.debuff)}] ${stack > 1 ? `${stack}스택 ` : ''}부여.`);
             }
+        }
+        else if (t.type === 'death_field_buff') {
+            result.fieldBuffsToAdd.push(t.buff);
+            logFn(`[특성] 사망 효과 발동! 필드버프 [${getBuffName(t.buff)}] 부여.`);
         }
         else if (t.type === 'death_sun_bless_chance') {
             if (Math.random() < t.val) {
@@ -1404,6 +1449,23 @@ const Logic = {
                     logFn(`[아티팩트] 빅뱅! 전설/초월 카드 자폭! <span class="log-dmg">${dmgResult.dmg}</span> 피해!`);
                 }
             }
+        }
+
+        return result;
+    },
+
+    handleOnHitTraits: function (victim, attacker, logFn) {
+        if (!logFn) logFn = function () { };
+
+        const result = { attackerDebuffs: {} };
+        const t = victim && victim.proto ? victim.proto.trait : null;
+        if (!t || !attacker) return result;
+
+        if (t.type === 'on_hit_random_debuff' && Array.isArray(t.pool) && t.pool.length > 0) {
+            const pick = t.pool[Math.floor(Math.random() * t.pool.length)];
+            const stack = t.stack || 1;
+            result.attackerDebuffs[pick] = (result.attackerDebuffs[pick] || 0) + stack;
+            logFn(`[특성] ${victim.name}: 피격 반응! 적에게 [${getBuffName(pick)}] ${stack > 1 ? `${stack}스택 ` : ''}부여.`);
         }
 
         return result;


### PR DESCRIPTION
## Summary
- add 7 new bonus cards to the card pool
- wire new trait/skill handling for on-hit debuffs, death field buffs, stacked death debuffs, and conditional bonus-card damage logic
- apply the new combat hooks in battle flow for both enemy and player damage paths

## Testing
- npm run verify

## Unverified
- browser-side manual checks for each new card's live battle behavior and text/layout