### PR TITLE
Refactor card runtime and standardize joker/deck helpers

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -1,0 +1,655 @@
+/**
+ * battle_runtime.js — Non-visual battle runtime for Card RPG.
+ *
+ * Keeps battle state transitions and skill/effect resolution outside index.html
+ * while preserving the existing RPG method names and DOM entrypoints.
+ */
+
+function getStackCap(rpg, buffId) {
+    if (buffId === 'burn') return rpg.hasArtifact('over_flame') ? 5 : 3;
+    if (buffId === 'divine') return rpg.hasArtifact('over_divine') ? 5 : 3;
+    return null;
+}
+
+function applyStackMap(rpg, target, buffMap) {
+    if (!target || !target.buffs || !buffMap) return;
+
+    Object.keys(buffMap).forEach(buffId => {
+        const cap = getStackCap(rpg, buffId);
+        const nextValue = (target.buffs[buffId] || 0) + buffMap[buffId];
+        target.buffs[buffId] = cap === null ? nextValue : Math.min(nextValue, cap);
+    });
+}
+
+function buildBattleEnemy(rpg) {
+    const enemyIdx = rpg.state.enemyScale % ENEMIES.length;
+    const baseEnemy = ENEMIES[enemyIdx];
+    const cycle = Math.floor(rpg.state.enemyScale / ENEMIES.length);
+    const scale = 1.0 + (cycle * 0.2);
+    const enemy = {
+        id: baseEnemy.id,
+        name: baseEnemy.name,
+        maxHp: Math.floor(baseEnemy.stats.hp * scale),
+        hp: Math.floor(baseEnemy.stats.hp * scale),
+        atk: Math.floor(baseEnemy.stats.atk * scale),
+        matk: Math.floor(baseEnemy.stats.matk * scale),
+        def: Math.floor(baseEnemy.stats.def * scale),
+        mdef: Math.floor(baseEnemy.stats.mdef * scale),
+        baseDef: Math.floor(baseEnemy.stats.def * scale),
+        baseMdef: Math.floor(baseEnemy.stats.mdef * scale),
+        skills: baseEnemy.skills,
+        buffs: {},
+        element: baseEnemy.element,
+        tookDamageThisTurn: false,
+        lastHitType: null
+    };
+
+    if (baseEnemy.id === 'creator_god') {
+        enemy.chargeTurn = 0;
+    }
+
+    return enemy;
+}
+
+function buildBattlePlayer(rpg, cardId, idx, allCards) {
+    if (!cardId) return null;
+
+    const proto = rpg.getCardData(cardId);
+    const init = Logic.calculateInitialStats(proto, rpg.state.deck, allCards, idx);
+
+    if (init.activeTrait) {
+        rpg.battle.activeTraits.push(init.activeTrait);
+        rpg.log(`[시너지] ${proto.trait.desc} 발동!`);
+    }
+    if (proto.trait.type === 'instant_delayed_skills') {
+        rpg.battle.activeTraits.push(proto.trait.type);
+    }
+
+    const player = {
+        id: proto.id,
+        proto: proto,
+        name: proto.name,
+        ...init.stats,
+        buffs: {},
+        pos: idx,
+        isDead: false,
+        skills: JSON.parse(JSON.stringify(proto.skills))
+    };
+
+    const blessing = (rpg.state.chaosBuffs || []).find(buff => buff.id === player.id);
+    if (blessing) {
+        player.baseStatsWithoutBlessing = {
+            atk: player.atk,
+            matk: player.matk,
+            def: player.def,
+            mdef: player.mdef
+        };
+
+        player.maxHp = Math.floor(player.maxHp * (1 + blessing.multiplier));
+        player.hp = player.maxHp;
+        player.blessing = blessing;
+
+        const mult = 1.0 + blessing.multiplier;
+        player.atk = Math.floor(player.atk * mult);
+        player.matk = Math.floor(player.matk * mult);
+        player.def = Math.floor(player.def * mult);
+        player.mdef = Math.floor(player.mdef * mult);
+    }
+
+    if (proto.trait.type.startsWith('pos_')) {
+        const trait = proto.trait;
+        const active =
+            (trait.type.includes('van') && idx === 0) ||
+            (trait.type.includes('mid') && idx === 1) ||
+            (trait.type.includes('rear') && idx === 2);
+        if (active) {
+            if (trait.type.includes('_atk')) player.atk = Math.floor(player.atk * (1 + trait.val / 100));
+            if (trait.type.includes('_matk')) player.matk = Math.floor(player.matk * (1 + trait.val / 100));
+            if (trait.type.includes('_def')) player.def = Math.floor(player.def * (1 + trait.val / 100));
+            if (trait.type.includes('_mdef')) player.mdef = Math.floor(player.mdef * (1 + trait.val / 100));
+        }
+    }
+
+    return player;
+}
+
+const BattleRuntime = {
+    startBattleInit(rpg) {
+        if (rpg.state.deck.every(cardId => cardId === null)) {
+            return rpg.showAlert("덱을 완성해주세요.");
+        }
+
+        rpg.showBattleScreen();
+        rpg.battle.enemy = buildBattleEnemy(rpg);
+        rpg.battle.activeTraits = [];
+
+        const allCards = GameUtils.getAllCards();
+        rpg.battle.players = rpg.state.deck.map((cardId, idx) => buildBattlePlayer(rpg, cardId, idx, allCards));
+        rpg.battle.fieldBuffs = [];
+        rpg.battle.delayedEffects = [];
+        rpg.battle.turn = 1;
+        rpg.battle.currentPlayerIdx = 0;
+        rpg.battle.isNewTurn = true;
+
+        while (
+            rpg.battle.currentPlayerIdx < GAME_CONSTANTS.DECK_SIZE &&
+            rpg.battle.players[rpg.battle.currentPlayerIdx] === null
+        ) {
+            rpg.battle.currentPlayerIdx++;
+        }
+
+        rpg.clearBattleLog();
+        rpg.log(`전투 개시! 적: ${rpg.battle.enemy.name}`);
+        if (rpg.battle.activeTraits.includes('instant_delayed_skills')) {
+            rpg.log('[특성] 시간의마술사: 덱의 지연 스킬이 즉시 발동합니다!');
+        }
+
+        if (rpg.hasArtifact('gale_storm')) {
+            BattleRuntime.applyFieldBuff(rpg, 'gale', {
+                expiresAtTurn: 4,
+                expireLog: '[아티팩트] 질풍노도 효과 종료. (질풍 제거)'
+            });
+            rpg.log('[아티팩트] 질풍노도: 전투 시작 시 질풍 발동!');
+        }
+
+        if (rpg.hasArtifact('support_boost')) {
+            rpg.battle.players.forEach(player => {
+                if (!player || !player.skills) return;
+                player.skills.forEach(skill => {
+                    if (skill.type === 'sup') skill.cost = 0;
+                });
+            });
+            rpg.log('[아티팩트] 서포트부스트: 모든 보조스킬 마나 소비 0!');
+        }
+
+        rpg.renderBattleView();
+        BattleRuntime.TurnManager.startPlayerTurn(rpg);
+    },
+
+    TurnManager: {
+        startPlayerTurn(rpg) {
+            const battle = rpg.battle;
+            if (battle.currentPlayerIdx >= GAME_CONSTANTS.DECK_SIZE) {
+                rpg.loseBattle();
+                return;
+            }
+
+            if (battle.isNewTurn) {
+                battle.isNewTurn = false;
+                rpg.log(`=== ${battle.turn}턴 ===`, 'info');
+                BattleRuntime.expireFieldBuffs(rpg, battle.turn);
+
+                if (rpg.hasArtifact('kaleidoscope')) {
+                    const count = battle.fieldBuffs.length;
+                    if (count > 0) {
+                        battle.fieldBuffs = [];
+                        rpg.log('[아티팩트] 만화경: 필드 버프 재구성!');
+
+                        const allBuffs = Object.keys(GAME_CONSTANTS.FIELD_BUFF_STATS)
+                            .filter(buffId => buffId !== 'destiny_oath');
+                        const pool = [...allBuffs].sort(() => 0.5 - Math.random());
+                        const picks = pool.slice(0, Math.min(count, pool.length));
+                        picks.forEach(buffId => BattleRuntime.applyFieldBuff(rpg, buffId));
+                    }
+                }
+
+                if (battle.enemy && battle.enemy.id === 'demon_god') {
+                    battle.enemy.def = battle.enemy.baseDef;
+                    battle.enemy.mdef = battle.enemy.baseMdef;
+                    if (battle.turn % 2 === 0) {
+                        battle.enemy.def = Math.floor(battle.enemy.def * 1.5);
+                        rpg.log("마신의 권능: 짝수 턴 물리방어력 50% 증가.");
+                    } else {
+                        battle.enemy.mdef = Math.floor(battle.enemy.mdef * 1.5);
+                        rpg.log("마신의 권능: 홀수 턴 마법방어력 50% 증가.");
+                    }
+                }
+            }
+
+            if (battle.enemy) battle.enemy.lastHitType = null;
+
+            const player = battle.players[battle.currentPlayerIdx];
+            if (!player || player.isDead) {
+                battle.currentPlayerIdx++;
+                BattleRuntime.TurnManager.startPlayerTurn(rpg);
+                return;
+            }
+
+            for (let idx = battle.delayedEffects.length - 1; idx >= 0; idx--) {
+                const effect = battle.delayedEffects[idx];
+                if (effect.turn === battle.turn) {
+                    battle.delayedEffects.splice(idx, 1);
+                    if (effect.source.isDead) {
+                        rpg.log(`${effect.skill.name} 발동 실패... (시전자 사망)`);
+                    } else {
+                        rpg.log(`${effect.skill.name} 발동!`);
+                        BattleRuntime.executeSkill(rpg, effect.source, battle.enemy, effect.skill, true);
+                    }
+                }
+            }
+
+            ['evasion', 'barrier', 'magic_guard', 'guard'].forEach(buffId => delete player.buffs[buffId]);
+
+            rpg.renderBattleView();
+
+            if (player.buffs.stun) {
+                rpg.log(`${player.name} 기절로 인해 행동 불가.`);
+                delete player.buffs.stun;
+                BattleRuntime.TurnManager.endPlayerTurn(rpg);
+                return;
+            }
+
+            rpg.renderBattleControls(player);
+        },
+
+        endPlayerTurn(rpg) {
+            setTimeout(() => BattleRuntime.TurnManager.startEnemyTurn(rpg), 500);
+        },
+
+        startEnemyTurn(rpg) {
+            const battle = rpg.battle;
+            const enemy = battle.enemy;
+            if (enemy.hp <= 0) {
+                rpg.winBattle();
+                return;
+            }
+
+            rpg.log("--- 적 턴 ---");
+            enemy.def = enemy.baseDef;
+            enemy.mdef = enemy.baseMdef;
+
+            if (enemy.id === 'artificial_demon_god') {
+                delete enemy.buffs.defProtocolPhy;
+                delete enemy.buffs.defProtocolMag;
+                if (enemy.lastHitType === 'phy') {
+                    enemy.buffs.defProtocolPhy = 1;
+                    rpg.log("방어 프로토콜: 물리 피격 감지 (다음 턴 물리방어력 증가).");
+                }
+                if (enemy.lastHitType === 'mag') {
+                    enemy.buffs.defProtocolMag = 1;
+                    rpg.log("방어 프로토콜: 마법 피격 감지 (다음 턴 마법방어력 증가).");
+                }
+                if (enemy.buffs.defProtocolPhy) enemy.def = Math.floor(enemy.def * 1.5);
+                if (enemy.buffs.defProtocolMag) enemy.mdef = Math.floor(enemy.mdef * 1.5);
+            }
+            if (enemy.id === 'demon_god') {
+                if (battle.turn % 2 === 0) enemy.def = Math.floor(enemy.def * 1.5);
+                else enemy.mdef = Math.floor(enemy.mdef * 1.5);
+            }
+
+            if (enemy.buffs.stun) {
+                rpg.log(`${enemy.name} 기절하여 행동 불가.`);
+                delete enemy.buffs.stun;
+                BattleRuntime.TurnManager.endEnemyTurn(rpg);
+                return;
+            }
+
+            let target = battle.players[battle.currentPlayerIdx];
+            if (!target || target.isDead) {
+                const validIdx = battle.players.findIndex(player => player && !player.isDead);
+                if (validIdx === -1) {
+                    rpg.loseBattle();
+                    return;
+                }
+                battle.currentPlayerIdx = validIdx;
+                target = battle.players[validIdx];
+            }
+
+            const skillInfo = Logic.decideEnemyAction(enemy, battle.turn);
+
+            if (skillInfo.chargeReset) enemy.isCharging = false;
+            if (skillInfo.isChargeStart) {
+                enemy.isCharging = true;
+                rpg.log("창조신이 힘을 모으고 있습니다... (공격 없음)");
+                BattleRuntime.TurnManager.endEnemyTurn(rpg);
+                return;
+            }
+
+            const skill = skillInfo;
+            let val = skill.type === 'phy' ? enemy.atk : enemy.matk;
+            let mult = skill.val || 1.0;
+
+            if (enemy.id === 'pharaoh' && skill.name === '고대의저주' && enemy.tookDamageThisTurn) {
+                mult = 3.0;
+                rpg.log("고대의 저주: 턴 내 피격 감지! 대미지 3배로 반격!");
+            }
+
+            if (enemy.buffs.weak && skill.type === 'phy') val *= 0.8;
+            if (enemy.buffs.silence && skill.type === 'mag') val *= 0.8;
+
+            let def = skill.type === 'phy' ? target.def : target.mdef;
+            let fieldDef = 1.0;
+            battle.fieldBuffs.forEach(fieldBuff => {
+                if (fieldBuff.name === 'star_powder') fieldDef += 0.3;
+                if (fieldBuff.name === 'sanctuary' && skill.type === 'mag') fieldDef += 0.25;
+                if (fieldBuff.name === 'goddess_descent') fieldDef += 0.3;
+            });
+
+            let defMult = 1.0;
+            if (skill.type === 'phy') {
+                if (target.buffs.darkness && target.buffs.corrosion) defMult = 0.6;
+                else if (target.buffs.darkness || target.buffs.corrosion) defMult = 0.8;
+            } else if (target.buffs.curse) {
+                defMult = 0.8;
+            }
+
+            def = Math.floor(def * fieldDef * defMult);
+
+            if (Logic.checkEvasion(target, skill.type, battle.fieldBuffs, rpg.state.mode, rpg.state.artifacts || [])) {
+                rpg.log(`${target.name} 회피 성공! (${skill.name} 회피)`);
+                if (rpg.hasArtifact('lucky_vicky')) {
+                    target.mp = Math.min(GAME_CONSTANTS.MAX_MP, target.mp + 10);
+                    rpg.log('[아티팩트] 럭키비키: 회피 성공! 마나 10 회복!');
+                }
+                if (target.proto && target.proto.trait && target.proto.trait.type === 'on_evasion_stun') {
+                    enemy.buffs.stun = 1;
+                    rpg.log(`[특성] ${target.name}: 회피 반격! 적에게 [기절] 부여.`);
+                }
+                BattleRuntime.TurnManager.endEnemyTurn(rpg);
+                return;
+            }
+            if (target.buffs.barrier && skill.type === 'phy') {
+                rpg.log(`${target.name} 배리어로 방어!`);
+                BattleRuntime.TurnManager.endEnemyTurn(rpg);
+                return;
+            }
+            if (target.buffs.magic_guard && skill.type === 'mag') {
+                rpg.log(`${target.name} 매직가드로 방어!`);
+                BattleRuntime.TurnManager.endEnemyTurn(rpg);
+                return;
+            }
+
+            let dmg = val * mult * (100 / (100 + def));
+            if (target.buffs.guard) dmg *= 0.5;
+            dmg = Math.floor(dmg);
+            target.hp -= dmg;
+            if (dmg > 0) {
+                target.tookDamageThisTurn = true;
+                BattleRuntime.handleOnHitTraits(rpg, target, enemy);
+            }
+            rpg.log(`${enemy.name}의 ${skill.name}! <span class="log-dmg">${dmg}</span> 피해.`);
+
+            if (skill.effects) {
+                skill.effects.forEach(effect => {
+                    if (effect.type === 'mana_burn') {
+                        target.mp = 0;
+                        rpg.log("플레이어 마나 소멸!");
+                    }
+                });
+            }
+
+            if (target.hp <= 0) {
+                target.isDead = true;
+                target.hp = 0;
+                rpg.log(`${target.name} 쓰러짐!`);
+                BattleRuntime.handleDeathTraits(rpg, target, enemy);
+
+                battle.currentPlayerIdx++;
+                while (battle.currentPlayerIdx < GAME_CONSTANTS.DECK_SIZE) {
+                    const nextPlayer = battle.players[battle.currentPlayerIdx];
+                    if (nextPlayer && !nextPlayer.isDead) break;
+                    battle.currentPlayerIdx++;
+                }
+                if (battle.currentPlayerIdx >= GAME_CONSTANTS.DECK_SIZE && battle.players.every(player => !player || player.isDead)) {
+                    rpg.loseBattle();
+                    return;
+                }
+            }
+
+            if (enemy.hp <= 0) rpg.winBattle();
+            else BattleRuntime.TurnManager.endEnemyTurn(rpg);
+        },
+
+        endEnemyTurn(rpg) {
+            rpg.battle.turn++;
+            rpg.battle.enemy.tookDamageThisTurn = false;
+            rpg.battle.isNewTurn = true;
+            BattleRuntime.TurnManager.startPlayerTurn(rpg);
+        }
+    },
+
+    handleDeathTraits(rpg, victim, killer) {
+        const result = Logic.handleDeathTraits(
+            victim,
+            killer,
+            rpg.battle.fieldBuffs,
+            msg => rpg.log(msg),
+            rpg.state.deck,
+            rpg.battle.turn,
+            rpg.state.artifacts || []
+        );
+
+        if (result.damageToKiller > 0 && killer) {
+            killer.hp -= result.damageToKiller;
+            killer.tookDamageThisTurn = true;
+        }
+
+        if (result.fieldBuffsToAdd && result.fieldBuffsToAdd.length > 0) {
+            result.fieldBuffsToAdd.forEach(buffId => BattleRuntime.applyFieldBuff(rpg, buffId));
+        }
+
+        applyStackMap(rpg, killer, result.killerDebuffs);
+    },
+
+    handleOnHitTraits(rpg, victim, attacker) {
+        const result = Logic.handleOnHitTraits(
+            victim,
+            attacker,
+            msg => rpg.log(msg)
+        );
+
+        applyStackMap(rpg, attacker, result.attackerDebuffs);
+    },
+
+    maybeTriggerDeathRoulette(rpg, source, skill, isDelayed = false) {
+        if (!rpg.hasArtifact('death_roulette') || isDelayed || skill.name === rpg.NORMAL_ATTACK.name) {
+            return false;
+        }
+        if (Math.random() >= 0.3) return false;
+
+        source.hp = 0;
+        rpg.log('<span style="color:#ff5252">[아티팩트] 데스룰렛: 죽음의 룰렛에 당첨...</span>');
+        return true;
+    },
+
+    resolveSourceDeath(rpg, source, target) {
+        if (source.hp > 0 || source.isDead) return;
+
+        source.isDead = true;
+        rpg.log(`${source.name} 사망!`);
+        BattleRuntime.handleDeathTraits(rpg, source, target);
+    },
+
+    hasActiveTrait(rpg, id) {
+        return (rpg.battle.activeTraits || []).includes(id);
+    },
+
+    executeSkill(rpg, source, target, skill, isDelayed = false) {
+        if (!isDelayed && !skill.isDelayed) {
+            if (rpg.hasArtifact('blue_moon') && Math.random() < 0.3) {
+                rpg.log('[아티팩트] 블루문: 마나 소비 없이 스킬 사용!');
+            } else {
+                source.mp -= skill.cost;
+            }
+        }
+
+        let modifiedSkill = skill;
+        if (rpg.hasArtifact('double_attack') && skill.name === rpg.NORMAL_ATTACK.name) {
+            modifiedSkill = { ...skill, val: (skill.val || 1.0) * 2.0 };
+        }
+
+        rpg.log(`<b>${source.name}</b>의 <b>${skill.name}</b>!`);
+
+        if (skill.name === rpg.NORMAL_ATTACK.name && source.proto && source.proto.trait && source.proto.trait.type === 'normal_attack_burn_divine') {
+            const burnAdd = rpg.hasArtifact('over_flame') ? 2 : 1;
+            const divineAdd = rpg.hasArtifact('over_divine') ? 2 : 1;
+            target.buffs.burn = Math.min((target.buffs.burn || 0) + burnAdd, getStackCap(rpg, 'burn'));
+            target.buffs.divine = Math.min((target.buffs.divine || 0) + divineAdd, getStackCap(rpg, 'divine'));
+            rpg.log("[특성] 일반 공격 추가 효과: 작열, 디바인 부여!");
+        }
+
+        if (
+            skill.name === rpg.NORMAL_ATTACK.name &&
+            source.proto &&
+            source.proto.trait &&
+            source.proto.trait.type === 'syn_fire_3_crit_burn' &&
+            rpg.battle.activeTraits.includes('syn_fire_3_crit_burn')
+        ) {
+            const burnAdd = rpg.hasArtifact('over_flame') ? 2 : 1;
+            target.buffs.burn = Math.min((target.buffs.burn || 0) + burnAdd, getStackCap(rpg, 'burn'));
+            rpg.log("[특성] 피닉스: 일반 공격 시 작열 부여!");
+        }
+
+        if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_trait' && Math.random() < 0.2) {
+            target.buffs.stun = 1;
+            rpg.log("[특성] 베히모스의 위압감! 적을 기절시킵니다!");
+        }
+
+        if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_liberated_trait' && Math.random() < 0.2) {
+            target.buffs.stun = 1;
+            rpg.log("[특성] 해방된 베히모스: 20% 확률로 적을 기절시킵니다!");
+        }
+
+        const delayedEff = typeof findDelayedSkillEffect === 'function'
+            ? findDelayedSkillEffect(modifiedSkill)
+            : null;
+
+        if (delayedEff && !isDelayed) {
+            const resolvedDelayedSkill = typeof buildResolvedDelayedSkill === 'function'
+                ? buildResolvedDelayedSkill(modifiedSkill, delayedEff, rpg.battle.turn)
+                : modifiedSkill;
+
+            if (BattleRuntime.hasActiveTrait(rpg, 'instant_delayed_skills')) {
+                rpg.log('[특성] 시간의마술사: 지연 스킬 즉시 발동!');
+                modifiedSkill = resolvedDelayedSkill;
+            } else {
+                rpg.log(`${skill.name} 준비... (${delayedEff.turns}턴 뒤 발동)`);
+                rpg.battle.delayedEffects.push({
+                    turn: rpg.battle.turn + delayedEff.turns,
+                    source: source,
+                    skill: resolvedDelayedSkill
+                });
+                BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
+                BattleRuntime.resolveSourceDeath(rpg, source, target);
+                if (target.hp <= 0) {
+                    rpg.winBattle();
+                    return;
+                }
+                BattleRuntime.TurnManager.endPlayerTurn(rpg);
+                return;
+            }
+        }
+
+        const dmgResult = BattleRuntime.calcDamage(rpg, source, target, modifiedSkill);
+
+        if (dmgResult.dmg > 0) {
+            target.hp -= dmgResult.dmg;
+            target.tookDamageThisTurn = true;
+            rpg.log(`${dmgResult.isCrit ? 'Critical! ' : ''}적에게 <span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
+            BattleRuntime.handleOnHitTraits(rpg, target, source);
+        }
+
+        if (dmgResult.luckyVicky) {
+            source.mp = Math.min(GAME_CONSTANTS.MAX_MP, source.mp + 10);
+            rpg.log('[아티팩트] 럭키비키: 치명타 발생! 마나 10 회복!');
+        }
+
+        BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
+        BattleRuntime.applySkillEffects(rpg, source, target, modifiedSkill);
+        BattleRuntime.resolveSourceDeath(rpg, source, target);
+
+        if (target.hp <= 0) {
+            rpg.winBattle();
+            return;
+        }
+
+        if (!isDelayed) BattleRuntime.TurnManager.endPlayerTurn(rpg);
+    },
+
+    calcDamage(rpg, source, target, skill) {
+        if (skill.type !== 'phy' && skill.type !== 'mag') return { dmg: 0 };
+
+        const result = Logic.calculateDamage(
+            source,
+            target,
+            skill,
+            rpg.battle.fieldBuffs,
+            rpg.battle.activeTraits,
+            msg => rpg.log(msg),
+            rpg.state.mode,
+            rpg.state.deck,
+            rpg.battle.turn,
+            rpg.state.artifacts || []
+        );
+
+        if (target.id === 'demon_god') {
+            const battle = rpg.battle;
+            if ((battle.turn % 2 === 0 && skill.type === 'phy') || (battle.turn % 2 !== 0 && skill.type === 'mag')) {
+                rpg.log("(마신의 권능: 방어력 상승 적용중)");
+            }
+        }
+
+        target.lastHitType = skill.type;
+
+        return result;
+    },
+
+    applySkillEffects(rpg, source, target, skill) {
+        if (!skill.effects) return;
+
+        const ctx = {
+            source: source,
+            target: target,
+            skill: skill,
+            activeTraits: rpg.battle.activeTraits,
+            logFn: msg => rpg.log(msg),
+            getBuffName: id => (BUFF_NAMES[id] || id),
+            applyFieldBuff: (id, options) => BattleRuntime.applyFieldBuff(rpg, id, options),
+            battle: rpg.battle,
+            executeSkill: (nextSource, nextTarget, nextSkill, delayed) =>
+                BattleRuntime.executeSkill(rpg, nextSource, nextTarget, nextSkill, delayed),
+            getCardData: id => rpg.getCardData(id)
+        };
+
+        skill.effects.forEach(effect => {
+            if (typeof SideEffects !== 'undefined') {
+                SideEffects.apply(ctx, effect);
+            }
+        });
+
+        if (rpg.battle.activeTraits.includes('syn_water_nature') && skill.name === '문라이트세레나') {
+            rpg.log("루미의 특성 발동! 트윙클파티 추가!");
+            BattleRuntime.applyFieldBuff(rpg, 'twinkle_party');
+        }
+
+        if (rpg.battle.activeTraits.includes('syn_water_2_moon_twinkle') && skill.name === '실버문베일') {
+            rpg.log("[특성] 세이렌의 노래! 트윙클파티 추가!");
+            BattleRuntime.applyFieldBuff(rpg, 'twinkle_party');
+        }
+    },
+
+    expireFieldBuffs(rpg, turn) {
+        const expiredBuffs = rpg.battle.fieldBuffs.filter(buff => buff.expiresAtTurn && buff.expiresAtTurn <= turn);
+        if (expiredBuffs.length === 0) return;
+
+        rpg.battle.fieldBuffs = rpg.battle.fieldBuffs.filter(buff => !(buff.expiresAtTurn && buff.expiresAtTurn <= turn));
+        expiredBuffs.forEach(buff => {
+            rpg.log(buff.expireLog || `필드버프 [${BUFF_NAMES[buff.name]}] 소멸.`);
+        });
+    },
+
+    applyFieldBuff(rpg, id, options = {}) {
+        if (rpg.battle.fieldBuffs.some(buff => buff.name === id)) {
+            return rpg.log(`필드버프 [${BUFF_NAMES[id]}] 이미 존재.`);
+        }
+
+        const maxBuffs = rpg.hasArtifact('buff_overload') ? 5 : GAME_CONSTANTS.MAX_FIELD_BUFFS;
+        if (rpg.battle.fieldBuffs.length >= maxBuffs) {
+            const removed = rpg.battle.fieldBuffs.shift();
+            rpg.log(`필드버프 [${BUFF_NAMES[removed.name]}] 소멸.`);
+        }
+
+        rpg.battle.fieldBuffs.push({ name: id, ...options });
+        rpg.log(`필드버프 [${BUFF_NAMES[id]}] 발동!`);
+    }
+};

--- a/card/data.js
+++ b/card/data.js
@@ -1,5 +1,5 @@
 const CARDS = [
-    // --- 전설 (Legend) ---
+    // --- Legend ---
     {
         id: 'deep_lord', name: '심해의주인', grade: 'legend', element: 'water', role: 'dealer',
         stats: { hp: 520, atk: 110, matk: 120, def: 70, mdef: 70 },
@@ -58,56 +58,6 @@ const CARDS = [
             { name: '밀키웨이엑스터시', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '필드버프 스타파우더 발동', effects: [{ type: 'field_buff', id: 'star_powder' }] },
             { name: '문라이트세레나', type: 'sup', tier: 2, cost: 20, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] }
-        ]
-    },
-    {
-        id: 'rumi_bunny', name: '루미(바니)', grade: 'event', element: 'dark', role: 'balancer', hide_from_gacha: true,
-        stats: { hp: 360, atk: 110, matk: 90, def: 65, mdef: 45 },
-        trait: { type: 'party_stat_boost', stat: 'atk', val: 30, desc: '파티 전체 공격력 30%상승' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '미드나잇쇼', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '암흑, 부식 부여', effects: [{ type: 'debuff', id: 'darkness' }, { type: 'debuff', id: 'corrosion' }] },
-            { name: '커튼콜', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '저주 상태의 적에게 대미지 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'curse', mult: 3.0 }] }
-        ]
-    },
-    {
-        id: 'rumi_maid', name: '루미(메이드)', grade: 'event', element: 'nature', role: 'balancer', hide_from_gacha: true,
-        stats: { hp: 370, atk: 85, matk: 80, def: 80, mdef: 55 },
-        trait: { type: 'party_stat_boost', stat: 'def', val: 30, desc: '파티 전체 방어력 30%상승' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '특제생크림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 대지의축복, 스타파우더 부여', effects: [{ type: 'field_buff', id: 'earth_bless' }, { type: 'field_buff', id: 'star_powder' }] },
-            { name: '달콤한유혹', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '약화, 저주 부여', effects: [{ type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'curse' }] }
-        ]
-    },
-    {
-        id: 'rumi_miko', name: '루미(무녀)', grade: 'event', element: 'fire', role: 'balancer', hide_from_gacha: true,
-        stats: { hp: 355, atk: 85, matk: 110, def: 55, mdef: 65 },
-        trait: { type: 'party_stat_boost', stat: 'matk', val: 30, desc: '파티 전체 마법공격력 30%상승' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '파마부', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열, 침묵 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'silence' }] },
-            { name: '화염부', type: 'sup', tier: 3, cost: 30, desc: '필드버프 태양의축복 발동', effects: [{ type: 'field_buff', id: 'sun_bless' }] }
-        ]
-    },
-    {
-        id: 'rumi_fairy', name: '루미(페어리)', grade: 'event', element: 'light', role: 'balancer', hide_from_gacha: true,
-        stats: { hp: 360, atk: 80, matk: 90, def: 55, mdef: 80 },
-        trait: { type: 'party_stat_boost', stat: 'mdef', val: 30, desc: '파티 전체 마법방어력 30%상승' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '요정의장난', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 약화 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'weak' }] },
-            { name: '요정의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 성역, 스타파우더 부여', effects: [{ type: 'field_buff', id: 'sanctuary' }, { type: 'field_buff', id: 'star_powder' }] }
-        ]
-    },
-    {
-        id: 'rumi_wedding', name: '루미(웨딩)', grade: 'event', element: 'water', role: 'balancer', hide_from_gacha: true,
-        stats: { hp: 360, atk: 95, matk: 95, def: 65, mdef: 65 },
-        trait: { type: 'party_stat_boost', stat: ['atk', 'matk', 'def', 'mdef'], val: 15, desc: '파티 전체 공격/마공 방어/마방 15%상승' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '하트샤워', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '디바인, 침묵 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'silence' }] },
-            { name: '순백의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 운명의서약 부여', effects: [{ type: 'field_buff', id: 'destiny_oath' }] }
         ]
     },
     {
@@ -171,7 +121,7 @@ const CARDS = [
         ]
     },
 
-    // --- 에픽 (Epic) ---
+    // --- Epic ---
     {
         id: 'sun_priestess', name: '태양의무녀', grade: 'epic', element: 'nature', role: 'buffer',
         stats: { hp: 400, atk: 75, matk: 100, def: 65, mdef: 75 },
@@ -293,7 +243,7 @@ const CARDS = [
         ]
     },
 
-    // --- 레어 (Rare) ---
+    // --- Rare ---
     {
         id: 'cloud_sheep', name: '구름양', grade: 'rare', element: 'water', role: 'balancer',
         stats: { hp: 350, atk: 85, matk: 85, def: 65, mdef: 55 },
@@ -415,7 +365,7 @@ const CARDS = [
         ]
     },
 
-    // --- 일반 (Normal) ---
+    // --- Normal ---
     {
         id: 'marshmallow', name: '마시멜로', grade: 'normal', element: 'fire', role: 'balancer',
         stats: { hp: 310, atk: 75, matk: 70, def: 50, mdef: 50 },
@@ -545,10 +495,63 @@ const CARDS = [
             { name: '레인보우룰렛', type: 'sup', tier: 10, cost: 100, desc: '모든 필드버프 교체', effects: [{ type: 'roulette_field' }] },
             { name: '와일드카드', type: 'sup', tier: 10, cost: 100, desc: '적의 디버프를 모두 제거하고 랜덤 디버프 2종 부여', effects: [{ type: 'wild_card_debuff' }] }
         ]
+    },
+
+    // --- Event ---
+    {
+        id: 'rumi_bunny', name: '루미(바니)', grade: 'event', element: 'dark', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 360, atk: 110, matk: 90, def: 65, mdef: 45 },
+        trait: { type: 'party_stat_boost', stat: 'atk', val: 30, desc: '파티 전체 공격력 30%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '미드나잇쇼', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '암흑, 부식 부여', effects: [{ type: 'debuff', id: 'darkness' }, { type: 'debuff', id: 'corrosion' }] },
+            { name: '커튼콜', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '저주 상태의 적에게 대미지 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'curse', mult: 3.0 }] }
+        ]
+    },
+    {
+        id: 'rumi_maid', name: '루미(메이드)', grade: 'event', element: 'nature', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 370, atk: 85, matk: 80, def: 80, mdef: 55 },
+        trait: { type: 'party_stat_boost', stat: 'def', val: 30, desc: '파티 전체 방어력 30%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '특제생크림', type: 'sup', tier: 3, cost: 30, desc: '필드버프 대지의축복, 스타파우더 부여', effects: [{ type: 'field_buff', id: 'earth_bless' }, { type: 'field_buff', id: 'star_powder' }] },
+            { name: '달콤한유혹', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '약화, 저주 부여', effects: [{ type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'curse' }] }
+        ]
+    },
+    {
+        id: 'rumi_miko', name: '루미(무녀)', grade: 'event', element: 'fire', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 355, atk: 85, matk: 110, def: 55, mdef: 65 },
+        trait: { type: 'party_stat_boost', stat: 'matk', val: 30, desc: '파티 전체 마법공격력 30%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '파마부', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열, 침묵 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'silence' }] },
+            { name: '화염부', type: 'sup', tier: 3, cost: 30, desc: '필드버프 태양의축복 발동', effects: [{ type: 'field_buff', id: 'sun_bless' }] }
+        ]
+    },
+    {
+        id: 'rumi_fairy', name: '루미(페어리)', grade: 'event', element: 'light', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 360, atk: 80, matk: 90, def: 55, mdef: 80 },
+        trait: { type: 'party_stat_boost', stat: 'mdef', val: 30, desc: '파티 전체 마법방어력 30%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '요정의장난', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 약화 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'weak' }] },
+            { name: '요정의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 성역, 스타파우더 부여', effects: [{ type: 'field_buff', id: 'sanctuary' }, { type: 'field_buff', id: 'star_powder' }] }
+        ]
+    },
+    {
+        id: 'rumi_wedding', name: '루미(웨딩)', grade: 'event', element: 'water', role: 'balancer', hide_from_gacha: true,
+        stats: { hp: 360, atk: 95, matk: 95, def: 65, mdef: 65 },
+        trait: { type: 'party_stat_boost', stat: ['atk', 'matk', 'def', 'mdef'], val: 15, desc: '파티 전체 공격/마공 방어/마방 15%상승' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '하트샤워', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '디바인, 침묵 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'silence' }] },
+            { name: '순백의축복', type: 'sup', tier: 3, cost: 30, desc: '필드버프 운명의서약 부여', effects: [{ type: 'field_buff', id: 'destiny_oath' }] }
+        ]
     }
 ];
 
 const BONUS_CARDS = [
+    // --- Legend ---
     {
         id: 'phoenix', name: '피닉스', grade: 'legend', element: 'fire', role: 'buffer',
         stats: { hp: 510, atk: 130, matk: 90, def: 75, mdef: 70 },
@@ -557,16 +560,6 @@ const BONUS_CARDS = [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
             { name: '메테오임팩트', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '필드버프 트윙클파티 발동', effects: [{ type: 'field_buff', id: 'twinkle_party' }] },
             { name: '샤이닝플레임', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '필드버프 태양의축복 발동', effects: [{ type: 'field_buff', id: 'sun_bless' }] }
-        ]
-    },
-    {
-        id: 'priest_of_end', name: '종말의사제', grade: 'epic', element: 'dark', role: 'buffer',
-        stats: { hp: 400, atk: 55, matk: 105, def: 80, mdef: 80 },
-        trait: { type: 'syn_dark_3_matk_boost', val: 100, desc: '덱에 어둠 3장 이상 시 마법공격력 100% 증가' },
-        skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '사신강림', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '5턴 뒤 발동, 발동 시 필드버프 사신강림 부여', effects: [{ type: 'delayed_attack_field', turns: 5, field: 'reaper_realm' }] }
         ]
     },
     {
@@ -580,66 +573,6 @@ const BONUS_CARDS = [
         ]
     },
     {
-        id: 'unicorn', name: '유니콘', grade: 'epic', element: 'light', role: 'looter',
-        stats: { hp: 360, atk: 90, matk: 65, def: 65, mdef: 70 },
-        trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '홀리차지', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }] },
-            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] }
-        ]
-    },
-    {
-        id: 'hellhound', name: '헬하운드', grade: 'rare', element: 'fire', role: 'balancer',
-        stats: { hp: 370, atk: 100, matk: 75, def: 45, mdef: 55 },
-        trait: { type: 'death_twinkle', desc: '사망 시 필드버프 트윙클파티 발동' },
-        skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '섀도우러쉬', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 부여', effects: [{ type: 'debuff', id: 'weak' }] },
-            { name: '헬바이트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 모두 소모, 소모한 개수당 2.0배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0 }] }
-        ]
-    },
-    {
-        id: 'siren', name: '세이렌', grade: 'rare', element: 'water', role: 'buffer',
-        stats: { hp: 345, atk: 60, matk: 95, def: 60, mdef: 75 },
-        trait: { type: 'syn_water_2_moon_twinkle', desc: '덱에 물 2장 이상 시, 실버문베일 발동 시 트윙클파티 추가 발동' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
-            { name: '타이달스크림', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] }
-        ]
-    },
-    {
-        id: 'shadow_cat', name: '섀도우캣', grade: 'normal', element: 'dark', role: 'debuffer',
-        stats: { hp: 300, atk: 85, matk: 50, def: 55, mdef: 55 },
-        trait: { type: 'death_debuff', debuff: 'darkness', desc: '사망 시 암흑 부여' },
-        skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
-            { name: '사일런트스텝', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '반드시 치명타로 적중', effects: [{ type: 'force_crit' }] },
-            { name: '베놈슬래시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] }
-        ]
-    },
-    {
-        id: 'mushroom_king', name: '머쉬룸킹', grade: 'epic', element: 'nature', role: 'dealer',
-        stats: { hp: 400, atk: 100, matk: 80, def: 80, mdef: 60 },
-        trait: { type: 'cond_earth_def_mdef', val: 50, desc: '대지의축복 상태에서 방어력/마법방어력 50% 증가' },
-        skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '그랜드슬램', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 생명력이 50% 이하일 때 위력 2배', effects: [{ type: 'dmg_boost', condition: 'target_hp_below', val: 0.5, mult: 2.0 }] },
-            { name: '스포어미스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '자신의 생명력이 25% 이하일 때 위력 5배', effects: [{ type: 'dmg_boost', condition: 'hp_below', val: 0.25, mult: 5.0 }] }
-        ]
-    },
-    {
-        id: 'fallen_angel', name: '타천사', grade: 'rare', element: 'dark', role: 'dealer',
-        stats: { hp: 340, atk: 65, matk: 100, def: 55, mdef: 60 },
-        trait: { type: 'cond_darkness_dmg', val: 1.5, desc: '암흑 상태의 적에게 대미지 1.5배' },
-        skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
-            { name: '다크레이', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'divine', count: 1, mult: 2.0 }] },
-            { name: '타락의낙인', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '디바인 1스택 소모하고 암흑 부여', effects: [{ type: 'consume_divine_add_darkness' }] }
-        ]
-    },
-    {
         id: 'cinderella', name: '신데렐라', grade: 'legend', element: 'light', role: 'debuffer',
         stats: { hp: 490, atk: 110, matk: 120, def: 75, mdef: 75 },
         trait: { type: 'ignore_def_mdef_by_stack', val: 0.1, desc: '작열 1스택당 방어력 10% 무시 / 디바인 1스택당 마법방어력 10% 무시' },
@@ -647,16 +580,6 @@ const BONUS_CARDS = [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
             { name: '크리스탈킥', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 부여 및 약화/부식 중 하나 추가 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'random_debuff', count: 1, pool: ['weak', 'corrosion'] }] },
             { name: '미드나잇스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인 부여 및 침묵/저주 중 하나 추가 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'random_debuff', count: 1, pool: ['silence', 'curse'] }] }
-        ]
-    },
-    {
-        id: 'snow_penguin', name: '눈꽃펭귄', grade: 'normal', element: 'water', role: 'debuffer',
-        stats: { hp: 300, atk: 80, matk: 70, def: 50, mdef: 50 },
-        trait: { type: 'death_debuff', debuff: 'weak', desc: '사망 시 적에게 약화 부여' },
-        skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '제트슬라이드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '기절한 적에게 대미지 5배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 5.0 }] },
-            { name: '콜드웨이크', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 혹은 침묵 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['curse', 'silence'] }] }
         ]
     },
     {
@@ -680,6 +603,58 @@ const BONUS_CARDS = [
         ]
     },
     {
+        id: 'ancient_dragon', name: '에인션트드래곤', grade: 'legend', element: 'nature', role: 'debuffer',
+        stats: { hp: 530, atk: 115, matk: 95, def: 70, mdef: 70 },
+        trait: { type: 'death_multi_debuff', desc: '사망시 적에게 약화, 부식, 저주, 침묵, 기절 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] },
+            { name: '에인션트브레스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 부여, 대지의축복 상태에서 대미지 2배', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'red_moon', name: '레드문', grade: 'legend', element: 'fire', role: 'dealer',
+        stats: { hp: 490, atk: 140, matk: 100, def: 65, mdef: 60 },
+        trait: { type: 'death_dmg_phy', val: 6.0, desc: '사망 시 적에게 600% 물리대미지' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '데이브레이커', type: 'phy', tier: 3, cost: 30, val: 5.0, desc: '현재 생명력 30% 소모', effects: [{ type: 'self_hp_cost_ratio', ratio: 0.3 }] },
+            { name: '이터널플레임', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모 시 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0 }] }
+        ]
+    },
+
+    // --- Epic ---
+    {
+        id: 'priest_of_end', name: '종말의사제', grade: 'epic', element: 'dark', role: 'buffer',
+        stats: { hp: 400, atk: 55, matk: 105, def: 80, mdef: 80 },
+        trait: { type: 'syn_dark_3_matk_boost', val: 100, desc: '덱에 어둠 3장 이상 시 마법공격력 100% 증가' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '사신강림', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '5턴 뒤 발동, 발동 시 필드버프 사신강림 부여', effects: [{ type: 'delayed_attack_field', turns: 5, field: 'reaper_realm' }] }
+        ]
+    },
+    {
+        id: 'unicorn', name: '유니콘', grade: 'epic', element: 'light', role: 'looter',
+        stats: { hp: 360, atk: 90, matk: 65, def: 65, mdef: 70 },
+        trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '홀리차지', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }] },
+            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] }
+        ]
+    },
+    {
+        id: 'mushroom_king', name: '머쉬룸킹', grade: 'epic', element: 'nature', role: 'dealer',
+        stats: { hp: 400, atk: 100, matk: 80, def: 80, mdef: 60 },
+        trait: { type: 'cond_earth_def_mdef', val: 50, desc: '대지의축복 상태에서 방어력/마법방어력 50% 증가' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '그랜드슬램', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 생명력이 50% 이하일 때 위력 2배', effects: [{ type: 'dmg_boost', condition: 'target_hp_below', val: 0.5, mult: 2.0 }] },
+            { name: '스포어미스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '자신의 생명력이 25% 이하일 때 위력 5배', effects: [{ type: 'dmg_boost', condition: 'hp_below', val: 0.25, mult: 5.0 }] }
+        ]
+    },
+    {
         id: 'jellyfish_princess', name: '젤리피쉬프린세스', grade: 'epic', element: 'water', role: 'debuffer',
         stats: { hp: 410, atk: 80, matk: 85, def: 75, mdef: 70 },
         trait: { type: 'on_hit_random_debuff', pool: ['corrosion', 'weak', 'silence', 'curse', 'stun'], desc: '피격 시 부식/약화/침묵/저주/기절 중 랜덤 부여' },
@@ -697,6 +672,48 @@ const BONUS_CARDS = [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '섀도우코로나', type: 'phy', tier: 2, cost: 20, val: 2.5, desc: '암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] },
             { name: '녹턴윙스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'weak', mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'crystal_dancer', name: '수정의무희', grade: 'epic', element: 'water', role: 'dealer',
+        stats: { hp: 395, atk: 110, matk: 90, def: 60, mdef: 60 },
+        trait: { type: 'on_evasion_stun', desc: '회피 성공 시 상대에게 기절 부여' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '댄싱대거', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '하트브레이커', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '기절 상태의 적에게 대미지 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 3.0 }] }
+        ]
+    },
+
+    // --- Rare ---
+    {
+        id: 'hellhound', name: '헬하운드', grade: 'rare', element: 'fire', role: 'balancer',
+        stats: { hp: 370, atk: 100, matk: 75, def: 45, mdef: 55 },
+        trait: { type: 'death_twinkle', desc: '사망 시 필드버프 트윙클파티 발동' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '섀도우러쉬', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 부여', effects: [{ type: 'debuff', id: 'weak' }] },
+            { name: '헬바이트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열 모두 소모, 소모한 개수당 2.0배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0 }] }
+        ]
+    },
+    {
+        id: 'siren', name: '세이렌', grade: 'rare', element: 'water', role: 'buffer',
+        stats: { hp: 345, atk: 60, matk: 95, def: 60, mdef: 75 },
+        trait: { type: 'syn_water_2_moon_twinkle', desc: '덱에 물 2장 이상 시, 실버문베일 발동 시 트윙클파티 추가 발동' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '실버문베일', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 발동', effects: [{ type: 'field_buff', id: 'moon_bless' }] },
+            { name: '타이달스크림', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] }
+        ]
+    },
+    {
+        id: 'fallen_angel', name: '타천사', grade: 'rare', element: 'dark', role: 'dealer',
+        stats: { hp: 340, atk: 65, matk: 100, def: 55, mdef: 60 },
+        trait: { type: 'cond_darkness_dmg', val: 1.5, desc: '암흑 상태의 적에게 대미지 1.5배' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '다크레이', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'divine', count: 1, mult: 2.0 }] },
+            { name: '타락의낙인', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '디바인 1스택 소모하고 암흑 부여', effects: [{ type: 'consume_divine_add_darkness' }] }
         ]
     },
     {
@@ -720,6 +737,38 @@ const BONUS_CARDS = [
         ]
     },
     {
+        id: 'time_magician', name: '시간의마술사', grade: 'rare', element: 'dark', role: 'balancer',
+        stats: { hp: 350, atk: 75, matk: 95, def: 60, mdef: 60 },
+        trait: { type: 'instant_delayed_skills', desc: '덱의 지연 스킬이 즉시 발동' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '엑셀레이터', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
+            { name: '데스클록', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '10의 배수 턴에 대미지 5배', effects: [{ type: 'turn_modulo_dmg', mod: 10, mult: 5.0 }] }
+        ]
+    },
+
+    // --- Normal ---
+    {
+        id: 'shadow_cat', name: '섀도우캣', grade: 'normal', element: 'dark', role: 'debuffer',
+        stats: { hp: 300, atk: 85, matk: 50, def: 55, mdef: 55 },
+        trait: { type: 'death_debuff', debuff: 'darkness', desc: '사망 시 암흑 부여' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '사일런트스텝', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '반드시 치명타로 적중', effects: [{ type: 'force_crit' }] },
+            { name: '베놈슬래시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] }
+        ]
+    },
+    {
+        id: 'snow_penguin', name: '눈꽃펭귄', grade: 'normal', element: 'water', role: 'debuffer',
+        stats: { hp: 300, atk: 80, matk: 70, def: 50, mdef: 50 },
+        trait: { type: 'death_debuff', debuff: 'weak', desc: '사망 시 적에게 약화 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '제트슬라이드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '기절한 적에게 대미지 5배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 5.0 }] },
+            { name: '콜드웨이크', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '저주 혹은 침묵 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['curse', 'silence'] }] }
+        ]
+    },
+    {
         id: 'desert_fox', name: '사막여우', grade: 'normal', element: 'fire', role: 'debuffer',
         stats: { hp: 300, atk: 80, matk: 75, def: 45, mdef: 50 },
         trait: { type: 'death_debuff', debuff: 'burn', stack: 3, desc: '사망 시 적에게 작열 3스택 부여' },
@@ -740,36 +789,6 @@ const BONUS_CARDS = [
         ]
     },
     {
-        id: 'time_magician', name: '시간의마술사', grade: 'rare', element: 'dark', role: 'balancer',
-        stats: { hp: 350, atk: 75, matk: 95, def: 60, mdef: 60 },
-        trait: { type: 'instant_delayed_skills', desc: '덱의 지연 스킬이 즉시 발동' },
-        skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '엑셀레이터', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
-            { name: '데스클록', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '10의 배수 턴에 대미지 5배', effects: [{ type: 'turn_modulo_dmg', mod: 10, mult: 5.0 }] }
-        ]
-    },
-    {
-        id: 'crystal_dancer', name: '수정의무희', grade: 'epic', element: 'water', role: 'dealer',
-        stats: { hp: 395, atk: 110, matk: 90, def: 60, mdef: 60 },
-        trait: { type: 'on_evasion_stun', desc: '회피 성공 시 상대에게 기절 부여' },
-        skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
-            { name: '댄싱대거', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
-            { name: '하트브레이커', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '기절 상태의 적에게 대미지 3배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 3.0 }] }
-        ]
-    },
-    {
-        id: 'ancient_dragon', name: '에인션트드래곤', grade: 'legend', element: 'nature', role: 'debuffer',
-        stats: { hp: 530, atk: 115, matk: 95, def: 70, mdef: 70 },
-        trait: { type: 'death_multi_debuff', desc: '사망시 적에게 약화, 부식, 저주, 침묵, 기절 부여' },
-        skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] },
-            { name: '에인션트브레스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 부여, 대지의축복 상태에서 대미지 2배', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] }
-        ]
-    },
-    {
         id: 'sunflower', name: '해바라기', grade: 'normal', element: 'nature', role: 'dealer',
         stats: { hp: 320, atk: 75, matk: 80, def: 50, mdef: 50 },
         trait: { type: 'cond_sun_matk_mdef', val: 100, desc: '태양의축복 상태에서 마법공격력/마법방어력 100%증가' },
@@ -777,16 +796,6 @@ const BONUS_CARDS = [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
             { name: '솔라플레어', type: 'mag', tier: 3, cost: 30, val: 4.0, desc: '사용 후 2턴 뒤에 공격', effects: [{ type: 'delayed_attack', turns: 2 }] },
             { name: '어쓰블라썸', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '대지의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] }
-        ]
-    },
-    {
-        id: 'red_moon', name: '레드문', grade: 'legend', element: 'fire', role: 'dealer',
-        stats: { hp: 490, atk: 140, matk: 100, def: 65, mdef: 60 },
-        trait: { type: 'death_dmg_phy', val: 6.0, desc: '사망 시 적에게 600% 물리대미지' },
-        skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '데이브레이커', type: 'phy', tier: 3, cost: 30, val: 5.0, desc: '현재 생명력 30% 소모', effects: [{ type: 'self_hp_cost_ratio', ratio: 0.3 }] },
-            { name: '이터널플레임', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모 시 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0 }] }
         ]
     }
 ];
@@ -847,6 +856,16 @@ const ENEMIES = [
 
 const TRANSCENDENCE_CARDS = [
     {
+        id: 'trans_gray', name: '사신그레이', grade: 'transcendence', element: 'dark', role: 'dealer',
+        stats: { hp: 530, atk: 150, matk: 135, def: 75, mdef: 75 },
+        trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~12배율)', effects: [{ type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 12.0 }] },
+            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{ type: 'turn_modulo_dmg', mod: 4, mult: 2.0 }, { type: 'force_crit_chance', val: 40 }] }
+        ]
+    },
+    {
         id: 'trans_executor', name: '종언의집행자', grade: 'transcendence', element: 'dark', role: 'debuffer',
         stats: { hp: 560, atk: 125, matk: 125, def: 70, mdef: 70 },
         trait: { type: 'pos_stat_boost', pos: 1, stat: ['matk', 'mdef'], val: 30, desc: '중견 배치시 마법공격력 마법방어력 30%증가' },
@@ -857,23 +876,13 @@ const TRANSCENDENCE_CARDS = [
         ]
     },
     {
-        id: 'trans_cinderella', name: '신데렐라(미라클폼)', grade: 'transcendence', element: 'light', role: 'debuffer',
-        stats: { hp: 540, atk: 120, matk: 135, def: 80, mdef: 80 },
-        trait: { type: 'ignore_def_mdef_by_stack', val: 0.15, desc: '작열 1스택당 방어력 15% 무시 / 디바인 1스택당 마법방어력 15% 무시' },
+        id: 'trans_yeon_rabbit', name: '연토끼', grade: 'transcendence', element: 'fire', role: 'dealer',
+        stats: { hp: 540, atk: 115, matk: 115, def: 95, mdef: 95 },
+        trait: { type: 'rabbit_synergy_boost', val: 50, desc: '자신 덱에 있는 토끼의 수 만큼 공격 마공이 50%증가' },
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
-            { name: '샤터링비트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열, 약화, 부식 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'corrosion' }] },
-            { name: '미라클스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 침묵, 저주 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'curse' }] }
-        ]
-    },
-    {
-        id: 'trans_lumi', name: '루미(꿈의형태)', grade: 'transcendence', element: 'water', role: 'buffer',
-        stats: { hp: 540, atk: 90, matk: 140, def: 90, mdef: 100 },
-        trait: { type: 'cosmic_harmony_random_buff', desc: '코스믹하모니 사용시 태양의축복, 달의축복, 스타파우더 중 랜덤한 필드버프 생성' },
-        skills: [
-            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [{ type: 'random_field_buff_lumi' }] },
-            { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '모든 버프를 제거하고 꿈의마법발동.', effects: [{ type: 'dream_form_execute' }] }
+            { name: '홍련각', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0 }] },
+            { name: '천화낙영', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{ type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5 }, { type: 'clear_target_debuffs' }] }
         ]
     },
     {
@@ -887,23 +896,13 @@ const TRANSCENDENCE_CARDS = [
         ]
     },
     {
-        id: 'trans_gray', name: '사신그레이', grade: 'transcendence', element: 'dark', role: 'dealer',
-        stats: { hp: 530, atk: 150, matk: 135, def: 75, mdef: 75 },
-        trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
+        id: 'trans_cinderella', name: '신데렐라(미라클폼)', grade: 'transcendence', element: 'light', role: 'debuffer',
+        stats: { hp: 540, atk: 120, matk: 135, def: 80, mdef: 80 },
+        trait: { type: 'ignore_def_mdef_by_stack', val: 0.15, desc: '작열 1스택당 방어력 15% 무시 / 디바인 1스택당 마법방어력 15% 무시' },
         skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
-            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~12배율)', effects: [{ type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 12.0 }] },
-            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{ type: 'turn_modulo_dmg', mod: 4, mult: 2.0 }, { type: 'force_crit_chance', val: 40 }] }
-        ]
-    },
-    {
-        id: 'trans_behemoth', name: '베히모스(해방)', grade: 'transcendence', element: 'nature', role: 'dealer',
-        stats: { hp: 620, atk: 120, matk: 100, def: 85, mdef: 65 },
-        trait: { type: 'behemoth_liberated_trait', val: 1.5, desc: '적이 디버프 3개 이상일 때 대미지 1.5배 / 스킬 사용 시 20% 확률로 적에게 스턴 부여' },
-        skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '월드브레이커', type: 'phy', tier: 3, cost: 30, val: 4.0, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] },
-            { name: '제로그라비티', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '다음 턴에 공격 (적에게 걸린 디버프 1종당 0.5배율 추가)', effects: [{ type: 'delayed_attack_debuff_scale', turns: 1, multPerDebuff: 0.5 }] }
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '샤터링비트', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '작열, 약화, 부식 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }, { type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'corrosion' }] },
+            { name: '미라클스펠', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 침묵, 저주 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'curse' }] }
         ]
     },
     {
@@ -917,13 +916,23 @@ const TRANSCENDENCE_CARDS = [
         ]
     },
     {
-        id: 'trans_yeon_rabbit', name: '연토끼', grade: 'transcendence', element: 'fire', role: 'dealer',
-        stats: { hp: 540, atk: 115, matk: 115, def: 95, mdef: 95 },
-        trait: { type: 'rabbit_synergy_boost', val: 50, desc: '자신 덱에 있는 토끼의 수 만큼 공격 마공이 50%증가' },
+        id: 'trans_behemoth', name: '베히모스(해방)', grade: 'transcendence', element: 'nature', role: 'dealer',
+        stats: { hp: 620, atk: 120, matk: 100, def: 85, mdef: 65 },
+        trait: { type: 'behemoth_liberated_trait', val: 1.5, desc: '적이 디버프 3개 이상일 때 대미지 1.5배 / 스킬 사용 시 20% 확률로 적에게 스턴 부여' },
         skills: [
-            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
-            { name: '홍련각', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'burn', count: 1, mult: 2.0 }] },
-            { name: '천화낙영', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '적 디버프 1개당 배율 1.5 증가, 사용 후 적 디버프 해제', effects: [{ type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.5 }, { type: 'clear_target_debuffs' }] }
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '월드브레이커', type: 'phy', tier: 3, cost: 30, val: 4.0, desc: '다음 턴 휴식 (대지의축복 시 위력 2배)', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] },
+            { name: '제로그라비티', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '다음 턴에 공격 (적에게 걸린 디버프 1종당 0.5배율 추가)', effects: [{ type: 'delayed_attack_debuff_scale', turns: 1, multPerDebuff: 0.5 }] }
+        ]
+    },
+    {
+        id: 'trans_lumi', name: '루미(꿈의형태)', grade: 'transcendence', element: 'water', role: 'buffer',
+        stats: { hp: 540, atk: 90, matk: 140, def: 90, mdef: 100 },
+        trait: { type: 'cosmic_harmony_random_buff', desc: '코스믹하모니 사용시 태양의축복, 달의축복, 스타파우더 중 랜덤한 필드버프 생성' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [{ type: 'random_field_buff_lumi' }] },
+            { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '모든 버프를 제거하고 꿈의마법발동.', effects: [{ type: 'dream_form_execute' }] }
         ]
     }
 ];

--- a/card/index.html
+++ b/card/index.html
@@ -1225,7 +1225,8 @@
                 { src: 'toeic.js', label: '토익 데이터' },
                 { src: 'toeic_explanations.js', label: '토익 해설' },
                 { src: 'api.js', label: 'API 모듈' },
-                { src: 'logic.js', label: '게임 로직' }
+                { src: 'logic.js', label: '게임 로직' },
+                { src: 'battle_runtime.js', label: '전투 런타임' }
             ];
             var idx = 0;
 
@@ -1583,6 +1584,11 @@
             }
         };
 
+        const getDefaultBlessingUses = () =>
+            (typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.DEFAULT_BLESSING_USES)
+                ? GAME_CONSTANTS.DEFAULT_BLESSING_USES
+                : 3;
+
         /**
          * RPG Game Namespace
          * Encapsulates all game logic, state, and UI handling.
@@ -1604,8 +1610,8 @@
                 inventory: [],
                 deck: [null, null, null],
                 enemyScale: 0,
-                chaosBlessingUses: 3,
-                greatSageBlessingUses: 3,
+                chaosBlessingUses: getDefaultBlessingUses(),
+                greatSageBlessingUses: getDefaultBlessingUses(),
                 chaosBuffs: [], // Array of { id: cardId, multiplier: float } (Merged)
                 activeChaosBlessing: [], // Specific buffs from Chaos Blessing
                 activeSageBlessing: [],   // Specific buffs from Great Sage Blessing
@@ -1650,7 +1656,31 @@
             },
 
             getCardData(id) {
-                return CARDS.find(c => c.id === id) || BONUS_CARDS.find(c => c.id === id) || (typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS.find(c => c.id === id) : null);
+                return GameUtils.getCardById(id);
+            },
+
+            loadStudyProgress() {
+                const vocab = Storage.load(Storage.keys.VOCAB);
+                if (vocab) this.state.wrongWords = vocab;
+
+                const col = Storage.load(Storage.keys.COLLOCATION);
+                if (col) this.state.wrongCollocations = col;
+            },
+
+            saveStudyProgress() {
+                Storage.save(Storage.keys.VOCAB, this.state.wrongWords || []);
+                if (this.state.wrongCollocations) {
+                    Storage.save(Storage.keys.COLLOCATION, this.state.wrongCollocations);
+                }
+            },
+
+            getRandomGrammarQuiz() {
+                let allQuizzes = [];
+                GRAMMAR_DATA.forEach(lecture => {
+                    allQuizzes = allQuizzes.concat(lecture.quizzes);
+                });
+                if (allQuizzes.length === 0) return null;
+                return allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
             },
 
             // --- Global Data ---
@@ -1801,6 +1831,7 @@
                     { name: 'Logic', ref: typeof Logic !== 'undefined' ? Logic : null },
                     { name: 'SideEffects', ref: typeof SideEffects !== 'undefined' ? SideEffects : null },
                     { name: 'GameUtils', ref: typeof GameUtils !== 'undefined' ? GameUtils : null },
+                    { name: 'BattleRuntime', ref: typeof BattleRuntime !== 'undefined' ? BattleRuntime : null },
                     { name: 'QuizEngine', ref: typeof QuizEngine !== 'undefined' ? QuizEngine : null },
                     { name: 'TOEIC_DATA', ref: typeof TOEIC_DATA !== 'undefined' ? TOEIC_DATA : null },
                     { name: 'GameAPI', ref: typeof GameAPI !== 'undefined' ? GameAPI : null }
@@ -1827,8 +1858,11 @@
 
             waitForInitialDataLoad() {
                 let attempts = 0;
-                const maxAttempts = 200;
-                const pollingMs = 150;
+                const loadingConfig = (typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.LOADING)
+                    ? GAME_CONSTANTS.LOADING
+                    : { MAX_ATTEMPTS: 200, POLLING_MS: 150 };
+                const maxAttempts = loadingConfig.MAX_ATTEMPTS;
+                const pollingMs = loadingConfig.POLLING_MS;
 
                 const checkReady = () => {
                     // Check for script load errors first
@@ -1877,8 +1911,8 @@
                 const missing = this.getMissingRequiredData();
 
                 if (missing.length > 0) {
-                    if (retryCount < 6) {
-                        setTimeout(() => this.startGame(mode, retryCount + 1), 180);
+                    if (retryCount < GAME_CONSTANTS.LOADING.START_RETRY_LIMIT) {
+                        setTimeout(() => this.startGame(mode, retryCount + 1), GAME_CONSTANTS.LOADING.START_RETRY_DELAY_MS);
                         return;
                     }
                     const names = missing.map(d => d.name).join(', ');
@@ -1893,8 +1927,8 @@
                     const save = Storage.load(Storage.keys.SAVE);
                     if (save) {
                         this.state = { ...this.state, ...save };
-                        if (this.state.chaosBlessingUses === undefined) this.state.chaosBlessingUses = 3;
-                        if (this.state.greatSageBlessingUses === undefined) this.state.greatSageBlessingUses = 3;
+                        if (this.state.chaosBlessingUses === undefined) this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
+                        if (this.state.greatSageBlessingUses === undefined) this.state.greatSageBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
                         if (!this.state.chaosBuffs) this.state.chaosBuffs = [];
                         if (!this.state.activeChaosBlessing) this.state.activeChaosBlessing = [];
                         if (!this.state.activeSageBlessing) this.state.activeSageBlessing = [];
@@ -1903,13 +1937,7 @@
                         if (!this.state.quiz_stats) this.state.quiz_stats = { correct: 0, total: 0 };
                         if (!this.state.artifacts) this.state.artifacts = [];
                         this.state.activeBonusPoolIds = this.normalizeActiveBonusPoolIds(this.state.activeBonusPoolIds);
-
-                        // Load persistent wordbook
-                        const vocab = Storage.load(Storage.keys.VOCAB);
-                        if (vocab) this.state.wrongWords = vocab;
-
-                        const col = Storage.load(Storage.keys.COLLOCATION);
-                        if (col) this.state.wrongCollocations = col;
+                        this.loadStudyProgress();
 
                         this.showAlert("불러오기 완료");
                         this.toMenu();
@@ -2032,8 +2060,8 @@
                     inventory: [],
                     deck: [null, null, null],
                     enemyScale: 0,
-                    chaosBlessingUses: 3,
-                    greatSageBlessingUses: 3,
+                    chaosBlessingUses: GAME_CONSTANTS.DEFAULT_BLESSING_USES,
+                    greatSageBlessingUses: GAME_CONSTANTS.DEFAULT_BLESSING_USES,
                     chaosBuffs: [],
                     activeChaosBlessing: [],
                     activeSageBlessing: [],
@@ -2042,7 +2070,7 @@
                     wrongWords: [],
                     quiz_stats: { correct: 0, total: 0 },
                     chaosPool: [],
-                    draft: { active: false, round: 0, rerolls: 3, currentOptions: [] },
+                    draft: { active: false, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] },
                     artifacts: [],
                     // [목적] 카오스/드래프트 모드에서 해당 런에서만 유효한 이벤트 카드 목록을 초기화
                     activeEventCards: []
@@ -2079,19 +2107,13 @@
                     setTimeout(() => this.showAlert(`초월 카드 ${this.state.activeTranscendenceCards.length}장이 인벤토리에 합류했습니다!`), 500);
                 }
 
-                // Load persistent wordbook
-                const vocab = Storage.load(Storage.keys.VOCAB);
-                if (vocab) this.state.wrongWords = vocab;
-
-                const col = Storage.load(Storage.keys.COLLOCATION);
-                if (col) this.state.wrongCollocations = col;
-
+                this.loadStudyProgress();
                 this.saveGame();
             },
 
             saveGame() {
                 Storage.save(Storage.keys.SAVE, this.state);
-                Storage.save(Storage.keys.VOCAB, this.state.wrongWords);
+                this.saveStudyProgress();
                 this.saveGlobalData(); // Also save global just in case
                 this.showAlert("저장되었습니다.");
             },
@@ -2157,6 +2179,10 @@
                 this.showScreen('screen-title');
             },
             showScreen(id) { document.querySelectorAll('.screen').forEach(el => el.classList.remove('active')); document.getElementById(id).classList.add('active'); },
+            showBattleScreen() { this.showScreen('screen-battle'); },
+            clearBattleLog() { document.getElementById('battle-log').innerHTML = ""; },
+            renderBattleView() { this.renderBattlefield(); },
+            renderBattleControls(player) { this.setupControls(player); },
 
             openSystemMenu() {
                 this.updateSystemMenuUI();
@@ -2346,7 +2372,7 @@
                 // Update UI immediately
                 document.getElementById('sage-uses').innerText = this.state.greatSageBlessingUses;
 
-                this.state.tickets += 1;
+                this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.SAGE_BLESSING;
                 if (document.getElementById('ui-tickets')) document.getElementById('ui-tickets').innerText = this.state.tickets;
 
                 // Apply to 12 random cards
@@ -2741,635 +2767,68 @@
             // --- Battle Logic Start ---
 
             startBattleInit() {
-                if (this.state.deck.every(x => x === null)) return this.showAlert("덱을 완성해주세요.");
-                this.showScreen('screen-battle');
-                const enemyIdx = this.state.enemyScale % ENEMIES.length;
-                const baseEnemy = ENEMIES[enemyIdx];
-                let cycle = Math.floor(this.state.enemyScale / ENEMIES.length);
-                let scale = 1.0 + (cycle * 0.2);
-
-                this.battle.enemy = {
-                    id: baseEnemy.id, name: baseEnemy.name,
-                    maxHp: Math.floor(baseEnemy.stats.hp * scale), hp: Math.floor(baseEnemy.stats.hp * scale),
-                    atk: Math.floor(baseEnemy.stats.atk * scale), matk: Math.floor(baseEnemy.stats.matk * scale),
-                    def: Math.floor(baseEnemy.stats.def * scale), mdef: Math.floor(baseEnemy.stats.mdef * scale),
-                    baseDef: Math.floor(baseEnemy.stats.def * scale), baseMdef: Math.floor(baseEnemy.stats.mdef * scale),
-                    skills: baseEnemy.skills, buffs: {}, element: baseEnemy.element,
-                    tookDamageThisTurn: false, lastHitType: null
-                };
-                if (baseEnemy.id === 'creator_god') this.battle.enemy.chargeTurn = 0;
-
-                // Init Players (Using Logic for Initial Stats)
-                this.battle.activeTraits = []; // Reset active traits before calc
-
-                this.battle.players = this.state.deck.map((id, idx) => {
-                    if (!id) return null;
-                    const proto = this.getCardData(id);
-
-                    // Call Logic to calculate initial stats (Base + Synergies)
-                    const allCards = [...CARDS, ...BONUS_CARDS, ...(typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS : [])];
-                    const init = Logic.calculateInitialStats(proto, this.state.deck, allCards, idx);
-
-                    // Log active synergy if any
-                    if (init.activeTrait) {
-                        // Avoid duplicate logs if multiple players trigger same synergy?
-                        // But synergy is usually per player check in Logic.
-                        // Actually, Logic returns activeTrait for THIS player.
-                        this.battle.activeTraits.push(init.activeTrait);
-                        RPG.log(`[시너지] ${proto.trait.desc} 발동!`);
-                    }
-                    if (proto.trait.type === 'instant_delayed_skills') {
-                        this.battle.activeTraits.push(proto.trait.type);
-                    }
-
-                    // Construct Player Object
-                    let p = {
-                        id: proto.id, proto: proto, name: proto.name,
-                        ...init.stats, // hp, maxHp, mp, atk, matk, def, mdef, baseCrit, baseEva
-                        buffs: {}, pos: idx, isDead: false,
-                        skills: JSON.parse(JSON.stringify(proto.skills)) // Clone skills
-                    };
-
-                    // Apply Chaos Blessing Buffs (Multiplicative to the Synergized Base)
-                    const blessing = this.state.chaosBuffs.find(b => b.id === p.id);
-                    if (blessing) {
-                        // Store base stats before blessing for UI comparison
-                        p.baseStatsWithoutBlessing = { atk: p.atk, matk: p.matk, def: p.def, mdef: p.mdef };
-
-                        p.maxHp = Math.floor(p.maxHp * (1 + blessing.multiplier));
-                        p.hp = p.maxHp;
-                        p.blessing = blessing;
-
-                        let mult = 1.0 + blessing.multiplier;
-                        p.atk = Math.floor(p.atk * mult);
-                        p.matk = Math.floor(p.matk * mult);
-                        p.def = Math.floor(p.def * mult);
-                        p.mdef = Math.floor(p.mdef * mult);
-                    }
-
-                    // Apply Positional Traits (Multiplicative)
-                    if (proto.trait.type.startsWith('pos_')) {
-                        const t = proto.trait;
-                        let active = (t.type.includes('van') && idx === 0) || (t.type.includes('mid') && idx === 1) || (t.type.includes('rear') && idx === 2);
-                        if (active) {
-                            if (t.type.includes('_atk')) p.atk = Math.floor(p.atk * (1 + t.val / 100));
-                            if (t.type.includes('_matk')) p.matk = Math.floor(p.matk * (1 + t.val / 100));
-                            if (t.type.includes('_def')) p.def = Math.floor(p.def * (1 + t.val / 100));
-                            if (t.type.includes('_mdef')) p.mdef = Math.floor(p.mdef * (1 + t.val / 100));
-                        }
-                    }
-                    return p;
-                });
-
-                // Dedup activeTraits if needed?
-                // Logic.calculateInitialStats checks active conditions.
-                // If 3 nature cards, each one triggers syn_nature_3_def in Logic?
-                // Yes, because Logic checks `countEl` based on the deck.
-                // So we might get duplicates in `this.battle.activeTraits`.
-                // This is fine for `includes` checks, but if we log multiple times it's noisy.
-                // We can unique them if we want, but logic relies on `includes` which works.
-
-                this.battle.fieldBuffs = [];
-                this.battle.delayedEffects = [];
-                this.battle.turn = 1;
-                this.battle.currentPlayerIdx = 0;
-                this.battle.isNewTurn = true;
-
-                while (this.battle.currentPlayerIdx < 3 && this.battle.players[this.battle.currentPlayerIdx] === null) {
-                    this.battle.currentPlayerIdx++;
-                }
-
-                document.getElementById('battle-log').innerHTML = "";
-                this.log(`전투 개시! 적: ${this.battle.enemy.name}`);
-                if (this.battle.activeTraits.includes('instant_delayed_skills')) {
-                    this.log('[특성] 시간의마술사: 덱의 지연 스킬이 즉시 발동합니다!');
-                }
-
-                // Artifact: gale_storm — apply gale field buff for first 3 turns
-                if (this.hasArtifact('gale_storm')) {
-                    this.applyFieldBuff('gale', {
-                        expiresAtTurn: 4,
-                        expireLog: '[아티팩트] 질풍노도 효과 종료. (질풍 제거)'
-                    });
-                    this.log('[아티팩트] 질풍노도: 전투 시작 시 질풍 발동!');
-                }
-
-                // Artifact: support_boost — set all sup skill costs to 0
-                if (this.hasArtifact('support_boost')) {
-                    this.battle.players.forEach(p => {
-                        if (p && p.skills) {
-                            p.skills.forEach(s => {
-                                if (s.type === 'sup') s.cost = 0;
-                            });
-                        }
-                    });
-                    this.log('[아티팩트] 서포트부스트: 모든 보조스킬 마나 소비 0!');
-                }
-
-                this.renderBattlefield();
-                this.TurnManager.startPlayerTurn();
+                return BattleRuntime.startBattleInit(this);
             },
 
             // --- Turn Manager ---
             TurnManager: {
                 startPlayerTurn() {
-                    const b = RPG.battle;
-                    if (b.currentPlayerIdx >= 3) { RPG.loseBattle(); return; }
-
-                    if (b.isNewTurn) {
-                        b.isNewTurn = false;
-                        RPG.log(`=== ${b.turn}턴 ===`, 'info');
-                        RPG.expireFieldBuffs(b.turn);
-
-                        // Artifact: kaleidoscope
-                        if (RPG.hasArtifact('kaleidoscope')) {
-                            let count = b.fieldBuffs.length;
-                            if (count > 0) {
-                                b.fieldBuffs = []; // Clear
-                                RPG.log('[아티팩트] 만화경: 필드 버프 재구성!');
-
-                                // Get all available buff keys
-                                const allBuffs = Object.keys(GAME_CONSTANTS.FIELD_BUFF_STATS)
-                                    .filter(buffId => buffId !== 'destiny_oath');
-
-                                // Select unique random buffs
-                                let pool = [...allBuffs].sort(() => 0.5 - Math.random());
-                                let picks = pool.slice(0, Math.min(count, pool.length));
-
-                                picks.forEach(bid => RPG.applyFieldBuff(bid));
-                            }
-                        }
-
-                        // Demon God Passive (Apply at start of turn for visibility)
-                        if (b.enemy && b.enemy.id === 'demon_god') {
-                            b.enemy.def = b.enemy.baseDef; b.enemy.mdef = b.enemy.baseMdef;
-                            if (b.turn % 2 === 0) {
-                                b.enemy.def = Math.floor(b.enemy.def * 1.5);
-                                RPG.log("마신의 권능: 짝수 턴 물리방어력 50% 증가.");
-                            } else {
-                                b.enemy.mdef = Math.floor(b.enemy.mdef * 1.5);
-                                RPG.log("마신의 권능: 홀수 턴 마법방어력 50% 증가.");
-                            }
-                        }
-                    }
-                    if (b.enemy) b.enemy.lastHitType = null;
-
-                    let p = b.players[b.currentPlayerIdx];
-                    if (!p || p.isDead) {
-                        b.currentPlayerIdx++;
-                        this.startPlayerTurn();
-                        return;
-                    }
-
-                    // Process Delayed Effects
-                    for (let i = b.delayedEffects.length - 1; i >= 0; i--) {
-                        let effect = b.delayedEffects[i];
-                        if (effect.turn === b.turn) {
-                            b.delayedEffects.splice(i, 1);
-                            if (effect.source.isDead) {
-                                RPG.log(`${effect.skill.name} 발동 실패... (시전자 사망)`);
-                            } else {
-                                RPG.log(`${effect.skill.name} 발동!`);
-                                RPG.executeSkill(effect.source, b.enemy, effect.skill, true);
-                            }
-                        }
-                    }
-
-                    // Clear temporary self buffs
-                    ['evasion', 'barrier', 'magic_guard', 'guard'].forEach(k => delete p.buffs[k]);
-
-                    RPG.renderBattlefield();
-
-                    if (p.buffs.stun) {
-                        RPG.log(`${p.name} 기절로 인해 행동 불가.`);
-                        delete p.buffs.stun;
-                        this.endPlayerTurn();
-                        return;
-                    }
-
-                    RPG.setupControls(p);
+                    return BattleRuntime.TurnManager.startPlayerTurn(RPG);
                 },
 
                 endPlayerTurn() {
-                    setTimeout(() => this.startEnemyTurn(), 500);
+                    return BattleRuntime.TurnManager.endPlayerTurn(RPG);
                 },
 
                 startEnemyTurn() {
-                    const b = RPG.battle;
-                    const e = b.enemy;
-                    if (e.hp <= 0) { RPG.winBattle(); return; }
-
-                    RPG.log("--- 적 턴 ---");
-                    e.def = e.baseDef; e.mdef = e.baseMdef; // Reset base
-
-                    // Boss Passive Logic
-                    if (e.id === 'artificial_demon_god') {
-                        delete e.buffs.defProtocolPhy; delete e.buffs.defProtocolMag;
-                        if (e.lastHitType === 'phy') { e.buffs.defProtocolPhy = 1; RPG.log("방어 프로토콜: 물리 피격 감지 (다음 턴 물리방어력 증가)."); }
-                        if (e.lastHitType === 'mag') { e.buffs.defProtocolMag = 1; RPG.log("방어 프로토콜: 마법 피격 감지 (다음 턴 마법방어력 증가)."); }
-                        if (e.buffs.defProtocolPhy) e.def = Math.floor(e.def * 1.5);
-                        if (e.buffs.defProtocolMag) e.mdef = Math.floor(e.mdef * 1.5);
-                    }
-                    if (e.id === 'demon_god') {
-                        // Re-apply without log (applied at start of player turn)
-                        if (b.turn % 2 === 0) { e.def = Math.floor(e.def * 1.5); }
-                        else { e.mdef = Math.floor(e.mdef * 1.5); }
-                    }
-
-                    if (e.buffs.stun) {
-                        RPG.log(`${e.name} 기절하여 행동 불가.`);
-                        delete e.buffs.stun;
-                        this.endEnemyTurn();
-                        return;
-                    }
-
-                    // Target Logic
-                    let target = b.players[b.currentPlayerIdx];
-                    if (!target || target.isDead) {
-                        let validIdx = b.players.findIndex(p => p && !p.isDead);
-                        if (validIdx === -1) { RPG.loseBattle(); return; }
-                        b.currentPlayerIdx = validIdx;
-                        target = b.players[validIdx];
-                    }
-
-                    // AI Skill Selection (Using Logic)
-                    let skillInfo = Logic.decideEnemyAction(e, b.turn);
-
-                    // Handle special AI states (Charge)
-                    if (skillInfo.chargeReset) e.isCharging = false;
-                    if (skillInfo.isChargeStart) {
-                        e.isCharging = true;
-                        RPG.log("창조신이 힘을 모으고 있습니다... (공격 없음)");
-                        this.endEnemyTurn();
-                        return;
-                    }
-
-                    // Map Logic result to actual skill execution
-                    // Logic returns { type, val, name ... } or a skill object
-                    // We treat it as the skill to execute.
-                    let skill = skillInfo;
-
-                    // Execute Enemy Skill (Simplified: Calculate -> Apply)
-                    let val = skill.type === 'phy' ? e.atk : e.matk;
-                    let mult = skill.val || 1.0;
-
-                    // Pharaoh Special Counter Logic
-                    if (e.id === 'pharaoh' && skill.name === '고대의저주' && e.tookDamageThisTurn) {
-                        mult = 3.0;
-                        RPG.log("고대의 저주: 턴 내 피격 감지! 대미지 3배로 반격!");
-                    }
-
-                    if (e.buffs.weak && skill.type === 'phy') val *= 0.8;
-                    if (e.buffs.silence && skill.type === 'mag') val *= 0.8;
-
-                    let def = skill.type === 'phy' ? target.def : target.mdef;
-                    let fieldDef = 1.0;
-                    b.fieldBuffs.forEach(fb => {
-                        if (fb.name === 'star_powder') fieldDef += 0.3;
-                        if (fb.name === 'sanctuary' && skill.type === 'mag') fieldDef += 0.25;
-                        if (fb.name === 'goddess_descent') fieldDef += 0.3;
-                    });
-
-                    // Target Defense Debuffs
-                    let defMult = 1.0;
-                    if (skill.type === 'phy') {
-                        if (target.buffs.darkness && target.buffs.corrosion) defMult = 0.6;
-                        else if (target.buffs.darkness || target.buffs.corrosion) defMult = 0.8;
-                    } else {
-                        if (target.buffs.curse) defMult = 0.8;
-                    }
-
-                    def = Math.floor(def * fieldDef * defMult);
-
-                    // Evasion Check
-                    if (Logic.checkEvasion(target, skill.type, b.fieldBuffs, RPG.state.mode, RPG.state.artifacts || [])) {
-                        RPG.log(`${target.name} 회피 성공! (${skill.name} 회피)`);
-                        // Artifact: lucky_vicky — mana recovery on evasion
-                        if (RPG.hasArtifact('lucky_vicky')) {
-                            target.mp = Math.min(GAME_CONSTANTS.MAX_MP, target.mp + 10);
-                            RPG.log('[아티팩트] 럭키비키: 회피 성공! 마나 10 회복!');
-                        }
-                        if (target.proto && target.proto.trait && target.proto.trait.type === 'on_evasion_stun') {
-                            e.buffs.stun = 1;
-                            RPG.log(`[특성] ${target.name}: 회피 반격! 적에게 [기절] 부여.`);
-                        }
-                        this.endEnemyTurn();
-                        return;
-                    }
-                    if (target.buffs.barrier && skill.type === 'phy') { RPG.log(`${target.name} 배리어로 방어!`); this.endEnemyTurn(); return; }
-                    if (target.buffs.magic_guard && skill.type === 'mag') { RPG.log(`${target.name} 매직가드로 방어!`); this.endEnemyTurn(); return; }
-
-                    let dmg = val * mult * (100 / (100 + def));
-                    if (target.buffs.guard) dmg *= 0.5;
-                    dmg = Math.floor(dmg);
-                    target.hp -= dmg;
-                    if (dmg > 0) {
-                        target.tookDamageThisTurn = true;
-                        RPG.handleOnHitTraits(target, e);
-                    }
-                    RPG.log(`${e.name}의 ${skill.name}! <span class="log-dmg">${dmg}</span> 피해.`);
-
-                    // Process Effects (if any)
-                    if (skill.effects) {
-                        skill.effects.forEach(eff => {
-                            if (eff.type === 'mana_burn') { target.mp = 0; RPG.log("플레이어 마나 소멸!"); }
-                        });
-                    }
-
-                    if (target.hp <= 0) {
-                        target.isDead = true; target.hp = 0;
-                        RPG.log(`${target.name} 쓰러짐!`);
-                        RPG.handleDeathTraits(target, e);
-
-                        // Advance to next valid player
-                        b.currentPlayerIdx++;
-                        while (b.currentPlayerIdx < 3) {
-                            if (b.players[b.currentPlayerIdx] && !b.players[b.currentPlayerIdx].isDead) break;
-                            b.currentPlayerIdx++;
-                        }
-                        if (b.currentPlayerIdx >= 3 && b.players.every(p => !p || p.isDead)) { RPG.loseBattle(); return; }
-                    }
-
-                    if (e.hp <= 0) RPG.winBattle();
-                    else this.endEnemyTurn();
+                    return BattleRuntime.TurnManager.startEnemyTurn(RPG);
                 },
 
                 endEnemyTurn() {
-                    RPG.battle.turn++;
-                    RPG.battle.enemy.tookDamageThisTurn = false;
-                    RPG.battle.isNewTurn = true;
-                    this.startPlayerTurn();
+                    return BattleRuntime.TurnManager.endEnemyTurn(RPG);
                 }
             },
 
             handleDeathTraits(victim, killer) {
-                // Delegate to Logic
-                const result = Logic.handleDeathTraits(
-                    victim,
-                    killer,
-                    RPG.battle.fieldBuffs,
-                    (msg) => RPG.log(msg),
-                    RPG.state.deck,
-                    RPG.battle.turn,
-                    RPG.state.artifacts || []
-                );
-
-                // Apply results
-                if (result.damageToKiller > 0) {
-                    killer.hp -= result.damageToKiller;
-                    killer.tookDamageThisTurn = true;
-                }
-
-                if (result.fieldBuffsToAdd && result.fieldBuffsToAdd.length > 0) {
-                    result.fieldBuffsToAdd.forEach(b => RPG.applyFieldBuff(b));
-                }
-
-                if (result.killerDebuffs && killer && killer.buffs) {
-                    Object.keys(result.killerDebuffs).forEach(k => {
-                        const nextStack = (killer.buffs[k] || 0) + result.killerDebuffs[k];
-                        if (k === 'burn') {
-                            const burnMax = this.hasArtifact('over_flame') ? 5 : 3;
-                            killer.buffs[k] = Math.min(nextStack, burnMax);
-                            return;
-                        }
-                        if (k === 'divine') {
-                            const divineMax = this.hasArtifact('over_divine') ? 5 : 3;
-                            killer.buffs[k] = Math.min(nextStack, divineMax);
-                            return;
-                        }
-                        killer.buffs[k] = nextStack;
-                        // If specific duration handling is needed, add here. Currently assumed 1 stack.
-                    });
-                }
+                return BattleRuntime.handleDeathTraits(this, victim, killer);
             },
 
             handleOnHitTraits(victim, attacker) {
-                const result = Logic.handleOnHitTraits(
-                    victim,
-                    attacker,
-                    (msg) => RPG.log(msg)
-                );
-
-                if (result.attackerDebuffs && attacker && attacker.buffs) {
-                    Object.keys(result.attackerDebuffs).forEach(k => {
-                        attacker.buffs[k] = (attacker.buffs[k] || 0) + result.attackerDebuffs[k];
-                    });
-                }
+                return BattleRuntime.handleOnHitTraits(this, victim, attacker);
             },
 
             maybeTriggerDeathRoulette(source, skill, isDelayed = false) {
-                if (!this.hasArtifact('death_roulette') || isDelayed || skill.name === RPG.NORMAL_ATTACK.name) {
-                    return false;
-                }
-                if (Math.random() >= 0.3) return false;
-
-                source.hp = 0;
-                RPG.log('<span style="color:#ff5252">[아티팩트] 데스룰렛: 죽음의 룰렛에 당첨...</span>');
-                return true;
+                return BattleRuntime.maybeTriggerDeathRoulette(this, source, skill, isDelayed);
             },
 
             resolveSourceDeath(source, target) {
-                if (source.hp > 0 || source.isDead) return;
-
-                source.isDead = true;
-                RPG.log(`${source.name} 사망!`);
-                RPG.handleDeathTraits(source, target);
+                return BattleRuntime.resolveSourceDeath(this, source, target);
             },
 
             hasActiveTrait(id) {
-                return (this.battle.activeTraits || []).includes(id);
+                return BattleRuntime.hasActiveTrait(this, id);
             },
 
             // --- Player Skill Execution ---
 
             executeSkill(source, target, skill, isDelayed = false) {
-                if (!isDelayed && !skill.isDelayed) {
-                    // Artifact: blue_moon
-                    if (this.hasArtifact('blue_moon') && Math.random() < 0.3) {
-                        RPG.log('[아티팩트] 블루문: 마나 소비 없이 스킬 사용!');
-                    } else {
-                        source.mp -= skill.cost;
-                    }
-                }
-
-                // Artifact: double_attack — normal attack 2.0x power
-                let modifiedSkill = skill;
-                if (this.hasArtifact('double_attack') && skill.name === RPG.NORMAL_ATTACK.name) {
-                    modifiedSkill = { ...skill, val: (skill.val || 1.0) * 2.0 };
-                }
-
-                RPG.log(`<b>${source.name}</b>의 <b>${skill.name}</b>!`);
-
-                // Trait: Normal Attack Burn & Divine
-                if (skill.name === RPG.NORMAL_ATTACK.name && source.proto && source.proto.trait && source.proto.trait.type === 'normal_attack_burn_divine') {
-                    let burnMax = this.hasArtifact('over_flame') ? 5 : 3;
-                    let divineMax = this.hasArtifact('over_divine') ? 5 : 3;
-                    let burnAdd = this.hasArtifact('over_flame') ? 2 : 1;
-                    let divineAdd = this.hasArtifact('over_divine') ? 2 : 1;
-                    target.buffs['burn'] = Math.min((target.buffs['burn'] || 0) + burnAdd, burnMax);
-                    target.buffs['divine'] = Math.min((target.buffs['divine'] || 0) + divineAdd, divineMax);
-                    RPG.log("[특성] 일반 공격 추가 효과: 작열, 디바인 부여!");
-                }
-
-                // Trait: Phoenix Normal Attack Burn
-                if (skill.name === RPG.NORMAL_ATTACK.name && source.proto && source.proto.trait && source.proto.trait.type === 'syn_fire_3_crit_burn' && RPG.battle.activeTraits.includes('syn_fire_3_crit_burn')) {
-                    let burnMax = this.hasArtifact('over_flame') ? 5 : 3;
-                    let burnAdd = this.hasArtifact('over_flame') ? 2 : 1;
-                    target.buffs['burn'] = Math.min((target.buffs['burn'] || 0) + burnAdd, burnMax);
-                    RPG.log("[특성] 피닉스: 일반 공격 시 작열 부여!");
-                }
-
-                // Trait: Behemoth (Skill Use -> Stun Chance)
-                if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_trait') {
-                    if (Math.random() < 0.2) {
-                        target.buffs.stun = 1;
-                        RPG.log("[특성] 베히모스의 위압감! 적을 기절시킵니다!");
-                    }
-                }
-
-                // Trait: Behemoth Liberated (Skill Use -> Stun Chance)
-                if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_liberated_trait') {
-                    if (Math.random() < 0.2) {
-                        target.buffs.stun = 1;
-                        RPG.log("[특성] 해방된 베히모스: 20% 확률로 적을 기절시킵니다!");
-                    }
-                }
-
-                // Check for Delayed Attack Effect
-                let delayedEff = typeof findDelayedSkillEffect === 'function'
-                    ? findDelayedSkillEffect(modifiedSkill)
-                    : null;
-
-                if (delayedEff && !isDelayed) {
-                    const resolvedDelayedSkill = typeof buildResolvedDelayedSkill === 'function'
-                        ? buildResolvedDelayedSkill(modifiedSkill, delayedEff, RPG.battle.turn)
-                        : modifiedSkill;
-
-                    if (this.hasActiveTrait('instant_delayed_skills')) {
-                        RPG.log('[특성] 시간의마술사: 지연 스킬 즉시 발동!');
-                        modifiedSkill = resolvedDelayedSkill;
-                    } else {
-                        RPG.log(`${skill.name} 준비... (${delayedEff.turns}턴 뒤 발동)`);
-                        RPG.battle.delayedEffects.push({ turn: RPG.battle.turn + delayedEff.turns, source: source, skill: resolvedDelayedSkill });
-                        this.maybeTriggerDeathRoulette(source, modifiedSkill, isDelayed);
-                        this.resolveSourceDeath(source, target);
-                        if (target.hp <= 0) { RPG.winBattle(); return; }
-                        RPG.TurnManager.endPlayerTurn();
-                        return;
-                    }
-                }
-
-                const dmgResult = this.calcDamage(source, target, modifiedSkill);
-
-                // Apply Damage
-                if (dmgResult.dmg > 0) {
-                    target.hp -= dmgResult.dmg;
-                    target.tookDamageThisTurn = true;
-                    RPG.log(`${dmgResult.isCrit ? 'Critical! ' : ''}적에게 <span class="log-dmg">${dmgResult.dmg}</span> 피해.`);
-                    RPG.handleOnHitTraits(target, source);
-                }
-
-                // Artifact: lucky_vicky — mana recovery on crit
-                if (dmgResult.luckyVicky) {
-                    source.mp = Math.min(GAME_CONSTANTS.MAX_MP, source.mp + 10);
-                    RPG.log('[아티팩트] 럭키비키: 치명타 발생! 마나 10 회복!');
-                }
-
-                this.maybeTriggerDeathRoulette(source, modifiedSkill, isDelayed);
-
-                // Apply Side Effects (Buffs, Debuffs, Field, Suicide, etc.)
-                this.applySkillEffects(source, target, modifiedSkill);
-
-                this.resolveSourceDeath(source, target);
-                if (target.hp <= 0) { RPG.winBattle(); return; }
-
-                if (!isDelayed) RPG.TurnManager.endPlayerTurn();
+                return BattleRuntime.executeSkill(this, source, target, skill, isDelayed);
             },
 
             calcDamage(source, target, skill) {
-                if (skill.type !== 'phy' && skill.type !== 'mag') return { dmg: 0 };
-
-                // Logic.js returns { dmg, isCrit, luckyVicky } and logs via callback
-                const result = Logic.calculateDamage(
-                    source,
-                    target,
-                    skill,
-                    RPG.battle.fieldBuffs,
-                    RPG.battle.activeTraits,
-                    (msg) => RPG.log(msg),
-                    RPG.state.mode, // PASS MODE
-                    RPG.state.deck, // PASS DECK
-                    RPG.battle.turn, // PASS TURN
-                    RPG.state.artifacts || [] // PASS ARTIFACTS
-                );
-
-                if (target.id === 'demon_god') {
-                    const b = RPG.battle;
-                    if ((b.turn % 2 === 0 && skill.type === 'phy') || (b.turn % 2 !== 0 && skill.type === 'mag')) {
-                        RPG.log("(마신의 권능: 방어력 상승 적용중)");
-                    }
-                }
-
-                target.lastHitType = skill.type;
-
-                return result;
+                return BattleRuntime.calcDamage(this, source, target, skill);
             },
 
             applySkillEffects(source, target, skill) {
-                if (!skill.effects) return;
-
-                const ctx = {
-                    source: source,
-                    target: target,
-                    skill: skill,
-                    activeTraits: RPG.battle.activeTraits,
-                    logFn: (msg) => RPG.log(msg),
-                    getBuffName: (id) => (BUFF_NAMES[id] || id),
-                    applyFieldBuff: (id) => RPG.applyFieldBuff(id),
-                    battle: this.battle,
-                    executeSkill: this.executeSkill.bind(this),
-                    getCardData: this.getCardData.bind(this)
-                };
-
-                skill.effects.forEach(eff => {
-                    if (typeof SideEffects !== 'undefined') {
-                        SideEffects.apply(ctx, eff);
-                    }
-                });
-
-                // Special Rumi Trait Trigger
-                if (RPG.battle.activeTraits.includes('syn_water_nature') && skill.name === '문라이트세레나') {
-                    RPG.log("루미의 특성 발동! 트윙클파티 추가!");
-                    this.applyFieldBuff('twinkle_party');
-                }
-
-                // Siren Trait Trigger
-                if (RPG.battle.activeTraits.includes('syn_water_2_moon_twinkle') && skill.name === '실버문베일') {
-                    RPG.log("[특성] 세이렌의 노래! 트윙클파티 추가!");
-                    this.applyFieldBuff('twinkle_party');
-                }
+                return BattleRuntime.applySkillEffects(this, source, target, skill);
             },
 
             expireFieldBuffs(turn) {
-                const expiredBuffs = this.battle.fieldBuffs.filter(buff => buff.expiresAtTurn && buff.expiresAtTurn <= turn);
-                if (expiredBuffs.length === 0) return;
-
-                this.battle.fieldBuffs = this.battle.fieldBuffs.filter(buff => !(buff.expiresAtTurn && buff.expiresAtTurn <= turn));
-                expiredBuffs.forEach(buff => {
-                    RPG.log(buff.expireLog || `필드버프 [${BUFF_NAMES[buff.name]}] 소멸.`);
-                });
+                return BattleRuntime.expireFieldBuffs(this, turn);
             },
 
             applyFieldBuff(id, options = {}) {
-                if (this.battle.fieldBuffs.some(b => b.name === id)) return RPG.log(`필드버프 [${BUFF_NAMES[id]}] 이미 존재.`);
-                // Artifact: buff_overload — increase max field buffs to 5
-                let maxBuffs = this.hasArtifact('buff_overload') ? 5 : GAME_CONSTANTS.MAX_FIELD_BUFFS;
-                if (this.battle.fieldBuffs.length >= maxBuffs) {
-                    let removed = this.battle.fieldBuffs.shift();
-                    RPG.log(`필드버프 [${BUFF_NAMES[removed.name]}] 소멸.`);
-                }
-                this.battle.fieldBuffs.push({ name: id, ...options });
-                RPG.log(`필드버프 [${BUFF_NAMES[id]}] 발동!`);
+                return BattleRuntime.applyFieldBuff(this, id, options);
             },
 
             // --- Setup & UI ---
@@ -3593,20 +3052,22 @@
                 let transMsg = this.cleanupTranscendenceCards();
                 let deadMsg = this.handlePermadeath(this.battle.players);
                 if (transMsg) deadMsg += transMsg;
-                let reward = 1;
+                let reward = GAME_CONSTANTS.MODE_REWARDS[this.state.mode] !== undefined
+                    ? GAME_CONSTANTS.MODE_REWARDS[this.state.mode]
+                    : GAME_CONSTANTS.MODE_REWARDS.default;
 
-                // Mode Rewards
-                if (this.state.mode === 'suffering') reward = 0;
-                if (this.state.mode === 'chaos') reward = 0;
-
-                if (this.battle.players.some(p => p && p.proto.trait.type === 'looter')) reward += 1;
-                if (this.state.mode === 'overdrive') reward += 1;
+                if (this.battle.players.some(p => p && p.proto.trait.type === 'looter')) {
+                    reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
+                }
+                if (this.state.mode === 'overdrive') {
+                    reward += GAME_CONSTANTS.BONUS_REWARDS.OVERDRIVE;
+                }
 
                 this.state.tickets += reward;
                 this.state.enemyScale++;
 
                 // Reset Chaos Blessing
-                this.state.chaosBlessingUses = 3;
+                this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
                 this.state.chaosBuffs = [];
                 this.state.activeChaosBlessing = [];
                 this.state.activeSageBlessing = [];
@@ -3616,21 +3077,8 @@
                 // Victory Condition Check
                 const mode = this.state.mode;
                 const stage = this.state.enemyScale; // current stage (already incremented)
-                let clearStage = 24;
-                if (['restriction', 'balance', 'archive'].includes(mode)) clearStage = 18;
-                if (mode === 'overdrive') clearStage = 30;
-                if (mode === 'curse' || mode === 'flood') clearStage = 30;
-                if (mode === 'chaos') clearStage = 24;
-                if (mode === 'draft') clearStage = 24;
-                if (mode === 'artifact') clearStage = 36;
-                if (mode === 'origin') clearStage = Infinity;
-
-                if (this.state.gameType === 'endless') clearStage = Infinity;
-
-                let gameClear = false;
-                if (stage >= clearStage) {
-                    gameClear = true;
-                }
+                const clearStage = GameUtils.getClearStage(mode, this.state.gameType);
+                const gameClear = stage >= clearStage;
 
                 // Chaos/Draft: Reset Deck/Inventory
                 if (mode === 'chaos') {
@@ -3657,16 +3105,18 @@
 
                 // Archive Mode: Mandatory Quiz (Direct to finishWinBattle via callback)
                 if (mode === 'archive') {
-                    let allQuizzes = [];
-                    GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
-                    let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+                    const q = this.getRandomGrammarQuiz();
+                    if (!q) {
+                        this.finishWinBattle(deadMsg, gameClear, null);
+                        return;
+                    }
                     this.state.lastArchiveQuizLectureId = q.lecture_id;
 
                     this.startGrammarQuiz(q,
                         () => { // Success
                             this.state.quiz_stats.correct++;
                             this.state.quiz_stats.total++;
-                            this.state.tickets++; // Reward Ticket
+                            this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.QUIZ;
                             setTimeout(() => this.finishWinBattle(deadMsg, gameClear, true), 200);
                         },
                         () => { // Fail
@@ -3748,7 +3198,7 @@
                                 () => {
                                     this.startCollocationQuiz((success) => {
                                         if (success) {
-                                            this.state.tickets += 1;
+                                            this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.QUIZ;
                                             document.getElementById('ui-tickets').innerText = this.state.tickets;
                                             this.showAlert("정답! 드로우권 1장을 추가로 획득했습니다.");
                                         } else {
@@ -3766,9 +3216,11 @@
                             // Artifact Mode: Quiz → Artifact Selection
                             this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 아티팩트 획득 기회)",
                                 () => { // Yes
-                                    let allQuizzes = [];
-                                    GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
-                                    let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+                                    const q = this.getRandomGrammarQuiz();
+                                    if (!q) {
+                                        this.toMenu();
+                                        return;
+                                    }
 
                                     this.startGrammarQuiz(q,
                                         () => { // Success - Show artifact selection
@@ -3796,13 +3248,15 @@
                         else if (this.battle.enemy.id === 'creator_god') {
                             this.showConfirm("창조신 격파 보너스! 문법 퀴즈에 도전하시겠습니까?\n(성공 시 뽑기권 3장 획득)",
                                 () => { // Yes
-                                    let allQuizzes = [];
-                                    GRAMMAR_DATA.forEach(lec => { allQuizzes = allQuizzes.concat(lec.quizzes); });
-                                    let q = allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+                                    const q = this.getRandomGrammarQuiz();
+                                    if (!q) {
+                                        this.toMenu();
+                                        return;
+                                    }
 
                                     this.startGrammarQuiz(q,
                                         () => { // Success
-                                            this.state.tickets += 3;
+                                            this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.CREATOR_GOD_QUIZ;
                                             document.getElementById('ui-tickets').innerText = this.state.tickets;
                                             this.showAlert("정답! 드로우권 3장을 추가로 획득했습니다.");
                                             this.toMenu();
@@ -3830,7 +3284,7 @@
                                 () => {
                                     this.startQuiz((success) => {
                                         if (success) {
-                                            this.state.tickets += 1;
+                                            this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.QUIZ;
                                             document.getElementById('ui-tickets').innerText = this.state.tickets;
                                             this.showAlert("정답! 드로우권 1장을 추가로 획득했습니다.");
                                         } else {

--- a/card/logic.js
+++ b/card/logic.js
@@ -7,6 +7,7 @@
  *   - GACHA_RATES: Gacha probability tables per mode
  *   - GameUtils.buildCardPool(): Unified card pool builder (replaces 6 duplicated patterns)
  *   - GameUtils.resolveGachaGrade(): Grade determination from GACHA_RATES table
+ *   - GameUtils.getCardById()/getAllCards()/buildDeckContext(): Shared card lookup and Joker-aware deck helpers
  */
 
 // ─── Storage Layer ────────────────────────────────────────────────────────────
@@ -101,6 +102,7 @@ const GAME_CONSTANTS = {
     MAX_RECORDS: 5,
     MAX_ARTIFACTS: 4,
     SAGE_BLESSING_PICK_COUNT: 12,
+    DEFAULT_BLESSING_USES: 3,
 
     // Costs
     COSTS: {
@@ -111,6 +113,41 @@ const GAME_CONSTANTS = {
 
     DRAFT: {
         INITIAL_REROLLS: 3
+    },
+
+    LOADING: {
+        MAX_ATTEMPTS: 200,
+        POLLING_MS: 150,
+        START_RETRY_LIMIT: 6,
+        START_RETRY_DELAY_MS: 180
+    },
+
+    MODE_CLEAR_STAGES: {
+        default: 24,
+        origin: Infinity,
+        restriction: 18,
+        balance: 18,
+        archive: 18,
+        overdrive: 30,
+        curse: 30,
+        flood: 30,
+        chaos: 24,
+        draft: 24,
+        artifact: 36
+    },
+
+    MODE_REWARDS: {
+        default: 1,
+        suffering: 0,
+        chaos: 0
+    },
+
+    BONUS_REWARDS: {
+        SAGE_BLESSING: 1,
+        QUIZ: 1,
+        CREATOR_GOD_QUIZ: 3,
+        LOOTER: 1,
+        OVERDRIVE: 1
     },
 
     // Battle Settings
@@ -194,6 +231,79 @@ const ARTIFACT_LIST = [
 // ─── Game Utilities ───────────────────────────────────────────────────────────
 
 const GameUtils = {
+    /**
+     * Get all collectible cards in lookup order.
+     * @returns {Array}
+     */
+    getAllCards() {
+        return [
+            ...CARDS,
+            ...BONUS_CARDS,
+            ...(typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS : [])
+        ];
+    },
+
+    /**
+     * Resolve a card by id from a given pool or the full card set.
+     * @param {string} id
+     * @param {Array} [pool]
+     * @returns {Object|null}
+     */
+    getCardById(id, pool) {
+        if (!id) return null;
+        const cards = Array.isArray(pool) ? pool : this.getAllCards();
+        return cards.find(card => card.id === id) || null;
+    },
+
+    /**
+     * Build a Joker-aware deck context for trait/effect evaluation.
+     * Joker counts as every element and every card name for deck checks.
+     *
+     * @param {string[]} deck
+     * @param {Array} [allCards]
+     * @returns {Object}
+     */
+    buildDeckContext(deck, allCards) {
+        const cards = (deck || [])
+            .map(id => this.getCardById(id, allCards))
+            .filter(Boolean);
+        const jokerCount = cards.filter(card => card.id === 'joker').length;
+        const elementCounts = {};
+        const cardCounts = {};
+
+        cards.forEach(card => {
+            cardCounts[card.id] = (cardCounts[card.id] || 0) + 1;
+            if (card.id !== 'joker') {
+                elementCounts[card.element] = (elementCounts[card.element] || 0) + 1;
+            }
+        });
+
+        const countMatchingIds = (ids) => {
+            const allowedIds = new Set(ids || []);
+            let count = jokerCount;
+
+            allowedIds.forEach(id => {
+                count += cardCounts[id] || 0;
+            });
+
+            return count;
+        };
+
+        return {
+            cards,
+            hasJoker: jokerCount > 0,
+            jokerCount,
+            elementCounts,
+            cardCounts,
+            hasCard: (id) => Boolean(cardCounts[id]) || (jokerCount > 0 && id !== 'joker'),
+            hasAnyCard: (ids) => countMatchingIds(ids) > 0,
+            countMatchingIds,
+            hasElement: (element) => jokerCount > 0 || Boolean(elementCounts[element]),
+            countElement: (element) => (elementCounts[element] || 0) + jokerCount,
+            countDeckAttributes: () => (jokerCount > 0 ? 5 : Object.keys(elementCounts).length)
+        };
+    },
+
     /**
      * Build a card pool with bonus and transcendence cards.
      * Replaces 6 duplicated card pool construction patterns throughout the codebase.
@@ -291,6 +401,19 @@ const GameUtils = {
         return GAME_CONSTANTS.INITIAL_TICKETS[mode] !== undefined
             ? GAME_CONSTANTS.INITIAL_TICKETS[mode]
             : GAME_CONSTANTS.INITIAL_TICKETS.default;
+    },
+
+    /**
+     * Get the clear stage requirement for a mode/game type.
+     * @param {string} mode
+     * @param {string} gameType
+     * @returns {number}
+     */
+    getClearStage(mode, gameType) {
+        if (gameType === 'endless') return Infinity;
+        return GAME_CONSTANTS.MODE_CLEAR_STAGES[mode] !== undefined
+            ? GAME_CONSTANTS.MODE_CLEAR_STAGES[mode]
+            : GAME_CONSTANTS.MODE_CLEAR_STAGES.default;
     }
 };
 
@@ -520,31 +643,9 @@ const DAMAGE_EFFECT_HANDLERS = {
         }
     },
     'count_deck_attr_dmg': (ctx, eff) => {
-        // Need access to deck or active traits to count attributes?
-        // Logic.calculateDamage receives activeTraits.
-        // But deck content isn't directly passed.
-        // However, `ctx.activeTraits` contains synergy strings, not deck info.
-        // Logic.calculateDamage is called with `activeTraits`.
-        // We might need to pass `deck` to calculateDamage or check `source.proto.element` etc.
-        // Workaround: We can't easily count deck attributes inside Logic without deck data.
-        // BUT, we can pass the count as a param when calling calculateDamage?
-        // OR, we assume `activeTraits` or `fieldBuffs` implies something? No.
-        // We should update `Logic.calculateDamage` to accept `deck` or `attrCount`.
-        // OR, for now, use a hack: Look at `activeTraits` if it has specific markers? No.
-        // Best approach: Add `deck` to the `calculateDamage` signature in the next step,
-        // or handle this in index.html and pass the multiplier?
-        // Index.html `calcDamage` calls `Logic.calculateDamage`.
-        // I will update `Logic` to accept `deck` in the next step.
-        // For now, I'll write the handler assuming `ctx.deck` exists.
         if (ctx.deck) {
-            const cards = ctx.deck.map(id => id ? (CARDS.find(c => c.id === id) || BONUS_CARDS.find(c => c.id === id) || TRANSCENDENCE_CARDS.find(c => c.id === id)) : null).filter(c => c);
-            let attrs = new Set();
-            let hasJoker = false;
-            cards.forEach(c => {
-                if (c.id === 'joker') hasJoker = true;
-                else attrs.add(c.element);
-            });
-            let count = hasJoker ? 5 : attrs.size;
+            const deckCtx = GameUtils.buildDeckContext(ctx.deck);
+            let count = deckCtx.countDeckAttributes();
             ctx.mult += count * 1.0;
             ctx.logFn(`덱 속성 ${count}종! 위력 +${count.toFixed(1)}배!`);
         }
@@ -1264,12 +1365,8 @@ const Logic = {
             baseCrit: 10, baseEva: 0
         };
 
-        // Filter active cards
-        const activeCards = deck.map(id => id ? allCards.find(c => c.id === id) : null).filter(c => c);
-        const jokerInDeck = deck.includes('joker');
-
-        const countEl = (el) => activeCards.filter(c => c.element === el || c.id === 'joker').length;
-        const hasEl = (el) => activeCards.some(c => c.element === el || c.id === 'joker');
+        const deckCtx = GameUtils.buildDeckContext(deck, allCards);
+        const activeCards = deckCtx.cards;
 
         // Traits
         const t = playerProto.trait;
@@ -1277,24 +1374,24 @@ const Logic = {
 
         // Synergy Traits
         if (t.type.startsWith('syn_')) {
-            if (t.type === 'syn_nature_3_all' && countEl('nature') >= 3) active = true;
-            else if (t.type === 'syn_nature_3_golem' && countEl('nature') >= 3) active = true;
-            else if (t.type === 'syn_water_3_ice_age' && countEl('water') >= 3) active = true;
-            else if (t.type === 'syn_fire_3_crit' && countEl('fire') >= 3) active = true;
-            else if (t.type === 'syn_dark_3_matk' && countEl('dark') >= 3) active = true;
-            else if (t.type === 'syn_light_fire_atk' && hasEl('light') && hasEl('fire')) active = true;
-            else if (t.type === 'syn_light_dark_matk_mdef' && hasEl('light') && hasEl('dark')) active = true;
-            else if (t.type === 'syn_light_3_matk_mdef' && countEl('light') >= 3) active = true;
-            else if (t.type === 'syn_water_nature' && hasEl('water') && hasEl('nature')) active = true;
-            else if (t.type === 'syn_nature_3_matk' && countEl('nature') >= 3) active = true;
-            else if (t.type === 'syn_night_rabbit' && (deck.includes('night_rabbit') || deck.includes('silver_rabbit') || jokerInDeck)) active = true;
-            else if (t.type === 'syn_snow_rabbit' && (deck.includes('snow_rabbit') || deck.includes('silver_rabbit') || jokerInDeck)) active = true;
-            else if (t.type === 'syn_silver_rabbit' && (deck.includes('snow_rabbit') || deck.includes('night_rabbit') || jokerInDeck)) active = true;
-            else if (t.type === 'syn_water_3_atk_matk' && countEl('water') >= 3) active = true;
-            else if (t.type === 'syn_fire_3_crit_burn' && countEl('fire') >= 3) active = true;
-            else if (t.type === 'syn_dark_3_matk_boost' && countEl('dark') >= 3) active = true;
-            else if (t.type === 'syn_dark_3_party_atk' && countEl('dark') >= 3) active = true;
-            else if (t.type === 'syn_water_2_moon_twinkle' && countEl('water') >= 2) active = true;
+            if (t.type === 'syn_nature_3_all' && deckCtx.countElement('nature') >= 3) active = true;
+            else if (t.type === 'syn_nature_3_golem' && deckCtx.countElement('nature') >= 3) active = true;
+            else if (t.type === 'syn_water_3_ice_age' && deckCtx.countElement('water') >= 3) active = true;
+            else if (t.type === 'syn_fire_3_crit' && deckCtx.countElement('fire') >= 3) active = true;
+            else if (t.type === 'syn_dark_3_matk' && deckCtx.countElement('dark') >= 3) active = true;
+            else if (t.type === 'syn_light_fire_atk' && deckCtx.hasElement('light') && deckCtx.hasElement('fire')) active = true;
+            else if (t.type === 'syn_light_dark_matk_mdef' && deckCtx.hasElement('light') && deckCtx.hasElement('dark')) active = true;
+            else if (t.type === 'syn_light_3_matk_mdef' && deckCtx.countElement('light') >= 3) active = true;
+            else if (t.type === 'syn_water_nature' && deckCtx.hasElement('water') && deckCtx.hasElement('nature')) active = true;
+            else if (t.type === 'syn_nature_3_matk' && deckCtx.countElement('nature') >= 3) active = true;
+            else if (t.type === 'syn_night_rabbit' && deckCtx.hasAnyCard(['night_rabbit', 'silver_rabbit'])) active = true;
+            else if (t.type === 'syn_snow_rabbit' && deckCtx.hasAnyCard(['snow_rabbit', 'silver_rabbit'])) active = true;
+            else if (t.type === 'syn_silver_rabbit' && deckCtx.hasAnyCard(['snow_rabbit', 'night_rabbit'])) active = true;
+            else if (t.type === 'syn_water_3_atk_matk' && deckCtx.countElement('water') >= 3) active = true;
+            else if (t.type === 'syn_fire_3_crit_burn' && deckCtx.countElement('fire') >= 3) active = true;
+            else if (t.type === 'syn_dark_3_matk_boost' && deckCtx.countElement('dark') >= 3) active = true;
+            else if (t.type === 'syn_dark_3_party_atk' && deckCtx.countElement('dark') >= 3) active = true;
+            else if (t.type === 'syn_water_2_moon_twinkle' && deckCtx.countElement('water') >= 2) active = true;
 
             if (active) {
                 if (t.type === 'syn_nature_3_all') { p.atk *= 1.3; p.matk *= 1.3; p.def *= 1.3; p.mdef *= 1.3; }
@@ -1333,9 +1430,7 @@ const Logic = {
         }
 
         if (t.type === 'rabbit_synergy_boost') {
-            const rabbits = ['night_rabbit', 'snow_rabbit', 'silver_rabbit', 'trans_yeon_rabbit', 'joker'];
-            let count = 0;
-            deck.forEach(id => { if (id && rabbits.includes(id)) count++; });
+            const count = deckCtx.countMatchingIds(['night_rabbit', 'snow_rabbit', 'silver_rabbit', 'trans_yeon_rabbit']);
             if (count > 0) {
                 let boost = count * (t.val / 100);
                 p.atk = Math.floor(p.atk * (1 + boost));
@@ -1353,7 +1448,7 @@ const Logic = {
                     if (partyBoost[s] !== undefined) partyBoost[s] += (tr.val || 0);
                 });
             }
-            else if (tr && tr.type === 'syn_dark_3_party_atk' && countEl('dark') >= 3) {
+            else if (tr && tr.type === 'syn_dark_3_party_atk' && deckCtx.countElement('dark') >= 3) {
                 partyBoost.atk += (tr.val || 0);
             }
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/toeic.js && node --check card/api.js",
+    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/toeic.js && node --check card/api.js && node --check card/battle_runtime.js",
     "test:smoke": "node scripts/verify_card_smoke.js && node scripts/verify_idle_hero_smoke.js",
     "verify": "npm run lint && npm run test:smoke"
   },


### PR DESCRIPTION
## Summary
- split non-visual battle flow into `card/battle_runtime.js` and keep battle rendering/screen wrappers in `card/index.html`
- add shared card/deck helpers in `card/logic.js` and route Joker-sensitive deck checks through one context builder
- normalize reward constants/loading checks and reorder card data arrays consistently by rarity/category

## Testing
- `npm run verify`

## Manual verification not run
- title loading UI and start/continue enable flow in browser
- save/load restore flow in browser
- gacha/challenge/bonus pool editor interaction in browser
- Joker deck elemental/rabbit synergy behavior in browser
- battle flow details such as delayed skills, field buffs, death traits, and artifact interactions in browser
