### PR TITLE
card: unify enemy-turn defense calculation with Logic.calculateStats

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -343,23 +343,14 @@ const BattleRuntime = {
             if (enemy.buffs.weak && skill.type === 'phy') val *= 0.8;
             if (enemy.buffs.silence && skill.type === 'mag') val *= 0.8;
 
-            let def = skill.type === 'phy' ? target.def : target.mdef;
-            let fieldDef = 1.0;
-            battle.fieldBuffs.forEach(fieldBuff => {
-                if (fieldBuff.name === 'star_powder') fieldDef += 0.3;
-                if (fieldBuff.name === 'sanctuary' && skill.type === 'mag') fieldDef += 0.25;
-                if (fieldBuff.name === 'goddess_descent') fieldDef += 0.3;
-            });
-
-            let defMult = 1.0;
-            if (skill.type === 'phy') {
-                if (target.buffs.darkness && target.buffs.corrosion) defMult = 0.6;
-                else if (target.buffs.darkness || target.buffs.corrosion) defMult = 0.8;
-            } else if (target.buffs.curse) {
-                defMult = 0.8;
-            }
-
-            def = Math.floor(def * fieldDef * defMult);
+            const tgtStats = Logic.calculateStats(
+                target,
+                battle.fieldBuffs,
+                rpg.state.mode,
+                rpg.state.artifacts || [],
+                battle.turn
+            );
+            const def = skill.type === 'phy' ? tgtStats.def : tgtStats.mdef;
 
             if (Logic.checkEvasion(target, skill.type, battle.fieldBuffs, rpg.state.mode, rpg.state.artifacts || [], battle.turn)) {
                 rpg.log(`${target.name} 회피 성공! (${skill.name} 회피)`);


### PR DESCRIPTION
### Motivation
- The enemy-turn path computed target defense manually in `card/battle_runtime.js`, which diverged from the centralized stat pipeline in `Logic.calculateStats`, causing inconsistent trait/artifact/field behavior.
- This divergence caused concrete miscounts for effects like `cond_earth_def_mdef`, `cond_sun_matk_mdef`, and `shadow_stab` where DEF/MDEF or debuffs were not applied on incoming enemy attacks.
- The intent of the change is to remove the dual calculation paths and ensure all incoming damage uses the same stat resolution so traits, artifacts, field buffs, and mode multipliers are applied consistently.

### Description
- Replaced the manual defense block in `BattleRuntime.TurnManager.startEnemyTurn` with a call to `Logic.calculateStats(...)` and read `def`/`mdef` from the returned `tgtStats`.
- Removed ad-hoc `fieldDef`/`defMult` scaling logic and now rely on `Logic.calculateStats` to incorporate field buffs, mode, artifacts, traits, and debuffs.
- Preserved separate special-case handling for `evasion`, `barrier`, `magic_guard`, and `guard` so their short-circuit behaviors remain unchanged.
- Change scope is limited to `card/battle_runtime.js` and aims to be the minimal fix to unify defense calculation paths.

### Testing
- Ran `npm run verify` which performed lint checks and smoke tests, and the run passed successfully.
- Linting (syntax checks) for relevant files and smoke verification (`scripts/verify_card_smoke.js` and `scripts/verify_idle_hero_smoke.js`) succeeded.
- Note: exhaustive combinatorial gameplay/balance scenarios were not exhaustively tested; only automated lint and smoke tests were run, so full end-to-end balance verification remains unverified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5ceee7cac832283c9186996f7aa0f)