### PR TITLE
Fix normal attack name checks for Arena and party trait multipliers

### DIFF
--- a/card/logic.js
+++ b/card/logic.js
@@ -1248,7 +1248,7 @@ const Logic = {
         let mult = ctx.mult;
         let dmgBonus = 0.0;
 
-        if (skill.name === '・ｼ・・・ｵ・ｩ') {
+        if (skill.name === '일반 공격') {
             if (fieldBuffs.some(buff => buff.name === 'arena')) {
                 mult *= 2.0;
                 logFn('[필드버프] 아레나: 일반공격 대미지 2배!');
@@ -1617,7 +1617,7 @@ const Logic = {
         else if (enemy.id === 'ares') {
             if (enemy.isCharging && enemy.chargeSkillId) {
                 const chargedSkill = enemy.skills.find(s => s.name === enemy.chargeSkillId);
-                return chargedSkill ? { ...chargedSkill, chargeReset: true } : { type: 'phy', val: 1.0, name: '・ｼ・・・ｵ・ｩ' };
+                return chargedSkill ? { ...chargedSkill, chargeReset: true } : { type: 'phy', val: 1.0, name: '일반 공격' };
             }
             if (turn === 3 || turn === 8) {
                 const chargeSkillId = Math.random() < 0.5 ? '테라소드' : '마그마이럽션';


### PR DESCRIPTION
### Motivation
- Fix a broken normal-attack name check so Arena field buff and `party_normal_attack_dmg` trait multipliers apply correctly to normal attacks.

### Description
- Replace the corrupted literal previously checked in `card/logic.js` with the actual emitted attack name `일반 공격` in the damage multiplier block.
- Update Ares charge fallback to return a normal-attack action with name `일반 공격` when no charged skill is found, keeping behavior consistent.

### Testing
- Ran `npm run verify` (which runs lint and `test:smoke`) and it completed successfully.
- `Card smoke verification passed.` and `Idle hero smoke verification passed.` were observed during the verify run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56181d26c83228a85f6324880fde4)