### PR TITLE
젤리피쉬 프린세스 특성명 변경 및 비스택 디버프 표기 수정

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -17,7 +17,15 @@ function applyStackMap(rpg, target, buffMap) {
     Object.keys(buffMap).forEach(buffId => {
         const cap = getStackCap(rpg, buffId);
         const nextValue = (target.buffs[buffId] || 0) + buffMap[buffId];
-        target.buffs[buffId] = cap === null ? nextValue : Math.min(nextValue, cap);
+
+        if (cap === null) {
+            // Non-stack debuffs/buffs are represented as presence flags.
+            target.buffs[buffId] = buffMap[buffId] > 0 ? 1 : 0;
+            if (target.buffs[buffId] <= 0) delete target.buffs[buffId];
+            return;
+        }
+
+        target.buffs[buffId] = Math.min(nextValue, cap);
     });
 }
 

--- a/card/data.js
+++ b/card/data.js
@@ -657,7 +657,7 @@ const BONUS_CARDS = [
     {
         id: 'jellyfish_princess', name: '젤리피쉬프린세스', grade: 'epic', element: 'water', role: 'debuffer',
         stats: { hp: 410, atk: 80, matk: 85, def: 75, mdef: 70 },
-        trait: { type: 'on_hit_random_debuff', pool: ['corrosion', 'weak', 'silence', 'curse', 'stun'], desc: '피격 시 부식/약화/침묵/저주/기절 중 랜덤 부여' },
+        trait: { type: 'on_hit_random_debuff', pool: ['corrosion', 'weak', 'silence', 'curse', 'stun'], desc: '해파리독: 피격 시 부식/약화/침묵/저주/기절 중 랜덤 부여' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
             { name: '오로라텐타클', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '약화 혹은 부식 부여', effects: [{ type: 'random_debuff', count: 1, pool: ['weak', 'corrosion'] }] },

--- a/card/logic.js
+++ b/card/logic.js
@@ -1813,7 +1813,7 @@ const Logic = {
             const pick = t.pool[Math.floor(Math.random() * t.pool.length)];
             const stack = t.stack || 1;
             result.attackerDebuffs[pick] = (result.attackerDebuffs[pick] || 0) + stack;
-            logFn(`[특성] ${victim.name}: 피격 반응! 적에게 [${getBuffName(pick)}] ${stack > 1 ? `${stack}스택 ` : ''}부여.`);
+            logFn(`[특성] ${victim.name} 해파리독! 적에게 [${getBuffName(pick)}] ${stack > 1 ? `${stack}스택 ` : ''}부여.`);
         }
 
         return result;


### PR DESCRIPTION
### Motivation
- 젤리피쉬 프린세스 특성명을 요청대로 `해파리독`으로 노출하고자 했습니다.
- 피격으로 부여되는 일부 디버프(부식, 약화 등)가 스택형이 아님에도 스택처럼 보이는 UI/로그 혼동을 제거하기 위함입니다.

### Description
- `card/data.js`에서 `jellyfish_princess`의 `trait.desc`를 `해파리독: ...`으로 변경했습니다.
- `card/logic.js`의 피격 특성 로그를 `handleOnHitTraits`의 출력문에 `해파리독` 명칭으로 수정했습니다.
- `card/battle_runtime.js`의 `applyStackMap`를 변경하여 `getStackCap`이 `null`을 반환하는(스택 비해당) 버프/디버프는 존재 여부(1)로만 표시하고 0이하면 삭제되도록 처리하고, 스택형(예: `burn`, `divine`)은 기존 제한 로직을 유지하도록 했습니다.

### Testing
- 실행한 자동화 검증: `npm run verify`이 성공했습니다 (lint 검사 통과 및 `node scripts/verify_card_smoke.js` / `node scripts/verify_idle_hero_smoke.js` 스모크 테스트 통과).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c648400c148322bdee18b94e839460)