### PR TITLE
Add consume_debuff_then_random_debuff handler and adjust card data (archangel buff, desert_fox skill)

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -255,7 +255,7 @@ const CARDS = [
     {
         id: 'archangel', name: '대천사', grade: 'epic', element: 'light', role: 'balancer',
         stats: { hp: 400, atk: 70, matk: 95, def: 65, mdef: 80 },
-        trait: { type: 'syn_light_dark_matk_mdef', val: 30, desc: '덱에 빛, 어둠이 있을 경우 마법공격력, 마법방어력 30%증가' },
+        trait: { type: 'syn_light_dark_matk_mdef', val: 50, desc: '덱에 빛, 어둠이 있을 경우 마법공격력, 마법방어력 50%증가' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
             { name: '성역전개', type: 'sup', tier: 2, cost: 20, desc: '필드버프 성역 발동 및 적에게 디바인 1스택 부여', effects: [{ type: 'field_buff', id: 'sanctuary' }, { type: 'debuff', id: 'divine', stack: 1 }] },
@@ -725,7 +725,7 @@ const BONUS_CARDS = [
         trait: { type: 'death_debuff', debuff: 'burn', stack: 3, desc: '사망 시 적에게 작열 3스택 부여' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '황금폭풍', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '작열 1스택 소모 및 약화/부식/저주/침묵 중 랜덤 2종 부여', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 1.0, customLog: '작열 1스택 소모!' }, { type: 'random_debuff', count: 2, pool: ['weak', 'corrosion', 'curse', 'silence'] }] },
+            { name: '황금폭풍', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '작열 1스택 소모 및 약화/부식/저주/침묵 중 랜덤 2종 부여', effects: [{ type: 'consume_debuff_then_random_debuff', debuff: 'burn', count: 1, randomCount: 2, pool: ['weak', 'corrosion', 'curse', 'silence'], customLog: '작열 1스택 소모!' }] },
             { name: '모래돌진', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
         ]
     }

--- a/card/logic.js
+++ b/card/logic.js
@@ -576,6 +576,25 @@ const SideEffects = {
                 }
             }
         },
+        'consume_debuff_then_random_debuff': (ctx, eff) => {
+            const debuff = eff.debuff;
+            const count = eff.count || 1;
+            if ((ctx.target.buffs[debuff] || 0) < count) return;
+
+            ctx.target.buffs[debuff] -= count;
+            if (ctx.target.buffs[debuff] <= 0) delete ctx.target.buffs[debuff];
+            if (eff.customLog) ctx.logFn(eff.customLog);
+            else ctx.logFn(`${getBuffName(debuff)} ${count}스택 소모!`);
+
+            let pool = [...eff.pool].sort(() => 0.5 - Math.random());
+            const randomCount = eff.randomCount || eff.count || 1;
+            for (let i = 0; i < randomCount; i++) {
+                if (pool[i]) {
+                    ctx.target.buffs[pool[i]] = 1;
+                    ctx.logFn(`적에게 [${getBuffName(pool[i])}] 부여.`);
+                }
+            }
+        },
         'conditional_debuff': (ctx, eff) => {
             if (eff.condition === 'target_debuff_count' && Object.keys(ctx.target.buffs).length >= eff.count) {
                 ctx.target.buffs[eff.debuff] = 1;


### PR DESCRIPTION
### Motivation
- Unify a two-step skill behavior that consumed a debuff then applied random debuffs into a single side-effect type for clearer logic and easier reuse.
- Fix/update card balance by increasing `archangel` synergy trait magnitude.
- Replace ad-hoc combined effect entries in card definitions with a single, explicit effect type to avoid duplicated client logic.

### Description
- Added a new side-effect handler `consume_debuff_then_random_debuff` in `card/logic.js` that consumes specified debuff stacks from the target, logs the consumption, and applies a configurable number of random debuffs from a pool.
- Updated `desert_fox` skill in `card/data.js` to use the new `consume_debuff_then_random_debuff` effect instead of a separate `consume_debuff_fixed` and `random_debuff` pair.
- Increased the `archangel` card trait `syn_light_dark_matk_mdef` value from `30` to `50` in `card/data.js` to adjust its light/dark synergy potency.

### Testing
- Ran the project test suite with `npm test`, and all tests completed successfully.
- Ran linter via `npm run lint` with no new issues reported.
- Exercised the new side-effect via relevant unit scenarios to confirm debuff consumption and random debuff application behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21f35f4688322a40422b490a6def3)