### PR TITLE
Fix 대천사 trait applying 30% instead of 50%

### DIFF
--- a/card/logic.js
+++ b/card/logic.js
@@ -1303,7 +1303,7 @@ const Logic = {
                 if (t.type === 'syn_fire_3_crit') p.baseCrit += 30;
                 if (t.type === 'syn_dark_3_matk') p.matk *= 1.5;
                 if (t.type === 'syn_light_fire_atk') p.atk *= 1.3;
-                if (t.type === 'syn_light_dark_matk_mdef') { p.matk *= 1.3; p.mdef *= 1.3; }
+                if (t.type === 'syn_light_dark_matk_mdef') { p.matk *= 1.5; p.mdef *= 1.5; }
                 if (t.type === 'syn_light_3_matk_mdef') { p.matk *= 1.5; p.mdef *= 1.5; }
                 if (t.type === 'syn_night_rabbit') { p.matk *= 1.5; p.mdef *= 1.5; }
                 if (t.type === 'syn_snow_rabbit') { p.atk *= 1.5; p.def *= 1.5; }


### PR DESCRIPTION
### Motivation
- The `대천사` (`archangel`) trait description states a 50% increase to magic attack and magic defense when Light+Dark synergy is active, but runtime applied 30%, causing mismatch between UI text and actual calculation.

### Description
- Adjusted the runtime multiplier for the `syn_light_dark_matk_mdef` trait from `1.3` to `1.5` in `card/logic.js` so the active synergy grants +50% `matk` and `mdef` as described.
- This is a minimal change targeting only the incorrect multiplier to preserve other behavior.

### Testing
- Ran `npm run verify`, which performs `node --check` linting and the smoke tests; both `Card smoke verification` and `Idle hero smoke verification` passed.
- `npm run lint` and `npm run test:smoke` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b64952a9a083228bab2d04c34d78de)