### PR TITLE
Add bonus-transcendence pool and three cards; adjust endless transcendence spawn weights

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -378,6 +378,10 @@ const BattleRuntime = {
 
             let dmg = val * mult * (100 / (100 + def));
             if (target.buffs.guard) dmg *= 0.5;
+            if (target.buffs.absolute_armor) {
+                dmg *= 0.5;
+                rpg.log(`${target.name} 앱솔루트아머로 피해 감소!`);
+            }
             dmg = Math.floor(dmg);
             target.hp -= dmg;
             if (dmg > 0) {
@@ -419,6 +423,14 @@ const BattleRuntime = {
         },
 
         endEnemyTurn(rpg) {
+            rpg.battle.players.forEach(player => {
+                if (!player || player.isDead || !player.buffs.absolute_armor) return;
+                player.buffs.absolute_armor--;
+                if (player.buffs.absolute_armor <= 0) {
+                    delete player.buffs.absolute_armor;
+                    rpg.log(`${player.name}의 앱솔루트아머 효과가 종료되었습니다.`);
+                }
+            });
             rpg.battle.turn++;
             rpg.battle.enemy.tookDamageThisTurn = false;
             rpg.battle.isNewTurn = true;
@@ -516,6 +528,16 @@ const BattleRuntime = {
             const burnAdd = rpg.hasArtifact('over_flame') ? 2 : 1;
             target.buffs.burn = Math.min((target.buffs.burn || 0) + burnAdd, getStackCap(rpg, 'burn'));
             rpg.log("[특성] 피닉스: 일반 공격 시 작열 부여!");
+        }
+
+        if (
+            source.proto &&
+            source.proto.trait &&
+            source.proto.trait.type === 'guard_stun_double_dmg' &&
+            skill.name === '가드'
+        ) {
+            target.buffs.stun = 1;
+            rpg.log("[특성] 해신포세이돈: 가드와 동시에 적에게 [기절] 부여!");
         }
 
         if (source.proto && source.proto.trait && source.proto.trait.type === 'behemoth_trait' && Math.random() < 0.2) {

--- a/card/data.js
+++ b/card/data.js
@@ -1028,6 +1028,36 @@ const TRANSCENDENCE_CARDS = [
             { name: '코스믹하모니', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '랜덤 필드버프 생성 (태양/달/스타파우더)', effects: [{ type: 'random_field_buff_lumi' }] },
             { name: '꿈의형태', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '모든 버프를 제거하고 꿈의마법발동.', effects: [{ type: 'dream_form_execute' }] }
         ]
+    },
+    {
+        id: 'trans_thor', name: '뇌신토르', grade: 'transcendence', element: 'light', role: 'dealer', unlockSource: 'bonus_transcendence',
+        stats: { hp: 530, atk: 110, matk: 150, def: 65, mdef: 85 },
+        trait: { type: 'cond_sanctuary_atk_def', val: 100, desc: '성역 상태에서 물리공격력, 방어력 100% 증가' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '묠니르', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '디바인 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'divine', count: 1, mult: 2.0 }] },
+            { name: '썬더러쉬', type: 'mag', tier: 3, cost: 30, val: 4.0, desc: '사용 후 3턴 뒤에 4~8배율 마법공격, 적에게 디바인 1스택 부여', effects: [{ type: 'delayed_random_attack', turns: 3, min: 4.0, max: 8.0 }, { type: 'debuff', id: 'divine', stack: 1 }] }
+        ]
+    },
+    {
+        id: 'trans_ares', name: '투신아레스', grade: 'transcendence', element: 'fire', role: 'dealer', unlockSource: 'bonus_transcendence',
+        stats: { hp: 560, atk: 130, matk: 100, def: 85, mdef: 75 },
+        trait: { type: 'syn_fire_3_atk_boost', val: 100, desc: '덱에 불 3장 이상 시 공격력 100% 증가' },
+        skills: [
+            { name: '앱솔루트아머', type: 'sup', tier: 3, cost: 30, desc: '3턴간 받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'absolute_armor', duration: 3 }] },
+            { name: '테라소드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '필드버프 아레나, 트윙클파티 발동', effects: [{ type: 'field_buff', id: 'arena' }, { type: 'field_buff', id: 'twinkle_party' }] },
+            { name: '마그마이럽션', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열을 전부 소모하고, 소모한 작열 1스택당 배율 2.5 증가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.5 }] }
+        ]
+    },
+    {
+        id: 'trans_poseidon', name: '해신포세이돈', grade: 'transcendence', element: 'water', role: 'balancer', unlockSource: 'bonus_transcendence',
+        stats: { hp: 550, atk: 115, matk: 140, def: 80, mdef: 95 },
+        trait: { type: 'guard_stun_double_dmg', val: 2.0, desc: '가드 사용 시 적에게 기절 부여 / 기절 상태의 적에게 대미지 2배' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '트라이던트', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '전투 시작 후 5턴 이내일 때 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'turn_lte', turn: 5, mult: 2.0 }] },
+            { name: '어비스프레셔', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프 1개를 제거하고 대미지 2배', effects: [{ type: 'remove_field_buff_dmg', mult: 2.0 }] }
+        ]
     }
 ];
 
@@ -1067,7 +1097,7 @@ ENEMIES.push(
 const BUFF_NAMES = {
     'darkness': '암흑', 'corrosion': '부식', 'silence': '침묵', 'curse': '저주', 'weak': '약화',
     'burn': '작열', 'divine': '디바인', 'stun': '기절', 'evasion': '회피', 'barrier': '배리어',
-    'magic_guard': '매직가드', 'guard': '가드',
+    'magic_guard': '매직가드', 'guard': '가드', 'absolute_armor': '앱솔루트아머',
     'defProtocolPhy': '방어프로토콜(물리)', 'defProtocolMag': '방어프로토콜(마법)',
     'sun_bless': '태양의축복', 'moon_bless': '달의축복', 'sanctuary': '성역',
     'goddess_descent': '여신강림', 'destiny_oath': '운명의서약', 'earth_bless': '대지의축복', 'twinkle_party': '트윙클파티',

--- a/card/index.html
+++ b/card/index.html
@@ -1623,6 +1623,7 @@
                 chaosTickets: 0,
                 lastRewardDate: null,
                 pendingTranscendenceCards: [],
+                bonusTranscendenceUnlocked: false,
                 tutoringEventEnabled: true,
                 hiddenStudyReady: false,
                 hiddenStudyPracticeCount: 0,
@@ -1728,6 +1729,42 @@
 
             getHiddenBonusCards() {
                 return BONUS_CARDS.filter(card => card.unlockSource === 'hidden');
+            },
+
+            getCardAppearanceWeight(card) {
+                if (!card) return 1;
+                if (this.state.gameType === 'endless' && (this.state.mode === 'chaos' || this.state.mode === 'draft') && card.grade === 'transcendence') {
+                    return 0.5;
+                }
+                return 1;
+            },
+
+            pickWeightedCard(pool) {
+                if (!Array.isArray(pool) || pool.length === 0) return null;
+                const weighted = pool.map(card => ({ card, weight: this.getCardAppearanceWeight(card) })).filter(item => item.weight > 0);
+                if (weighted.length === 0) return pool[Math.floor(Math.random() * pool.length)];
+                const totalWeight = weighted.reduce((sum, item) => sum + item.weight, 0);
+                let r = Math.random() * totalWeight;
+                for (const item of weighted) {
+                    r -= item.weight;
+                    if (r <= 0) return item.card;
+                }
+                return weighted[weighted.length - 1].card;
+            },
+
+            pickWeightedUniqueCards(pool, count) {
+                if (!Array.isArray(pool) || pool.length === 0 || count <= 0) return [];
+                const source = [...pool];
+                const picks = [];
+                const pickCount = Math.min(count, source.length);
+                for (let i = 0; i < pickCount; i++) {
+                    const picked = this.pickWeightedCard(source);
+                    if (!picked) break;
+                    picks.push(picked);
+                    const idx = source.findIndex(card => card.id === picked.id);
+                    if (idx !== -1) source.splice(idx, 1);
+                }
+                return picks;
             },
 
             getGradeSortValue(grade) {
@@ -2355,8 +2392,7 @@
                         activeEventCards: this.state.activeEventCards
                     });
 
-                    allCards.sort(() => Math.random() - 0.5);
-                    const picks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
+                    const picks = this.pickWeightedUniqueCards(allCards, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
 
                     this.state.chaosPool = picks;
                     this.state.inventory = [...picks];
@@ -2484,9 +2520,17 @@
             spinChaosRoulette() {
                 if ((this.global.chaosTickets || 0) < 1) return this.showAlert("티켓이 부족합니다.");
 
-                let pool = TRANSCENDENCE_CARDS.filter(c => !this.global.pendingTranscendenceCards.includes(c.id));
+                let pool = TRANSCENDENCE_CARDS.filter(c =>
+                    !this.global.pendingTranscendenceCards.includes(c.id) &&
+                    (c.unlockSource !== 'bonus_transcendence' || this.global.bonusTranscendenceUnlocked)
+                );
 
-                if (pool.length === 0) return this.showAlert("이미 모든 초월 카드를 보유하고 있습니다. (다음 오리진 게임에서 사용하세요)");
+                if (pool.length === 0) {
+                    if (!this.global.bonusTranscendenceUnlocked) {
+                        return this.showAlert("기본 초월 카드를 모두 보유 중입니다. 보너스초월은 난입 보스 승리 시 10% 확률로 해금됩니다.");
+                    }
+                    return this.showAlert("이미 모든 초월 카드를 보유하고 있습니다. (다음 오리진 게임에서 사용하세요)");
+                }
 
                 this.global.chaosTickets--;
                 const pick = pool[Math.floor(Math.random() * pool.length)];
@@ -2737,8 +2781,7 @@
                             activeEventCards: this.state.activeEventCards
                         });
 
-                        allCards.sort(() => Math.random() - 0.5);
-                        const newPicks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
+                        const newPicks = this.pickWeightedUniqueCards(allCards, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
 
                         this.state.chaosPool = newPicks;
                         this.state.inventory = [...newPicks];
@@ -3228,7 +3271,7 @@
 
                 let options = [];
                 for (let i = 0; i < 4; i++) {
-                    const pick = pool[Math.floor(Math.random() * pool.length)];
+                    const pick = this.pickWeightedCard(pool);
                     options.push(pick.id);
                 }
                 this.state.draft.currentOptions = options;
@@ -3338,6 +3381,18 @@
                 this.state.enemyScale++;
                 this.clearPendingEnemySelection();
 
+                const raidBossIds = ['thor', 'ares', 'poseidon'];
+                const bossUnlockSucceeded =
+                    !this.global.bonusTranscendenceUnlocked &&
+                    this.battle.enemy &&
+                    raidBossIds.includes(this.battle.enemy.id) &&
+                    Math.random() < 0.1;
+                if (bossUnlockSucceeded) {
+                    this.global.bonusTranscendenceUnlocked = true;
+                    this.saveGlobalData();
+                    this.log("<b>[해금]</b> 보너스초월 풀이 해금되었습니다! 이제 카오스 룰렛에서 등장합니다.");
+                }
+
                 // Reset Chaos Blessing
                 this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
                 this.state.chaosBuffs = [];
@@ -3368,9 +3423,7 @@
                         // [목적] 전투 승리 후 카오스 풀 초기화 시 획득한 이벤트 카드를 포함
                         activeEventCards: this.state.activeEventCards
                     });
-                    allCards.sort(() => Math.random() - 0.5);
-
-                    const nextPicks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
+                    const nextPicks = this.pickWeightedUniqueCards(allCards, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
                     this.state.chaosPool = nextPicks;
                     this.state.inventory = [...nextPicks];
                 }

--- a/card/logic.js
+++ b/card/logic.js
@@ -537,6 +537,11 @@ const DAMAGE_EFFECT_HANDLERS = {
             ctx.mult *= eff.mult;
             matched = true;
         }
+        else if (eff.condition === 'turn_lte' && ctx.turn && ctx.turn <= (eff.turn || 1)) {
+            ctx.mult *= eff.mult;
+            matched = true;
+            if (!eff.customLog) ctx.logFn(`[효과] ${eff.turn}턴 이내 조건 충족! 위력 ${eff.mult}배!`);
+        }
         else if (eff.condition === 'target_element') {
             const elements = eff.elements || (eff.element ? [eff.element] : []);
             if (elements.includes(ctx.target.element)) {
@@ -1081,6 +1086,11 @@ const Logic = {
             m.atk += boost;
             m.def += boost;
         }
+        if (trait && trait.type === 'cond_sanctuary_atk_def' && fieldBuffs.some(b => b.name === 'sanctuary')) {
+            const boost = (trait.val || 0) / 100;
+            m.atk += boost;
+            m.def += boost;
+        }
 
         // Field Buffs (Only apply to Allies)
         if (isPlayer) {
@@ -1301,6 +1311,10 @@ const Logic = {
             if (t.type === 'behemoth_liberated_trait' && Object.keys(target.buffs).length >= 3) {
                 dmgBonus += (t.val - 1.0);
                 logFn("[특성] 해방된 베히모스: 디버프 3개 이상! 파괴적 일격!");
+            }
+            if (t.type === 'guard_stun_double_dmg' && target.buffs.stun) {
+                dmgBonus += (t.val - 1.0);
+                logFn("[특성] 해신포세이돈: 기절 대상 추가 피해!");
             }
         }
 


### PR DESCRIPTION
### Motivation
- Introduce a new "보너스초월" (bonus transcendence) pool and three new transcendence cards unlocked via raid boss wins. 
- Ensure these new cards' traits and skills interact correctly with existing combat systems (delayed attacks, field buffs, stack consumption, guard interactions). 
- Reduce frequency of transcendence card appearances in Endless (`chaos`/`draft`) runs by applying a 0.5 weight for transcendence grade in Endless pool generation. 

### Description
- Added three transcendence cards (`trans_thor`, `trans_ares`, `trans_poseidon`) to `card/data.js` with the requested stats, traits, skills, and `unlockSource: 'bonus_transcendence'`. 
- Implemented new effect/trait handling in `card/logic.js`, including a `turn_lte` damage condition, support for `cond_sanctuary_atk_def` trait, and damage bonus for `guard_stun_double_dmg` when target is stunned. 
- Implemented runtime behavior in `card/battle_runtime.js` for `absolute_armor` (3-turn 50% damage reduction with per-turn decrement and logs) and made `poseidon`-style trait cause a stun when using `가드`. 
- Added global unlock state and pool-selection logic in `card/index.html`: `bonusTranscendenceUnlocked`, 10% chance to unlock the bonus pool on defeating raid bosses (`thor`, `ares`, `poseidon`), and gacha/roulette filtering so bonus transcendence cards only appear after unlock. 
- Added weighted selection utilities `pickWeightedCard` and `pickWeightedUniqueCards` (used by chaos pool generation, shuffle, draft options) and applied a `0.5` weight to transcendence cards when `gameType === 'endless'` and `mode` is `chaos` or `draft`. 

### Testing
- Ran `npm run verify` (per project requirement), which runs lint and smoke tests; the command completed successfully and both `Card smoke verification` and `Idle hero smoke verification` passed. 
- No browser visual/manual checks were performed in this environment, so UI/visual behaviors (modals, roulette visuals, and on-screen messages) remain unverified visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a707dbe883228a4fb5dbfb53a08f)