### PR TITLE
Cap death-applied burn/divine stacks to respect artifact limits

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -3127,7 +3127,18 @@
 
                 if (result.killerDebuffs && killer && killer.buffs) {
                     Object.keys(result.killerDebuffs).forEach(k => {
-                        killer.buffs[k] = (killer.buffs[k] || 0) + result.killerDebuffs[k];
+                        const nextStack = (killer.buffs[k] || 0) + result.killerDebuffs[k];
+                        if (k === 'burn') {
+                            const burnMax = this.hasArtifact('over_flame') ? 5 : 3;
+                            killer.buffs[k] = Math.min(nextStack, burnMax);
+                            return;
+                        }
+                        if (k === 'divine') {
+                            const divineMax = this.hasArtifact('over_divine') ? 5 : 3;
+                            killer.buffs[k] = Math.min(nextStack, divineMax);
+                            return;
+                        }
+                        killer.buffs[k] = nextStack;
                         // If specific duration handling is needed, add here. Currently assumed 1 stack.
                     });
                 }


### PR DESCRIPTION
### Motivation
- Death-triggered debuffs (e.g. 사막여우의 `burn` 3스택) could push the attacker's stacks past the configured maximums, bypassing the normal caps and artifact overrides.

### Description
- Restrict application of death-applied stack debuffs in `handleDeathTraits` by computing `nextStack` and capping it before assignment in `card/index.html`.
- Enforce `burn` cap as `3` or `5` when `over_flame` is present, and `divine` cap as `3` or `5` when `over_divine` is present, while leaving other debuffs unchanged.
- Change is localized to the result application block that processes `result.killerDebuffs` so other logic is unaffected.

### Testing
- Ran the mandatory verification: `npm run verify` which runs linting and smoke tests, and the run passed (`Card smoke verification passed.` and `Idle hero smoke verification passed.`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac581de5e883228a0ec2b790bfe55c)