### PR TITLE
보너스풀에 에인션트드래곤·해바라기 추가 및 연동(태양/드래곤하트/시간)

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -760,6 +760,26 @@ const BONUS_CARDS = [
         ]
     },
     {
+        id: 'ancient_dragon', name: '에인션트드래곤', grade: 'legend', element: 'nature', role: 'debuffer',
+        stats: { hp: 530, atk: 115, matk: 95, def: 70, mdef: 70 },
+        trait: { type: 'death_multi_debuff', desc: '사망시 적에게 약화, 부식, 저주, 침묵, 기절 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] },
+            { name: '에인션트브레스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 부여, 대지의축복 상태에서 대미지 2배', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'sunflower', name: '해바라기', grade: 'normal', element: 'nature', role: 'dealer',
+        stats: { hp: 320, atk: 75, matk: 80, def: 50, mdef: 50 },
+        trait: { type: 'cond_sun_matk_mdef', val: 100, desc: '태양의축복 상태에서 마법공격력/마법방어력 100%증가' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '솔라플레어', type: 'mag', tier: 3, cost: 30, val: 4.0, desc: '사용 후 2턴 뒤에 공격', effects: [{ type: 'delayed_attack', turns: 2 }] },
+            { name: '어쓰블라썸', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '대지의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] }
+        ]
+    },
+    {
         id: 'red_moon', name: '레드문', grade: 'legend', element: 'fire', role: 'dealer',
         stats: { hp: 490, atk: 140, matk: 100, def: 65, mdef: 60 },
         trait: { type: 'death_dmg_phy', val: 6.0, desc: '사망 시 적에게 600% 물리대미지' },

--- a/card/logic.js
+++ b/card/logic.js
@@ -184,7 +184,7 @@ const ARTIFACT_LIST = [
     { id: 'double_attack', name: '더블어택', desc: '일반공격 위력 2.0배' },
     { id: 'death_roulette', name: '데스룰렛', desc: '모든 스킬 대미지 2배, 스킬 사용시 30% 확률로 사망' },
     { id: 'shadow_stab', name: '섀도우스탭', desc: '회피율 20%증가, 방어력과 마법방어력 30% 감소' },
-    { id: 'dragon_heart', name: '드래곤하트', desc: '베이비드래곤/레드드래곤/골드드래곤 마공 100% 증가' },
+    { id: 'dragon_heart', name: '드래곤하트', desc: '베이비드래곤/레드드래곤/골드드래곤/에인션트드래곤 마공 100% 증가' },
     { id: 'big_bang', name: '빅뱅', desc: '전설/초월 카드 사망시 물리 3배율 자폭대미지' },
     { id: 'companion', name: '길동무', desc: '사망시 적에게 대미지를 주는 특성이나 아티팩트 대미지 2배' },
     { id: 'kaleidoscope', name: '만화경', desc: '매 턴 개시시 모든 필드버프를 변경한다' },
@@ -911,6 +911,11 @@ const Logic = {
             m.def += 0.5;
             m.mdef += 0.5;
         }
+        if (trait && trait.type === 'cond_sun_matk_mdef' && fieldBuffs.some(b => b.name === 'sun_bless')) {
+            const boost = (trait.val || 0) / 100;
+            m.matk += boost;
+            m.mdef += boost;
+        }
 
         // Field Buffs (Only apply to Allies)
         if (isPlayer) {
@@ -1361,7 +1366,7 @@ const Logic = {
         // Artifact: dragon_heart — dragon cards matk +100%
         const artifacts = (typeof RPG !== 'undefined' && RPG.state && RPG.state.artifacts) ? RPG.state.artifacts : [];
         if (artifacts.includes('dragon_heart')) {
-            const dragonIds = ['baby_dragon', 'red_dragon', 'gold_dragon'];
+            const dragonIds = ['baby_dragon', 'red_dragon', 'gold_dragon', 'ancient_dragon'];
             if (dragonIds.includes(playerProto.id)) {
                 p.matk = Math.floor(p.matk * 2.0);
             }
@@ -1497,6 +1502,15 @@ const Logic = {
                 logFn(`[특성] 마시멜로가 녹으며 태양의 축복을 남깁니다!`);
             } else {
                 logFn(`[특성] 마시멜로가 흔적도 없이 사라졌습니다... (축복 실패)`);
+            }
+        }
+        else if (t.type === 'death_multi_debuff') {
+            if (killer) {
+                ['weak', 'corrosion', 'curse', 'silence'].forEach(debuff => {
+                    result.killerDebuffs[debuff] = (result.killerDebuffs[debuff] || 0) + 1;
+                });
+                result.killerDebuffs['stun'] = (result.killerDebuffs['stun'] || 0) + 1;
+                logFn('[특성] 사망 효과 발동! 적에게 약화, 부식, 저주, 침묵, 기절 부여.');
             }
         }
         else if (t.type === 'death_field_buff_count_dmg') {


### PR DESCRIPTION
### Motivation
- 보너스 카드 풀에 요청된 두 카드를 추가하고 기존 특성/아티팩트/지연스킬 처리와 연동하여 전투 동작을 일관되게 만들기 위함입니다.

### Description
- `card/data.js`의 `BONUS_CARDS`에 `ancient_dragon`(에인션트드래곤)과 `sunflower`(해바라기)를 추가했습니다.
- `sunflower`의 특성은 `cond_sun_matk_mdef`로 구현했고, 기존 `cream_maid`/`mushroom_king` 처리 흐름을 참고해 `sun_bless` 상태에서 `MATK`/`MDEF` 증가가 적용되도록 `card/logic.js`의 스탯 계산에 처리 로직을 추가했습니다.
- `sunflower`의 `솔라플레어`는 `delayed_attack`으로 정의하여 `시간의마술사(time_magician)`의 `instant_delayed_skills` 특성과 기존 지연스킬 처리 로직과 연동됩니다 (`delayed_attack` 사용 방식과 동일한 패턴 적용). 
- `ancient_dragon`의 특성은 `death_multi_debuff`로 구현하여 사망 시 적에게 `weak`, `corrosion`, `curse`, `silence`, `stun`을 부여하도록 `handleDeathTraits`에 처리 코드를 추가했습니다.
- 아티팩트 `dragon_heart`의 적용 대상에 `ancient_dragon`을 추가하고, 아티팩트 설명 문구를 갱신했습니다.

### Testing
- 자동검증: `npm run verify`를 실행하여 `lint`(node --check)와 스모크 테스트(`scripts/verify_card_smoke.js` 및 `scripts/verify_idle_hero_smoke.js`)를 통과했습니다 (성공).
- 참고: 코드 수준의 정적/스모크 검증은 통과했지만 브라우저에서의 UI 렌더링(보너스 풀 편집 UI에 새 카드 노출 등)과 플레이어가 직접 확인하는 시각적 동작은 수동으로 확인되지 않았습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b56c68d1c0832285387cc08b2fbac3)