### PR TITLE
Add hidden study mode, monthly missions, and card data fixes

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -22,9 +22,13 @@ function applyStackMap(rpg, target, buffMap) {
 }
 
 function buildBattleEnemy(rpg) {
-    const enemyIdx = rpg.state.enemyScale % ENEMIES.length;
-    const baseEnemy = ENEMIES[enemyIdx];
-    const cycle = Math.floor(rpg.state.enemyScale / ENEMIES.length);
+    const baseEnemy = rpg.getCurrentStageEnemyData
+        ? rpg.getCurrentStageEnemyData()
+        : ENEMIES[rpg.state.enemyScale % ENEMIES.length];
+    const cycleLength = (typeof ENDLESS_ENEMY_ROTATION !== 'undefined' && ENDLESS_ENEMY_ROTATION.length)
+        ? ENDLESS_ENEMY_ROTATION.length
+        : ENEMIES.length;
+    const cycle = Math.floor(rpg.state.enemyScale / cycleLength);
     const scale = 1.0 + (cycle * 0.2);
     const enemy = {
         id: baseEnemy.id,
@@ -33,6 +37,8 @@ function buildBattleEnemy(rpg) {
         hp: Math.floor(baseEnemy.stats.hp * scale),
         atk: Math.floor(baseEnemy.stats.atk * scale),
         matk: Math.floor(baseEnemy.stats.matk * scale),
+        baseAtk: Math.floor(baseEnemy.stats.atk * scale),
+        baseMatk: Math.floor(baseEnemy.stats.matk * scale),
         def: Math.floor(baseEnemy.stats.def * scale),
         mdef: Math.floor(baseEnemy.stats.mdef * scale),
         baseDef: Math.floor(baseEnemy.stats.def * scale),
@@ -41,7 +47,9 @@ function buildBattleEnemy(rpg) {
         buffs: {},
         element: baseEnemy.element,
         tookDamageThisTurn: false,
-        lastHitType: null
+        lastHitType: null,
+        isHiddenBoss: !!baseEnemy.hiddenBossFor,
+        bonusRewardTickets: baseEnemy.hiddenBossFor ? 3 : 0
     };
 
     if (baseEnemy.id === 'creator_god') {
@@ -125,6 +133,15 @@ const BattleRuntime = {
 
         const allCards = GameUtils.getAllCards();
         rpg.battle.players = rpg.state.deck.map((cardId, idx) => buildBattlePlayer(rpg, cardId, idx, allCards));
+        const hasAttackSwap = rpg.battle.players.some(player => player && player.proto && player.proto.trait.type === 'reverse_atk_matk_party');
+        const normalAttackTrait = rpg.battle.players.find(player => player && player.proto && player.proto.trait.type === 'party_normal_attack_dmg');
+        if (hasAttackSwap || normalAttackTrait) {
+            rpg.battle.players.forEach(player => {
+                if (!player) return;
+                if (hasAttackSwap) player.swapAtkMatk = true;
+                if (normalAttackTrait) player.normalAttackPartyMult = normalAttackTrait.proto.trait.val || 1.0;
+            });
+        }
         rpg.battle.fieldBuffs = [];
         rpg.battle.delayedEffects = [];
         rpg.battle.turn = 1;
@@ -297,15 +314,24 @@ const BattleRuntime = {
 
             const skillInfo = Logic.decideEnemyAction(enemy, battle.turn);
 
-            if (skillInfo.chargeReset) enemy.isCharging = false;
+            if (skillInfo.chargeReset) {
+                enemy.isCharging = false;
+                enemy.chargeSkillId = null;
+            }
             if (skillInfo.isChargeStart) {
                 enemy.isCharging = true;
-                rpg.log("창조신이 힘을 모으고 있습니다... (공격 없음)");
+                rpg.log(skillInfo.chargeMessage || "창조신이 힘을 모으고 있습니다... (공격 없음)");
                 BattleRuntime.TurnManager.endEnemyTurn(rpg);
                 return;
             }
 
             const skill = skillInfo;
+            if (skill.type !== 'phy' && skill.type !== 'mag') {
+                rpg.log(`${enemy.name}・・${skill.name}!`);
+                BattleRuntime.applySkillEffects(rpg, enemy, target, skill);
+                BattleRuntime.TurnManager.endEnemyTurn(rpg);
+                return;
+            }
             let val = skill.type === 'phy' ? enemy.atk : enemy.matk;
             let mult = skill.val || 1.0;
 
@@ -335,7 +361,7 @@ const BattleRuntime = {
 
             def = Math.floor(def * fieldDef * defMult);
 
-            if (Logic.checkEvasion(target, skill.type, battle.fieldBuffs, rpg.state.mode, rpg.state.artifacts || [])) {
+            if (Logic.checkEvasion(target, skill.type, battle.fieldBuffs, rpg.state.mode, rpg.state.artifacts || [], battle.turn)) {
                 rpg.log(`${target.name} 회피 성공! (${skill.name} 회피)`);
                 if (rpg.hasArtifact('lucky_vicky')) {
                     target.mp = Math.min(GAME_CONSTANTS.MAX_MP, target.mp + 10);
@@ -368,6 +394,7 @@ const BattleRuntime = {
                 BattleRuntime.handleOnHitTraits(rpg, target, enemy);
             }
             rpg.log(`${enemy.name}의 ${skill.name}! <span class="log-dmg">${dmg}</span> 피해.`);
+            BattleRuntime.applySkillEffects(rpg, enemy, target, skill);
 
             if (skill.effects) {
                 skill.effects.forEach(effect => {

--- a/card/data.js
+++ b/card/data.js
@@ -800,6 +800,100 @@ const BONUS_CARDS = [
     }
 ];
 
+const BONUS_CARD_EXPANSION = [
+    {
+        id: 'doom_luther', name: '둠', grade: 'legend', element: 'dark', role: 'luther', unlockSource: 'hidden',
+        stats: { hp: 430, atk: 115, matk: 70, def: 60, mdef: 60 },
+        trait: { type: 'looter', desc: '루터: 이 카드로 승리 시 추가 드로우' },
+        skills: [
+            { name: '진실의거울', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '물리 1.5배율, 상대의 물리공격 무효화', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '허실의거울', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '마법 1.5배율, 상대의 마법공격 무효화', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '갓킬러', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '물리 2배율, 빛속성 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_element', element: 'light', mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'cherry_prince', name: '체리프린스', grade: 'legend', element: 'fire', role: 'dealer', unlockSource: 'bonus',
+        stats: { hp: 500, atk: 150, matk: 75, def: 70, mdef: 70 },
+        trait: { type: 'burn_stack_phy_pen', val: 0.2, desc: '작열 1스택당 적의 물리방어력 20% 관통' },
+        skills: [
+            { name: '체리로열가드', type: 'sup', tier: 3, cost: 30, desc: '생명력 50% 회복하고 받는 대미지 50% 감소', effects: [{ type: 'heal_ratio', ratio: 0.5 }, { type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '블러썸피어스', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '물리 1.5배율, 부식과 저주 부여', effects: [{ type: 'debuff', id: 'corrosion' }, { type: 'debuff', id: 'curse' }] },
+            { name: '루비스타카토', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '마법 3배율, 달의축복 상태에서 대미지 2.5배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.5 }] }
+        ]
+    },
+    {
+        id: 'alchemist', name: '연금술사', grade: 'epic', element: 'water', role: 'buffer', unlockSource: 'hidden',
+        stats: { hp: 430, atk: 75, matk: 75, def: 95, mdef: 95 },
+        trait: { type: 'reverse_atk_matk_party', desc: '덱의 모든 카드의 물리공격과 마법공격이 뒤바뀐다' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격을 1회 무효화', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '금단의실험', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '마법 2배율, 필드버프 스타파우더 부여', effects: [{ type: 'field_buff', id: 'star_powder' }] },
+            { name: '은빛마법진', type: 'sup', tier: 3, cost: 30, desc: '필드버프 달의축복 부여', effects: [{ type: 'field_buff', id: 'moon_bless' }] }
+        ]
+    },
+    {
+        id: 'santa', name: '산타', grade: 'epic', element: 'light', role: 'buffer', unlockSource: 'bonus',
+        stats: { hp: 400, atk: 100, matk: 100, def: 60, mdef: 60 },
+        trait: { type: 'syn_light_3_party_def_mdef', val: 30, desc: '덱이 전부 빛속성일 때 덱 전체 방어력/마법방어력 30% 증가' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격을 1회 무효화', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '프레젠트', type: 'sup', tier: 3, cost: 30, desc: '랜덤한 필드버프를 부여', effects: [{ type: 'random_field_buff' }] },
+            { name: '징글벨', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '마법 1~5배율, 적에게 디바인 부여', effects: [{ type: 'random_mult', min: 1.0, max: 5.0 }, { type: 'debuff', id: 'divine', stack: 1 }] }
+        ]
+    },
+    {
+        id: 'legendary_captain', name: '전설의선장', grade: 'rare', element: 'water', role: 'balancer', unlockSource: 'bonus',
+        stats: { hp: 360, atk: 100, matk: 70, def: 60, mdef: 60 },
+        trait: { type: 'death_debuff', debuff: 'stun', desc: '사망 시 적에게 기절 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '앵커체인', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '물리 2배율, 적에게 침묵 혹은 부식 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['silence', 'corrosion'] }] },
+            { name: '선상결투', type: 'sup', tier: 2, cost: 20, desc: '필드버프 아레나 부여', effects: [{ type: 'field_buff', id: 'arena' }] }
+        ]
+    },
+    {
+        id: 'ember_tiger', name: '엠버타이거', grade: 'rare', element: 'fire', role: 'balancer', unlockSource: 'hidden',
+        stats: { hp: 365, atk: 105, matk: 70, def: 60, mdef: 55 },
+        trait: { type: 'party_normal_attack_dmg', val: 2.0, desc: '덱 전체의 일반공격 대미지 2배' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '와일드러쉬', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '물리 2.5배율, 적에게 작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] },
+            { name: '블레이즈크로', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 적에게 약화 혹은 침묵 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['weak', 'silence'] }] }
+        ]
+    },
+    {
+        id: 'executor', name: '처형인', grade: 'normal', element: 'nature', role: 'balancer', unlockSource: 'bonus',
+        stats: { hp: 320, atk: 80, matk: 70, def: 60, mdef: 55 },
+        trait: { type: 'opening_atk_def', val: 50, desc: '전투 시작 후 3턴간 공격력/방어력 50% 증가' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '워크라이', type: 'sup', tier: 2, cost: 20, desc: '필드버프 아레나 부여', effects: [{ type: 'field_buff', id: 'arena' }] },
+            { name: '섀도우길로틴', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] }
+        ]
+    },
+    {
+        id: 'black_swan', name: '블랙스완', grade: 'normal', element: 'dark', role: 'dealer', unlockSource: 'hidden',
+        stats: { hp: 310, atk: 60, matk: 90, def: 50, mdef: 55 },
+        trait: { type: 'syn_dark_full_party_crit', val: 20, desc: '덱 전체가 어둠속성인 경우 덱 전체 치명타율 20% 증가' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '흑조의속삭임', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '물리 2배율, 적에게 암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] },
+            { name: '운명의무도', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 달의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.0 }] }
+        ]
+    }
+];
+
+BONUS_CARDS.push(...BONUS_CARD_EXPANSION);
+
+const ENDLESS_ENEMY_ROTATION = [
+    'artificial_demon_god',
+    'iris_love',
+    'iris_curse',
+    'pharaoh',
+    'demon_god',
+    'creator_god'
+];
+
 const ENEMIES = [
     {
         id: 'artificial_demon_god', name: '인조 마신', element: 'water',
@@ -937,6 +1031,39 @@ const TRANSCENDENCE_CARDS = [
     }
 ];
 
+ENEMIES.push(
+    {
+        id: 'thor', name: '뇌신 토르', element: 'light', hiddenBossFor: 'iris_curse',
+        stats: { hp: 900, atk: 100, matk: 50, def: 100, mdef: 50 },
+        skills: [
+            { name: '묠니르', type: 'mag', rate: 0.2, val: 2.0, desc: '마법공격 2배율', effects: [] },
+            {
+                name: '썬더러쉬', type: 'mag', rate: 0.0, val: 3.0, desc: '마법공격 3배율, 사용 후 전투 성향 변화',
+                effects: [{ type: 'set_self_stats', stats: { atk: 50, matk: 100, def: 50, mdef: 100 } }]
+            }
+        ]
+    },
+    {
+        id: 'poseidon', name: '해신 포세이돈', element: 'water', hiddenBossFor: 'pharaoh',
+        stats: { hp: 1100, atk: 100, matk: 80, def: 80, mdef: 100 },
+        skills: [
+            { name: '트라이던트', type: 'phy', rate: 0.2, val: 2.0, desc: '물리공격 2배율', effects: [] },
+            { name: '어비스프레셔', type: 'mag', rate: 0.0, val: 3.0, desc: '마법공격 3배율', effects: [] },
+            { name: '어비스블레싱', type: 'sup', rate: 0.0, val: 0, desc: '자신에게 걸린 모든 디버프를 해제', effects: [{ type: 'clear_self_debuffs' }] },
+            { name: '디바우러', type: 'mag', rate: 0.0, val: 2.0, desc: '마법공격 2배율, 유저의 필드버프를 랜덤으로 하나 삭제', effects: [{ type: 'remove_random_field_buff' }] }
+        ]
+    },
+    {
+        id: 'ares', name: '투신 아레스', element: 'fire', hiddenBossFor: 'demon_god',
+        stats: { hp: 1500, atk: 120, matk: 120, def: 100, mdef: 100 },
+        skills: [
+            { name: '스피어레인', type: 'mag', rate: 0.2, val: 2.0, desc: '마법공격 2배율', effects: [] },
+            { name: '테라소드', type: 'phy', rate: 0.0, val: 4.0, desc: '차징 후 발동하는 물리공격 4배율', effects: [] },
+            { name: '마그마이럽션', type: 'mag', rate: 0.0, val: 4.0, desc: '차징 후 발동하는 마법공격 4배율', effects: [] }
+        ]
+    }
+);
+
 const BUFF_NAMES = {
     'darkness': '암흑', 'corrosion': '부식', 'silence': '침묵', 'curse': '저주', 'weak': '약화',
     'burn': '작열', 'divine': '디바인', 'stun': '기절', 'evasion': '회피', 'barrier': '배리어',
@@ -945,6 +1072,7 @@ const BUFF_NAMES = {
     'sun_bless': '태양의축복', 'moon_bless': '달의축복', 'sanctuary': '성역',
     'goddess_descent': '여신강림', 'destiny_oath': '운명의서약', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',
     'star_powder': '스타파우더',
+    'arena': '아레나',
     'reaper_realm': '사신강림',
     'gale': '질풍'
 };

--- a/card/index.html
+++ b/card/index.html
@@ -897,6 +897,11 @@
                 덱 편집<br>
                 <span style="font-size:0.8rem; color:#b3e5fc;">기본 카드는 항상 포함 / 보너스 카드만 ON/OFF</span>
             </button>
+            <button class="menu-btn" onclick="RPG.openMonthlyMission()"
+                style="padding:18px; border-color:#ffb74d; color:#ffb74d; margin-bottom:10px;">
+                월간 미션<br>
+                <span style="font-size:0.8rem; color:#ffe0b2;">매달 3개의 미션을 완료하고 히든 보상을 해금</span>
+            </button>
             <button onclick="RPG.toTitle()" style="margin-top:20px; width:100%; padding:10px;">뒤로가기</button>
         </div>
     </div>
@@ -912,6 +917,23 @@
             <button class="menu-btn" onclick="RPG.enableAllBonusPoolCards()"
                 style="margin-bottom:8px; border-color:#66bb6a; color:#66bb6a;">모두 활성화</button>
             <button onclick="RPG.closeBonusPoolEditor()" style="width:100%; padding:10px;">닫기</button>
+        </div>
+    </div>
+
+    <div id="modal-monthly-mission" class="modal">
+        <div class="modal-content" style="height:auto; min-height:360px; width: 380px;">
+            <h3 style="color:#ffb74d;">월간 미션</h3>
+            <div id="monthly-mission-status" style="font-size:0.9rem; color:#ffe0b2; margin-bottom:10px;">-</div>
+            <div style="padding:12px; border:1px solid #6d4c41; border-radius:8px; background:#2a211a; margin-bottom:10px;">
+                <div style="font-size:0.8rem; color:#bcaaa4; margin-bottom:6px;">이달의 보상</div>
+                <div id="monthly-mission-reward-name" style="font-weight:bold; color:#fff; margin-bottom:8px;">-</div>
+                <button id="btn-monthly-mission-reward" class="menu-btn"
+                    style="margin-bottom:0; border-color:#ffcc80; color:#ffcc80;">카드 정보 보기</button>
+            </div>
+            <div id="monthly-mission-list" class="modal-scroll" style="max-height:220px; margin-bottom:10px;"></div>
+            <button id="btn-claim-monthly-mission" class="menu-btn" onclick="RPG.claimMonthlyMissionReward()"
+                style="border-color:#66bb6a; color:#66bb6a;">보상받기</button>
+            <button onclick="RPG.closeMonthlyMission()" style="width:100%; padding:10px;">닫기</button>
         </div>
     </div>
 
@@ -1142,7 +1164,7 @@
                 style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; flex-shrink:0;">
                 <h3 id="toeic-title" style="margin:0; font-size:1.1rem; color:#ffd700;">Practice</h3>
                 <button id="toeic-exit-btn"
-                    onclick="document.getElementById('modal-toeic-practice').classList.remove('active');"
+                    onclick="RPG.closeToeicPractice()"
                     style="padding:5px 15px; background:#444; border:1px solid #666; color:#fff; cursor:pointer; border-radius:4px;">나가기</button>
             </div>
 
@@ -1600,7 +1622,11 @@
                 achievements: { origin: false },
                 chaosTickets: 0,
                 lastRewardDate: null,
-                pendingTranscendenceCards: []
+                pendingTranscendenceCards: [],
+                tutoringEventEnabled: true,
+                hiddenStudyReady: false,
+                hiddenStudyPracticeCount: 0,
+                monthlyMission: null
             },
 
             // Game State (Session Persistent)
@@ -1616,7 +1642,9 @@
                 activeChaosBlessing: [], // Specific buffs from Chaos Blessing
                 activeSageBlessing: [],   // Specific buffs from Great Sage Blessing
                 activeBonusPoolIds: [],
-                quiz_stats: { correct: 0, total: 0 }
+                quiz_stats: { correct: 0, total: 0 },
+                pendingEnemyId: null,
+                pendingEnemyStage: null
             },
 
             // Battle State (Transient)
@@ -1694,6 +1722,221 @@
                 Storage.save(Storage.keys.GLOBAL, this.global);
             },
 
+            getStandardBonusCards() {
+                return BONUS_CARDS.filter(card => card.unlockSource !== 'hidden');
+            },
+
+            getHiddenBonusCards() {
+                return BONUS_CARDS.filter(card => card.unlockSource === 'hidden');
+            },
+
+            getGradeSortValue(grade) {
+                const gradeOrder = {
+                    transcendence: 0,
+                    legend: 1,
+                    epic: 2,
+                    rare: 3,
+                    normal: 4,
+                    event: 5
+                };
+                return gradeOrder[grade] ?? 99;
+            },
+
+            sortCardDataByGrade(cards) {
+                return [...cards].sort((a, b) => {
+                    const gradeDiff = this.getGradeSortValue(a.grade) - this.getGradeSortValue(b.grade);
+                    if (gradeDiff !== 0) return gradeDiff;
+                    return a.name.localeCompare(b.name, 'ko');
+                });
+            },
+
+            sortCardIdsByGrade(ids) {
+                return [...ids].sort((a, b) => {
+                    const cardA = this.getCardData(a);
+                    const cardB = this.getCardData(b);
+                    if (!cardA && !cardB) return 0;
+                    if (!cardA) return 1;
+                    if (!cardB) return -1;
+                    const gradeDiff = this.getGradeSortValue(cardA.grade) - this.getGradeSortValue(cardB.grade);
+                    if (gradeDiff !== 0) return gradeDiff;
+                    return cardA.name.localeCompare(cardB.name, 'ko');
+                });
+            },
+
+            sortBlessingsByGrade(blessings) {
+                return [...blessings].sort((a, b) => {
+                    const gradeDiff = this.getGradeSortValue(a.grade) - this.getGradeSortValue(b.grade);
+                    if (gradeDiff !== 0) return gradeDiff;
+                    return a.name.localeCompare(b.name, 'ko');
+                });
+            },
+
+            getCurrentMonthKey() {
+                const now = new Date();
+                return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+            },
+
+            createMonthlyMissionState() {
+                const hiddenCards = this.getHiddenBonusCards();
+                const lockedHidden = hiddenCards.filter(card => !(this.global.unlocked_bonus_cards || []).includes(card.id));
+                const rewardPool = lockedHidden.length > 0 ? lockedHidden : hiddenCards;
+                const rewardCard = rewardPool[Math.floor(Math.random() * rewardPool.length)] || null;
+                return {
+                    monthKey: this.getCurrentMonthKey(),
+                    rewardCardId: rewardCard ? rewardCard.id : null,
+                    claimed: false,
+                    missions: {
+                        endless40: { label: '무한 모드 40 스테이지 돌파', progress: 0, target: 1 },
+                        challenge3: { label: '챌린지 모드 클리어 3회', progress: 0, target: 3 },
+                        toeic3: { label: '실전마법연습 3회 플레이', progress: 0, target: 3 }
+                    }
+                };
+            },
+
+            ensureMonthlyMissionState() {
+                const currentKey = this.getCurrentMonthKey();
+                if (!this.global.monthlyMission || this.global.monthlyMission.monthKey !== currentKey) {
+                    this.global.monthlyMission = this.createMonthlyMissionState();
+                    this.saveGlobalData();
+                }
+                return this.global.monthlyMission;
+            },
+
+            incrementMonthlyMissionProgress(id, amount = 1) {
+                const monthly = this.ensureMonthlyMissionState();
+                const mission = monthly.missions ? monthly.missions[id] : null;
+                if (!mission) return;
+                mission.progress = Math.min(mission.target, (mission.progress || 0) + amount);
+                this.saveGlobalData();
+            },
+
+            areAllMonthlyMissionsCleared() {
+                const monthly = this.ensureMonthlyMissionState();
+                return Object.values(monthly.missions || {}).every(mission => (mission.progress || 0) >= mission.target);
+            },
+
+            openMonthlyMission() {
+                this.renderMonthlyMission();
+                document.getElementById('modal-monthly-mission').classList.add('active');
+            },
+
+            closeMonthlyMission() {
+                document.getElementById('modal-monthly-mission').classList.remove('active');
+            },
+
+            renderMonthlyMission() {
+                const monthly = this.ensureMonthlyMissionState();
+                const reward = monthly.rewardCardId ? this.getCardData(monthly.rewardCardId) : null;
+                const rewardNameEl = document.getElementById('monthly-mission-reward-name');
+                const rewardBtn = document.getElementById('btn-monthly-mission-reward');
+                const list = document.getElementById('monthly-mission-list');
+                const status = document.getElementById('monthly-mission-status');
+                const claimBtn = document.getElementById('btn-claim-monthly-mission');
+
+                rewardNameEl.innerText = reward ? reward.name : '보상이 없습니다';
+                rewardBtn.disabled = !reward;
+                rewardBtn.style.opacity = reward ? '1' : '0.5';
+                rewardBtn.onclick = reward ? (() => this.showCardInfo(reward.id)) : null;
+
+                const allClear = this.areAllMonthlyMissionsCleared();
+                status.innerText = `${monthly.monthKey} 월 미션`;
+                list.innerHTML = '';
+
+                Object.values(monthly.missions || {}).forEach(mission => {
+                    const cleared = (mission.progress || 0) >= mission.target;
+                    const item = document.createElement('div');
+                    item.style.padding = '10px';
+                    item.style.marginBottom = '8px';
+                    item.style.border = `1px solid ${cleared ? '#66bb6a' : '#555'}`;
+                    item.style.borderRadius = '8px';
+                    item.style.background = cleared ? 'rgba(102, 187, 106, 0.12)' : '#2a2a2a';
+                    item.innerHTML = `
+                        <div style="font-weight:bold; color:${cleared ? '#a5d6a7' : '#fff'};">${cleared ? '완료' : '진행'} · ${mission.label}</div>
+                        <div style="font-size:0.85rem; color:#b0bec5; margin-top:4px;">${mission.progress}/${mission.target}</div>
+                    `;
+                    list.appendChild(item);
+                });
+
+                claimBtn.disabled = !allClear || monthly.claimed || !reward;
+                claimBtn.style.opacity = claimBtn.disabled ? '0.5' : '1';
+                claimBtn.innerText = monthly.claimed ? '보상 수령 완료' : '보상받기';
+            },
+
+            claimMonthlyMissionReward() {
+                const monthly = this.ensureMonthlyMissionState();
+                if (monthly.claimed) return this.showAlert('이번 달 보상은 이미 수령했습니다.');
+                if (!this.areAllMonthlyMissionsCleared()) return this.showAlert('모든 월간 미션을 완료해야 보상을 받을 수 있습니다.');
+                const reward = monthly.rewardCardId ? this.getCardData(monthly.rewardCardId) : null;
+                if (!reward) return this.showAlert('이번 달 보상 카드가 없습니다.');
+
+                if (!this.global.unlocked_bonus_cards.includes(reward.id)) {
+                    this.global.unlocked_bonus_cards.push(reward.id);
+                }
+                monthly.claimed = true;
+                this.saveGlobalData();
+                this.updateBonusPoolEditorButton();
+                this.renderMonthlyMission();
+                this.openInfoModal('월간 미션 보상', `<b>${reward.name}</b> 이(가) 보너스 카드로 해금되었습니다!`);
+            },
+
+            registerToeicPracticeAttempt(options = {}) {
+                if (options.countMonthly !== false) {
+                    this.incrementMonthlyMissionProgress('toeic3', 1);
+                }
+
+                if (options.countHiddenUnlock === false || this.state.mode === 'dream_corridor') {
+                    return false;
+                }
+
+                let unlocked = false;
+                if (this.global.tutoringEventEnabled === false) {
+                    this.global.hiddenStudyPracticeCount = (this.global.hiddenStudyPracticeCount || 0) + 1;
+                    if (!this.global.hiddenStudyReady && this.global.hiddenStudyPracticeCount >= 5) {
+                        this.global.hiddenStudyReady = true;
+                        unlocked = true;
+                    }
+                } else {
+                    this.global.hiddenStudyPracticeCount = 0;
+                }
+                this.saveGlobalData();
+                return unlocked;
+            },
+
+            clearPendingEnemySelection() {
+                this.state.pendingEnemyId = null;
+                this.state.pendingEnemyStage = null;
+            },
+
+            getEnemyDataById(id) {
+                return ENEMIES.find(enemy => enemy.id === id) || ENEMIES[0];
+            },
+
+            getCurrentStageEnemyData() {
+                if (this.state.pendingEnemyStage === this.state.enemyScale && this.state.pendingEnemyId) {
+                    return this.getEnemyDataById(this.state.pendingEnemyId);
+                }
+
+                const rotation = (typeof ENDLESS_ENEMY_ROTATION !== 'undefined' && ENDLESS_ENEMY_ROTATION.length > 0)
+                    ? ENDLESS_ENEMY_ROTATION
+                    : ENEMIES.slice(0, 6).map(enemy => enemy.id);
+                const baseId = rotation[this.state.enemyScale % rotation.length];
+                const stageNumber = this.state.enemyScale + 1;
+                const hiddenBossMap = {
+                    iris_curse: 'thor',
+                    pharaoh: 'poseidon',
+                    demon_god: 'ares'
+                };
+
+                let enemyId = baseId;
+                if (this.state.gameType === 'endless' && stageNumber > 36 && hiddenBossMap[baseId] && Math.random() < 0.3) {
+                    enemyId = hiddenBossMap[baseId];
+                }
+
+                this.state.pendingEnemyStage = this.state.enemyScale;
+                this.state.pendingEnemyId = enemyId;
+                return this.getEnemyDataById(enemyId);
+            },
+
             checkDailyChaosTicket() {
                 const today = new Date().toDateString();
                 if (this.global.lastRewardDate !== today) {
@@ -1706,7 +1949,7 @@
 
             checkAllBonusUnlocked() {
                 if (!this.global.unlocked_bonus_cards) return false;
-                return BONUS_CARDS.every(c => this.global.unlocked_bonus_cards.includes(c.id));
+                return this.getStandardBonusCards().every(c => this.global.unlocked_bonus_cards.includes(c.id));
             },
 
             getUnlockedBonusCards() {
@@ -1759,7 +2002,7 @@
             renderBonusPoolEditor() {
                 const list = document.getElementById('bonus-pool-editor-list');
                 const summary = document.getElementById('bonus-pool-editor-summary');
-                const cards = this.getUnlockedBonusCards();
+                const cards = this.sortCardDataByGrade(this.getUnlockedBonusCards());
                 const activeIds = new Set(this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds));
 
                 this.pendingActiveBonusPoolIds = [...activeIds];
@@ -1921,6 +2164,7 @@
                 }
 
                 this.loadGlobalData();
+                this.ensureMonthlyMissionState();
                 this.checkDailyChaosTicket();
 
                 if (mode === 'load') {
@@ -1936,6 +2180,8 @@
                         if (!this.state.mode) this.state.mode = 'origin';
                         if (!this.state.quiz_stats) this.state.quiz_stats = { correct: 0, total: 0 };
                         if (!this.state.artifacts) this.state.artifacts = [];
+                        if (this.state.pendingEnemyId === undefined) this.state.pendingEnemyId = null;
+                        if (this.state.pendingEnemyStage === undefined) this.state.pendingEnemyStage = null;
                         this.state.activeBonusPoolIds = this.normalizeActiveBonusPoolIds(this.state.activeBonusPoolIds);
                         this.loadStudyProgress();
 
@@ -1999,6 +2245,13 @@
                         if (m.id === 'draft') m.desc = '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
                         if (m.id === 'artifact') m.desc = '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게!\n(성공조건: 없음 / 무한)';
                     });
+                    if (this.global.hiddenStudyReady) {
+                        MODES.push({
+                            id: 'dream_corridor',
+                            name: '꿈의회랑',
+                            desc: '학습용 히든 엔드리스 모드. 전투 종료 후 퀴즈가 자동 진행되며, 오답이 나오면 해당 런이 종료됩니다.\n(개인과외 이벤트 OFF 상태의 실전마법연습 5회로 출현)'
+                        });
+                    }
                 } else if (this.tempGameType === 'challenge') {
                     MODES = MODES.filter(m => m.id !== 'origin');
                 }
@@ -2011,7 +2264,7 @@
                     btn.innerText = m.name;
                     btn.id = `mode-btn-${m.id}`;
 
-                    const isUnlocked = this.global.unlocked_modes.includes(m.id);
+                    const isUnlocked = m.id === 'dream_corridor' || this.global.unlocked_modes.includes(m.id);
                     if (isUnlocked) btn.style.color = "#e040fb"; // Purple for unlocked
 
                     btn.onclick = () => {
@@ -2072,9 +2325,17 @@
                     chaosPool: [],
                     draft: { active: false, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] },
                     artifacts: [],
+                    pendingEnemyId: null,
+                    pendingEnemyStage: null,
                     // [목적] 카오스/드래프트 모드에서 해당 런에서만 유효한 이벤트 카드 목록을 초기화
                     activeEventCards: []
                 };
+
+                if (mode === 'dream_corridor') {
+                    this.global.hiddenStudyReady = false;
+                    this.global.hiddenStudyPracticeCount = 0;
+                    this.saveGlobalData();
+                }
 
                 // Transfer Pending Transcendence to Active State (Endless Only)
                 if (this.state.gameType === 'endless') {
@@ -2111,11 +2372,11 @@
                 this.saveGame();
             },
 
-            saveGame() {
+            saveGame(showMessage = true) {
                 Storage.save(Storage.keys.SAVE, this.state);
                 this.saveStudyProgress();
                 this.saveGlobalData(); // Also save global just in case
-                this.showAlert("저장되었습니다.");
+                if (showMessage) this.showAlert("저장되었습니다.");
             },
 
             saveRecord(score = null) {
@@ -2146,8 +2407,8 @@
             toMenu() {
                 this.showScreen('screen-menu');
                 document.getElementById('ui-tickets').innerText = this.state.tickets;
-                const enemyIdx = this.state.enemyScale % ENEMIES.length;
-                const nextEnemy = ENEMIES[enemyIdx];
+                this.ensureMonthlyMissionState();
+                const nextEnemy = this.getCurrentStageEnemyData();
                 document.getElementById('next-enemy-text').innerText = `${nextEnemy.name} [Stage ${this.state.enemyScale + 1}]`;
                 const imgEl = document.getElementById('next-enemy-img');
                 imgEl.src = `${nextEnemy.name}.png`;
@@ -2192,6 +2453,9 @@
             toggleTutoringEvent() {
                 if (this.global.tutoringEventEnabled === undefined) this.global.tutoringEventEnabled = true;
                 this.global.tutoringEventEnabled = !this.global.tutoringEventEnabled;
+                if (this.global.tutoringEventEnabled) {
+                    this.global.hiddenStudyPracticeCount = 0;
+                }
                 this.saveGlobalData();
                 this.updateSystemMenuUI();
             },
@@ -2276,7 +2540,7 @@
                     return this.showAlert("현재 적용된 축복이 없습니다.");
                 }
                 let msg = "<b>현재 적용된 축복</b><br><br>";
-                this.state.chaosBuffs.forEach(b => {
+                this.sortBlessingsByGrade(this.state.chaosBuffs).forEach(b => {
                     msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}%, 치명타/회피율 증가`;
                     msg += "<br>";
                 });
@@ -2365,6 +2629,7 @@
 
                 if (this.state.activeChaosBlessing) addBuffs(this.state.activeChaosBlessing);
                 if (this.state.activeSageBlessing) addBuffs(this.state.activeSageBlessing);
+                this.state.chaosBuffs = this.sortBlessingsByGrade(this.state.chaosBuffs);
             },
 
             applyGreatSageBlessing() {
@@ -2394,8 +2659,9 @@
                     else if (c.grade === 'rare') mult = 0.3;
                     else if (c.grade === 'epic') mult = 0.2;
                     else if (c.grade === 'legend') mult = 0.1;
-                    return { id: c.id, name: c.name, multiplier: mult, isSage: true };
+                    return { id: c.id, name: c.name, grade: c.grade, multiplier: mult, isSage: true };
                 });
+                newBuffs = this.sortBlessingsByGrade(newBuffs);
 
                 // Set to activeSageBlessing (Replacing previous)
                 this.state.activeSageBlessing = newBuffs;
@@ -2433,8 +2699,9 @@
                     else if (c.grade === 'rare') mult = 0.3;
                     else if (c.grade === 'epic') mult = 0.2;
                     else if (c.grade === 'legend') mult = 0.1;
-                    return { id: c.id, name: c.name, multiplier: mult };
+                    return { id: c.id, name: c.name, grade: c.grade, multiplier: mult };
                 });
+                newBuffs = this.sortBlessingsByGrade(newBuffs);
 
                 // Set to activeChaosBlessing (Replacing previous)
                 this.state.activeChaosBlessing = newBuffs;
@@ -2708,7 +2975,8 @@
                 box.innerHTML = "";
                 let counts = {};
                 list.forEach(id => { counts[id] = (counts[id] || 0) + 1; });
-                for (let id in counts) {
+                const sortedIds = this.sortCardIdsByGrade(Object.keys(counts));
+                for (let id of sortedIds) {
                     const data = this.getCardData(id);
                     if (!data) continue;
                     const el = document.createElement('div');
@@ -3062,9 +3330,13 @@
                 if (this.state.mode === 'overdrive') {
                     reward += GAME_CONSTANTS.BONUS_REWARDS.OVERDRIVE;
                 }
+                if (this.battle.enemy && this.battle.enemy.bonusRewardTickets) {
+                    reward += this.battle.enemy.bonusRewardTickets;
+                }
 
                 this.state.tickets += reward;
                 this.state.enemyScale++;
+                this.clearPendingEnemySelection();
 
                 // Reset Chaos Blessing
                 this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
@@ -3079,6 +3351,10 @@
                 const stage = this.state.enemyScale; // current stage (already incremented)
                 const clearStage = GameUtils.getClearStage(mode, this.state.gameType);
                 const gameClear = stage >= clearStage;
+
+                if (this.state.gameType === 'endless' && stage >= 40) {
+                    this.incrementMonthlyMissionProgress('endless40', 1);
+                }
 
                 // Chaos/Draft: Reset Deck/Inventory
                 if (mode === 'chaos') {
@@ -3127,7 +3403,75 @@
                     return;
                 }
 
+                if (mode === 'dream_corridor') {
+                    this.finishDreamCorridorBattle(deadMsg);
+                    return;
+                }
+
                 this.finishWinBattle(deadMsg, gameClear, null);
+            },
+
+            finishDreamCorridorBattle(deadMsg) {
+                const stage = this.state.enemyScale;
+                const stepIndex = (stage - 1) % 6;
+                const steps = ['word', 'collocation', 'word', 'grammar', 'word', 'toeic'];
+                const step = steps[stepIndex];
+
+                const finishSuccess = (label) => {
+                    let msg = `승리!<br>${label} 성공.`;
+                    if (deadMsg) msg += `<br><br>${deadMsg}`;
+                    this.openInfoModal('꿈의회랑', msg, () => this.toMenu());
+                };
+
+                const fail = (label) => this.failDreamCorridorRun(`${label}에서 오답이 발생해 꿈의회랑이 종료되었습니다.`);
+
+                if (step === 'word') {
+                    this.startQuiz(success => {
+                        if (success) finishSuccess('단어 퀴즈');
+                        else fail('단어 퀴즈');
+                    });
+                    return;
+                }
+
+                if (step === 'collocation') {
+                    this.startCollocationQuiz(success => {
+                        if (success) finishSuccess('숙어 퀴즈');
+                        else fail('숙어 퀴즈');
+                    });
+                    return;
+                }
+
+                if (step === 'grammar') {
+                    const q = this.getRandomGrammarQuiz();
+                    if (!q) {
+                        finishSuccess('문법 퀴즈');
+                        return;
+                    }
+                    this.startGrammarQuiz(q,
+                        () => finishSuccess('문법 퀴즈'),
+                        () => fail('문법 퀴즈')
+                    );
+                    return;
+                }
+
+                this.startToeicPractice({
+                    ignoreSessionLimit: true,
+                    suppressDate: true,
+                    lockExit: true,
+                    countHiddenUnlock: false,
+                    countMonthly: false,
+                    onComplete: () => finishSuccess('실전마법연습'),
+                    onFailure: () => fail('실전마법연습')
+                });
+            },
+
+            failDreamCorridorRun(message) {
+                this.global.hiddenStudyReady = false;
+                this.global.hiddenStudyPracticeCount = 0;
+                this.saveStudyProgress();
+                this.saveGlobalData();
+                Storage.remove(Storage.keys.SAVE);
+                this.openInfoModal('꿈의회랑 종료', message, () => this.toTitle());
             },
 
             finishWinBattle(deadMsg, gameClear, quizResult) {
@@ -3157,6 +3501,10 @@
                         }
                     }
 
+                    if (this.state.gameType === 'challenge') {
+                        this.incrementMonthlyMissionProgress('challenge3', 1);
+                    }
+
                     // Transcendence Ticket Logic (On Clear)
                     if (this.state.gameType === 'challenge' || (this.state.mode !== 'origin' && this.checkAllBonusUnlocked())) {
                         this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
@@ -3172,7 +3520,7 @@
 
                     // Unlock Bonus Card
                     let newCard = null;
-                    let lockedBonus = BONUS_CARDS.filter(c => !this.global.unlocked_bonus_cards.includes(c.id));
+                    let lockedBonus = this.getStandardBonusCards().filter(c => !this.global.unlocked_bonus_cards.includes(c.id));
                     if (lockedBonus.length > 0) {
                         let pick = lockedBonus[Math.floor(Math.random() * lockedBonus.length)];
                         this.global.unlocked_bonus_cards.push(pick.id);
@@ -3348,6 +3696,14 @@
                 this.state.activeSageBlessing = [];
 
                 let deadMsg = this.handlePermadeath(this.battle.players);
+                if (this.state.mode === 'dream_corridor') {
+                    let msg = "전투에서 패배해 꿈의회랑 런이 종료되었습니다.";
+                    if (deadMsg) msg += `<br><br>${deadMsg}`;
+                    if (transMsg) msg += transMsg;
+                    this.failDreamCorridorRun(msg);
+                    return;
+                }
+
                 let msg = "패배...";
                 if (deadMsg) msg += "<br><br>" + deadMsg;
                 if (transMsg) msg += transMsg;
@@ -3355,7 +3711,7 @@
             },
 
             getEffectiveStats(char, fieldBuffs) {
-                return Logic.calculateStats(char, fieldBuffs, this.state.mode, this.state.artifacts || []);
+                return Logic.calculateStats(char, fieldBuffs, this.state.mode, this.state.artifacts || [], this.battle.turn || 1);
             },
 
             showBattleStat(side, idx) {
@@ -3371,7 +3727,7 @@
                     return `${name}(${val})`;
                 }).join(', ') || '없음';
 
-                const eff = Logic.calculateStats(char, this.battle.fieldBuffs, this.state.mode, this.state.artifacts || []);
+                const eff = Logic.calculateStats(char, this.battle.fieldBuffs, this.state.mode, this.state.artifacts || [], this.battle.turn || 1);
 
                 // Use baseStatsWithoutBlessing if available to show Green for blessed stats
                 const getBase = (key, fallback) => {
@@ -3747,48 +4103,80 @@
                 document.getElementById('modal-toeic-menu').classList.add('active');
             },
 
-            resetToeicProgress() {
+            resetToeicProgress(options = {}) {
+                const reset = () => {
+                    this.state.completedToeicSets = [];
+                    this.saveGame(false);
+                    if (!options.silent) {
+                        this.showAlert("초기화되었습니다.");
+                    }
+                };
+
+                if (options.silent) {
+                    reset();
+                    return;
+                }
+
                 this.showDoubleConfirm(
                     "모든 실전 연습 기록을 초기화하시겠습니까?",
                     "정말 초기화하시겠습니까?<br>완료한 문제 세트가 다시 등장하게 됩니다.",
-                    () => {
-                        this.state.completedToeicSets = [];
-                        this.saveGame();
-                        this.showAlert("초기화되었습니다.");
-                    }
+                    reset
                 );
             },
 
-            startToeicPractice() {
-                // Session limit: 1 time per game session
-                if (this.state.toeicPracticeDone) {
+            closeToeicPractice() {
+                const session = this.state.currentToeicSession;
+                if (session && session.options && session.options.lockExit) {
+                    return;
+                }
+                document.getElementById('modal-toeic-practice').classList.remove('active');
+            },
+
+            startToeicPractice(options = {}) {
+                const practiceOptions = {
+                    ignoreSessionLimit: false,
+                    suppressDate: false,
+                    lockExit: false,
+                    countHiddenUnlock: true,
+                    countMonthly: true,
+                    onComplete: null,
+                    onFailure: null,
+                    ...options
+                };
+
+                if (!practiceOptions.ignoreSessionLimit && this.state.toeicPracticeDone) {
                     return this.showAlert("이번 세션에서는 이미 실전 연습을 완료했습니다.\n다음 세션에서 다시 도전해주세요.");
                 }
                 if (!this.state.completedToeicSets) this.state.completedToeicSets = [];
 
-                // Filter available sets
-                const available = TOEIC_DATA.filter(set =>
+                let available = TOEIC_DATA.filter(set =>
                     !this.state.completedToeicSets.includes(set.id) &&
                     set.questions && set.questions.length > 0
                 );
 
                 if (available.length === 0) {
-                    this.showConfirm(
-                        "모든 문제를 학습했습니다!<br>기록을 초기화하고 다시 학습하시겠습니까?",
-                        () => this.resetToeicProgress(),
-                        () => { }
-                    );
-                    return;
+                    if (practiceOptions.lockExit || practiceOptions.ignoreSessionLimit) {
+                        this.resetToeicProgress({ silent: true });
+                        available = TOEIC_DATA.filter(set => set.questions && set.questions.length > 0);
+                    } else {
+                        this.showConfirm(
+                            "모든 문제를 학습했습니다!<br>기록을 초기화하고 다시 학습하시겠습니까?",
+                            () => this.resetToeicProgress(),
+                            () => { }
+                        );
+                        return;
+                    }
                 }
 
-                // Pick random set
+                if (available.length === 0) {
+                    return this.showAlert("실전 연습 데이터를 불러오지 못했습니다.");
+                }
+
+                const hiddenUnlocked = this.registerToeicPracticeAttempt(practiceOptions);
                 const set = available[Math.floor(Math.random() * available.length)];
 
-                // Build expanded question list
                 let expandedQuestions = [];
                 let expandedShuffled = [];
-
-                // All Parts: single pass (Part 5 also 3 questions only)
                 set.questions.forEach(q => {
                     expandedQuestions.push(q);
                     const opts = [...q.options];
@@ -3796,21 +4184,35 @@
                     expandedShuffled.push(opts);
                 });
 
-                // Prepare session
                 this.state.currentToeicSession = {
                     set: set,
                     qIndex: 0,
                     expandedQuestions: expandedQuestions,
                     shuffledOptions: expandedShuffled,
                     results: [],
-                    viewState: 'hub' // 'hub', 'passage', 'question'
+                    viewState: 'hub',
+                    options: practiceOptions
                 };
+
+                const exitBtn = document.getElementById('toeic-exit-btn');
+                if (exitBtn) {
+                    exitBtn.disabled = !!practiceOptions.lockExit;
+                    exitBtn.style.opacity = practiceOptions.lockExit ? '0.4' : '1';
+                    exitBtn.style.pointerEvents = practiceOptions.lockExit ? 'none' : 'auto';
+                }
 
                 document.getElementById('modal-toeic-menu').classList.remove('active');
                 document.getElementById('modal-toeic-practice').classList.add('active');
                 document.getElementById('modal-toeic-practice').classList.remove('is-review');
+                document.getElementById('modal-toeic-practice').classList.remove('is-explanation');
 
                 this.renderToeicQuestion();
+
+                if (hiddenUnlocked) {
+                    setTimeout(() => {
+                        this.showAlert("엔드리스 히든 모드 '꿈의회랑'이 출현했습니다.");
+                    }, 150);
+                }
             },
 
             renderToeicQuestion() {
@@ -3951,6 +4353,7 @@
 
             checkToeicAnswer(btn, selected, correct) {
                 const session = this.state.currentToeicSession;
+                const sessionOptions = session.options || {};
                 const opts = document.getElementById('toeic-options').children;
                 for (let c of opts) c.disabled = true;
 
@@ -3983,6 +4386,19 @@
                     }
                 }
 
+                if (!isCorrect && typeof sessionOptions.onFailure === 'function') {
+                    setTimeout(() => {
+                        session.isAnswering = false;
+                        if (backBtn) backBtn.style.pointerEvents = 'auto';
+                        document.getElementById('modal-toeic-practice').classList.remove('active');
+                        document.getElementById('modal-toeic-result').classList.remove('active');
+                        const onFailure = sessionOptions.onFailure;
+                        this.state.currentToeicSession = null;
+                        onFailure();
+                    }, 800);
+                    return;
+                }
+
                 setTimeout(() => {
                     session.isAnswering = false;
 
@@ -4007,7 +4423,9 @@
             },
 
             finishToeicSession() {
-                const set = this.state.currentToeicSession.set;
+                const session = this.state.currentToeicSession;
+                const set = session.set;
+                const sessionOptions = session.options || {};
 
                 // Mark complete
                 if (!this.state.completedToeicSets.includes(set.id)) {
@@ -4015,7 +4433,9 @@
                 }
 
                 // Mark session done (1 time per session limit)
-                this.state.toeicPracticeDone = true;
+                if (!sessionOptions.ignoreSessionLimit) {
+                    this.state.toeicPracticeDone = true;
+                }
 
                 // Reset Sage Blessing
                 this.state.greatSageBlessingUses = 3;
@@ -4029,14 +4449,32 @@
                     exitBtn.style.pointerEvents = 'none';
                 }
 
-                this.saveGame();
+                this.saveGame(false);
 
                 document.getElementById('modal-toeic-practice').classList.remove('active');
 
-                const results = this.state.currentToeicSession.results || [];
+                const results = session.results || [];
                 const correctCount = results.filter(r => r.isCorrect).length;
                 const total = results.length;
                 const wrongList = results.filter(r => !r.isCorrect);
+
+                if (sessionOptions.suppressDate) {
+                    if (exitBtn) {
+                        exitBtn.disabled = false;
+                        exitBtn.style.opacity = '1';
+                        exitBtn.style.pointerEvents = 'auto';
+                    }
+                    const onComplete = sessionOptions.onComplete;
+                    this.state.currentToeicSession = null;
+                    if (typeof onComplete === 'function') {
+                        onComplete({
+                            correctCount,
+                            total,
+                            wrongList
+                        });
+                    }
+                    return;
+                }
 
                 let msg = `수고하셨습니다!<br>'${set.title}' 학습을 완료했습니다.<br><br>`;
                 msg += `정답률: ${correctCount}/${total} (${total > 0 ? ((correctCount / total) * 100).toFixed(0) : 0}%)<br><br>`;

--- a/card/logic.js
+++ b/card/logic.js
@@ -168,6 +168,7 @@ const GAME_CONSTANTS = {
         'earth_bless': { atk: 0.25, matk: 0.25 },
         'twinkle_party': { atk: 0.2, crit: 15 },
         'star_powder': { def: 0.4, mdef: 0.4 },
+        'arena': {},
         'reaper_realm': { crit: 40 },
         'gale': { crit: 20, evasion: 20 }
     }
@@ -650,6 +651,12 @@ const DAMAGE_EFFECT_HANDLERS = {
             ctx.logFn(`덱 속성 ${count}종! 위력 +${count.toFixed(1)}배!`);
         }
     },
+    'dream_form_execute': (ctx, eff) => {
+        if (ctx.fieldBuffs.some(buff => buff.name === 'arena')) {
+            ctx.mult += 4.0;
+            ctx.logFn('[융합] 아레나가 꿈의형태에 섞여 위력이 크게 증가합니다! (+4.0배)');
+        }
+    },
     'turn_modulo_dmg': (ctx, eff) => {
         // Need current turn. ctx does not have turn.
         // Add turn to ctx in calculateDamage.
@@ -702,6 +709,19 @@ const SideEffects = {
         },
         'field_buff': (ctx, eff) => {
             ctx.applyFieldBuff(eff.id);
+        },
+        'heal_ratio': (ctx, eff) => {
+            const ratio = eff.ratio || eff.val || 0;
+            if (ratio <= 0) return;
+            const heal = Math.max(1, Math.floor(ctx.source.maxHp * ratio));
+            ctx.source.hp = Math.min(ctx.source.maxHp, ctx.source.hp + heal);
+            ctx.logFn(`HP ${heal} 회복!`);
+        },
+        'random_field_buff': (ctx, eff) => {
+            const pool = eff.pool || ['sun_bless', 'moon_bless', 'sanctuary', 'goddess_descent', 'earth_bless', 'twinkle_party', 'star_powder', 'arena'];
+            const pick = pool[Math.floor(Math.random() * pool.length)];
+            ctx.applyFieldBuff(pick);
+            ctx.logFn(`[랜덤] ${getBuffName(pick)} 부여!`);
         },
         'conditional_field_buff': (ctx, eff) => {
             if (eff.condition === 'target_has_debuff' && ctx.target.buffs[eff.debuff]) ctx.applyFieldBuff(eff.id);
@@ -773,6 +793,40 @@ const SideEffects = {
             const count = Object.keys(ctx.target.buffs).length;
             ctx.target.buffs = {};
             if (count > 0) ctx.logFn(`적의 모든 디버프를 제거했습니다! (${count}개)`);
+        },
+        'clear_self_debuffs': (ctx, eff) => {
+            const removable = ['darkness', 'corrosion', 'silence', 'curse', 'weak', 'burn', 'divine', 'stun'];
+            let removed = 0;
+            removable.forEach(id => {
+                if (ctx.source.buffs[id]) {
+                    delete ctx.source.buffs[id];
+                    removed++;
+                }
+            });
+            ctx.logFn(removed > 0 ? `자신의 디버프 ${removed}개를 해제했다!` : '해제할 디버프가 없었다.');
+        },
+        'remove_random_field_buff': (ctx, eff) => {
+            if (!ctx.battle.fieldBuffs.length) {
+                ctx.logFn('삭제할 필드버프가 없었다.');
+                return;
+            }
+            const idx = Math.floor(Math.random() * ctx.battle.fieldBuffs.length);
+            const removed = ctx.battle.fieldBuffs.splice(idx, 1)[0];
+            ctx.logFn(`필드버프 [${getBuffName(removed.name)}] 이(가) 사라졌다!`);
+        },
+        'set_self_stats': (ctx, eff) => {
+            const stats = eff.stats || {};
+            if (typeof stats.atk === 'number') ctx.source.atk = stats.atk;
+            if (typeof stats.matk === 'number') ctx.source.matk = stats.matk;
+            if (typeof stats.def === 'number') {
+                ctx.source.def = stats.def;
+                if (typeof ctx.source.baseDef === 'number') ctx.source.baseDef = stats.def;
+            }
+            if (typeof stats.mdef === 'number') {
+                ctx.source.mdef = stats.mdef;
+                if (typeof ctx.source.baseMdef === 'number') ctx.source.baseMdef = stats.mdef;
+            }
+            ctx.logFn('전투 성향이 변화했다!');
         },
         'consume_all_burn_cond_buff': (ctx, eff) => {
             if (ctx.target.buffs['burn']) {
@@ -970,7 +1024,7 @@ const SideEffects = {
 
 const Logic = {
     // 1. Stats Calculation
-    calculateStats: function (char, fieldBuffs, mode, artifacts) {
+    calculateStats: function (char, fieldBuffs, mode, artifacts, battleTurn = 1) {
         if (!artifacts) artifacts = [];
         // Base stats
         let stats = {
@@ -1016,6 +1070,16 @@ const Logic = {
             const boost = (trait.val || 0) / 100;
             m.matk += boost;
             m.mdef += boost;
+        }
+        if (trait && trait.type === 'luther_guard_mastery' && (char.buffs.barrier || char.buffs.magic_guard)) {
+            const boost = (trait.val || 0) / 100;
+            m.atk += boost;
+            m.matk += boost;
+        }
+        if (trait && trait.type === 'opening_atk_def' && battleTurn <= 3) {
+            const boost = (trait.val || 0) / 100;
+            m.atk += boost;
+            m.def += boost;
         }
 
         // Field Buffs (Only apply to Allies)
@@ -1101,12 +1165,18 @@ const Logic = {
         stats.def = Math.floor(stats.def * Math.max(0, m.def));
         stats.mdef = Math.floor(stats.mdef * Math.max(0, m.mdef));
 
+        if (char.swapAtkMatk) {
+            const nextAtk = stats.matk;
+            stats.matk = stats.atk;
+            stats.atk = nextAtk;
+        }
+
         return stats;
     },
 
     // 2. Evasion Check
-    checkEvasion: function (target, skillType, fieldBuffs, mode, artifacts) {
-        const stats = this.calculateStats(target, fieldBuffs, mode, artifacts);
+    checkEvasion: function (target, skillType, fieldBuffs, mode, artifacts, battleTurn = 1) {
+        const stats = this.calculateStats(target, fieldBuffs, mode, artifacts, battleTurn);
         return Math.random() * 100 < stats.evasion;
     },
 
@@ -1117,8 +1187,8 @@ const Logic = {
 
         if (skill.type !== 'phy' && skill.type !== 'mag') return { dmg: 0, isCrit: false };
 
-        const srcStats = this.calculateStats(source, fieldBuffs, mode, artifacts);
-        const tgtStats = this.calculateStats(target, fieldBuffs, mode, artifacts);
+        const srcStats = this.calculateStats(source, fieldBuffs, mode, artifacts, turn);
+        const tgtStats = this.calculateStats(target, fieldBuffs, mode, artifacts, turn);
 
         // 1. Critical
         let isCrit = Math.random() * 100 < srcStats.crit;
@@ -1178,6 +1248,17 @@ const Logic = {
         let mult = ctx.mult;
         let dmgBonus = 0.0;
 
+        if (skill.name === '・ｼ・・・ｵ・ｩ') {
+            if (fieldBuffs.some(buff => buff.name === 'arena')) {
+                mult *= 2.0;
+                logFn('[필드버프] 아레나: 일반공격 대미지 2배!');
+            }
+            if (source.normalAttackPartyMult && source.normalAttackPartyMult > 1) {
+                mult *= source.normalAttackPartyMult;
+                logFn(`[특성] 일반공격 강화! x${source.normalAttackPartyMult.toFixed(1)}`);
+            }
+        }
+
         // Trait Multipliers
         const t = source.proto ? source.proto.trait : null;
         if (t) {
@@ -1223,8 +1304,20 @@ const Logic = {
             }
         }
 
+        if (t && t.type === 'burn_stack_phy_pen' && skill.type === 'phy' && target.buffs['burn']) {
+            const ignoreRate = target.buffs['burn'] * (t.val || 0);
+            if (ignoreRate > 0) {
+                ctx.pendingBurnPenRate = ignoreRate;
+            }
+        }
+
         // Defense
         let def = (skill.type === 'phy') ? tgtStats.def : tgtStats.mdef;
+
+        if (ctx.pendingBurnPenRate && skill.type === 'phy') {
+            def = Math.max(0, def - Math.floor(tgtStats.def * ctx.pendingBurnPenRate));
+            logFn(`[특성] 작열 ${target.buffs['burn']}스택으로 물리방어 ${Math.round(ctx.pendingBurnPenRate * 100)}% 관통!`);
+        }
 
         if (ctx.ignoreMdefRate > 0 && skill.type === 'mag') {
             let ignore = Math.floor(tgtStats.mdef * ctx.ignoreMdefRate);
@@ -1392,6 +1485,8 @@ const Logic = {
             else if (t.type === 'syn_dark_3_matk_boost' && deckCtx.countElement('dark') >= 3) active = true;
             else if (t.type === 'syn_dark_3_party_atk' && deckCtx.countElement('dark') >= 3) active = true;
             else if (t.type === 'syn_water_2_moon_twinkle' && deckCtx.countElement('water') >= 2) active = true;
+            else if (t.type === 'syn_light_3_party_def_mdef' && deckCtx.countElement('light') >= 3) active = true;
+            else if (t.type === 'syn_dark_full_party_crit' && deckCtx.countElement('dark') >= 3) active = true;
 
             if (active) {
                 if (t.type === 'syn_nature_3_all') { p.atk *= 1.3; p.matk *= 1.3; p.def *= 1.3; p.mdef *= 1.3; }
@@ -1408,10 +1503,15 @@ const Logic = {
                 if (t.type === 'syn_water_3_atk_matk') { p.atk *= 1.5; p.matk *= 1.5; }
                 if (t.type === 'syn_fire_3_crit_burn') p.baseCrit += t.val;
                 if (t.type === 'syn_dark_3_matk_boost') p.matk *= (1 + t.val / 100);
+                if (t.type === 'syn_dark_full_party_crit') p.baseCrit += t.val;
 
                 p.atk = Math.floor(p.atk); p.matk = Math.floor(p.matk);
                 p.def = Math.floor(p.def); p.mdef = Math.floor(p.mdef);
             }
+        }
+
+        if (t.type === 'party_normal_attack_dmg' || t.type === 'reverse_atk_matk_party') {
+            active = true;
         }
 
         // Positional Traits (Generalized)
@@ -1439,7 +1539,7 @@ const Logic = {
         }
 
         // Party-wide Stat Boost Traits (Event)
-        const partyBoost = { atk: 0, matk: 0, def: 0, mdef: 0 };
+        const partyBoost = { atk: 0, matk: 0, def: 0, mdef: 0, crit: 0 };
         activeCards.forEach(c => {
             const tr = c.trait;
             if (tr && tr.type === 'party_stat_boost') {
@@ -1451,12 +1551,20 @@ const Logic = {
             else if (tr && tr.type === 'syn_dark_3_party_atk' && deckCtx.countElement('dark') >= 3) {
                 partyBoost.atk += (tr.val || 0);
             }
+            else if (tr && tr.type === 'syn_light_3_party_def_mdef' && deckCtx.countElement('light') >= 3) {
+                partyBoost.def += (tr.val || 0);
+                partyBoost.mdef += (tr.val || 0);
+            }
+            else if (tr && tr.type === 'syn_dark_full_party_crit' && deckCtx.countElement('dark') >= 3) {
+                partyBoost.crit += (tr.val || 0);
+            }
         });
 
         if (partyBoost.atk) p.atk = Math.floor(p.atk * (1 + partyBoost.atk / 100));
         if (partyBoost.matk) p.matk = Math.floor(p.matk * (1 + partyBoost.matk / 100));
         if (partyBoost.def) p.def = Math.floor(p.def * (1 + partyBoost.def / 100));
         if (partyBoost.mdef) p.mdef = Math.floor(p.mdef * (1 + partyBoost.mdef / 100));
+        if (partyBoost.crit) p.baseCrit += partyBoost.crit;
 
         // Artifact: dragon_heart — dragon cards matk +100%
         const artifacts = (typeof RPG !== 'undefined' && RPG.state && RPG.state.artifacts) ? RPG.state.artifacts : [];
@@ -1495,6 +1603,36 @@ const Logic = {
         else if (enemy.id === 'demon_god') {
             if (turn === 7 || turn === 14) skill = enemy.skills.find(s => s.name === '제노사이드');
             else if (r < 0.2) skill = enemy.skills.find(s => s.name === '다크니스');
+        }
+        else if (enemy.id === 'thor') {
+            if (turn === 10) skill = enemy.skills.find(s => s.name === '썬더러쉬');
+            else if (r < 0.2) skill = enemy.skills.find(s => s.name === '묠니르');
+        }
+        else if (enemy.id === 'poseidon') {
+            if (turn === 5) skill = enemy.skills.find(s => s.name === '어비스블레싱');
+            else if (turn === 10) skill = enemy.skills.find(s => s.name === '어비스프레셔');
+            else if (turn === 15) skill = enemy.skills.find(s => s.name === '디바우러');
+            else if (r < 0.2) skill = enemy.skills.find(s => s.name === '트라이던트');
+        }
+        else if (enemy.id === 'ares') {
+            if (enemy.isCharging && enemy.chargeSkillId) {
+                const chargedSkill = enemy.skills.find(s => s.name === enemy.chargeSkillId);
+                return chargedSkill ? { ...chargedSkill, chargeReset: true } : { type: 'phy', val: 1.0, name: '・ｼ・・・ｵ・ｩ' };
+            }
+            if (turn === 3 || turn === 8) {
+                const chargeSkillId = Math.random() < 0.5 ? '테라소드' : '마그마이럽션';
+                enemy.chargeSkillId = chargeSkillId;
+                return {
+                    type: 'sup',
+                    val: 0,
+                    name: `${chargeSkillId} 차징`,
+                    isChargeStart: true,
+                    chargeMessage: chargeSkillId === '테라소드'
+                        ? '아레스가 테라소드의 힘을 끌어모읍니다...'
+                        : '아레스가 마그마이럽션의 화염을 응축합니다...'
+                };
+            }
+            if (r < 0.2) skill = enemy.skills.find(s => s.name === '스피어레인');
         }
         else if (enemy.id === 'creator_god') {
             if (enemy.isCharging) {


### PR DESCRIPTION
## Summary
- add the hidden endless study flow, monthly mission UI/rewards, and hidden boss runtime support
- add the new bonus/hidden bonus cards and fix Doom/Ember Tiger card data
- sort card/blessing displays by grade and wire the TOEIC hidden-mode fail flow

## Testing
- npm run verify