### PR TITLE
Handle source death and death traits immediately after applying skill effects

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -3252,8 +3252,12 @@
                 // Apply Side Effects (Buffs, Debuffs, Field, Suicide, etc.)
                 this.applySkillEffects(source, target, modifiedSkill);
 
+                if (source.hp <= 0 && !source.isDead) {
+                    source.isDead = true;
+                    RPG.log(`${source.name} 사망!`);
+                    RPG.handleDeathTraits(source, target);
+                }
                 if (target.hp <= 0) { RPG.winBattle(); return; }
-                if (source.hp <= 0 && !source.isDead) { source.isDead = true; RPG.log(`${source.name} 사망!`); }
 
                 if (!isDelayed) RPG.TurnManager.endPlayerTurn();
             },


### PR DESCRIPTION
### Motivation
- Ensure a combatant that dies as a result of skill side-effects (buffs/debuffs, suicide effects, etc.) is marked dead and has death traits processed immediately after `applySkillEffects`, before win checks or ending the turn.

### Description
- Add a post-effect check after `this.applySkillEffects(source, target, modifiedSkill)` that sets `source.isDead`, logs the death, and calls `RPG.handleDeathTraits(source, target)` when `source.hp <= 0`, and remove the redundant later death handling.

### Testing
- Ran the battle resolution unit tests covering death, artifact, and trait interactions (`battle` specs) to validate scenarios where the source dies from skill effects and confirmed `RPG.handleDeathTraits` is invoked; tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae27ca0d488322864ff765e585cf98)