### PR TITLE
Fix cond_twinkle_all to use trait.val in battle stat calculation

### DIFF
--- a/card/logic.js
+++ b/card/logic.js
@@ -937,7 +937,9 @@ const Logic = {
         // Trait Multipliers
         if (trait) {
             if (trait.type === 'cond_twinkle_all' && fieldBuffs.some(b => b.name === 'twinkle_party')) {
-                m.atk += 0.3; m.matk += 0.3;
+                const twinkleAllBonus = (trait.val || 0) / 100;
+                m.atk += twinkleAllBonus;
+                m.matk += twinkleAllBonus;
             }
         }
 


### PR DESCRIPTION
### Motivation
- The `cream_maid` trait was updated to `val: 50` but `calculateBattleStats` still applied a hard-coded `+0.3` for `cond_twinkle_all`, causing a mismatch between data/description and runtime behavior.

### Description
- Replace the hard-coded `0.3` with a computed bonus using `const twinkleAllBonus = (trait.val || 0) / 100` and add it to `m.atk` and `m.matk` so the in-game bonus matches `trait.val`.

### Testing
- Ran `npm run verify` (runs lint and smoke tests) and it completed successfully (`Card smoke verification passed.` and `Idle hero smoke verification passed.`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4118ad6dc83229f34e8843404cd5c)