### PR TITLE
Balance update for Crystal Dancer card

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -751,7 +751,7 @@ const BONUS_CARDS = [
     },
     {
         id: 'crystal_dancer', name: '수정의무희', grade: 'epic', element: 'water', role: 'dealer',
-        stats: { hp: 395, atk: 100, matk: 100, def: 60, mdef: 60 },
+        stats: { hp: 395, atk: 110, matk: 90, def: 60, mdef: 60 },
         trait: { type: 'on_evasion_stun', desc: '회피 성공 시 상대에게 기절 부여' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },


### PR DESCRIPTION
This patch updates the stats for the "Crystal Dancer" (수정의무희) card in the card RPG module.
Following the balance adjustment request, the card's physical attack (atk) has been increased by 10, and its magic attack (matk) has been decreased by 10.

Changes:
- In `card/data.js`, the `crystal_dancer` stats object was updated.
- Verified the change through both code inspection and frontend visual verification using Playwright.
- Ensured all linting and smoke tests pass.

---
*PR created automatically by Jules for task [11072353303857812663](https://jules.google.com/task/11072353303857812663) started by @romarin0325-cell*