### PR TITLE
card: replay bonus transcendence patch on latest main

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -29,6 +29,20 @@ function applyStackMap(rpg, target, buffMap) {
     });
 }
 
+const TURN_BUFF_IDS = ['evasion', 'barrier', 'magic_guard', 'guard'];
+
+function tickTurnBuffs(target, buffIds = TURN_BUFF_IDS) {
+    if (!target || !target.buffs) return;
+
+    buffIds.forEach(buffId => {
+        const duration = target.buffs[buffId];
+        if (!duration) return;
+
+        if (duration > 1) target.buffs[buffId] = duration - 1;
+        else delete target.buffs[buffId];
+    });
+}
+
 function buildBattleEnemy(rpg) {
     const baseEnemy = rpg.getCurrentStageEnemyData
         ? rpg.getCurrentStageEnemyData()
@@ -57,7 +71,8 @@ function buildBattleEnemy(rpg) {
         tookDamageThisTurn: false,
         lastHitType: null,
         isHiddenBoss: !!baseEnemy.hiddenBossFor,
-        bonusRewardTickets: baseEnemy.hiddenBossFor ? 3 : 0
+        bonusRewardTickets: baseEnemy.hiddenBossFor ? 3 : 0,
+        bonusTranscendenceReward: baseEnemy.bonusTranscendenceReward || null
     };
 
     if (baseEnemy.id === 'creator_god') {
@@ -253,7 +268,7 @@ const BattleRuntime = {
                 }
             }
 
-            ['evasion', 'barrier', 'magic_guard', 'guard'].forEach(buffId => delete player.buffs[buffId]);
+            tickTurnBuffs(player);
 
             rpg.renderBattleView();
 
@@ -282,6 +297,7 @@ const BattleRuntime = {
             rpg.log("--- 적 턴 ---");
             enemy.def = enemy.baseDef;
             enemy.mdef = enemy.baseMdef;
+            tickTurnBuffs(enemy);
 
             if (enemy.id === 'artificial_demon_god') {
                 delete enemy.buffs.defProtocolPhy;
@@ -642,6 +658,16 @@ const BattleRuntime = {
                 SideEffects.apply(ctx, effect);
             }
         });
+
+        if (
+            source.proto &&
+            source.proto.trait &&
+            source.proto.trait.type === 'guard_stun_double_dmg' &&
+            skill.effects.some(effect => effect.type === 'buff' && effect.id === 'guard')
+        ) {
+            target.buffs.stun = 1;
+            rpg.log(`[특성] ${source.name}: 가드 사용으로 적을 기절시켰다!`);
+        }
 
         if (rpg.battle.activeTraits.includes('syn_water_nature') && skill.name === '문라이트세레나') {
             rpg.log("루미의 특성 발동! 트윙클파티 추가!");

--- a/card/data.js
+++ b/card/data.js
@@ -1031,9 +1031,58 @@ const TRANSCENDENCE_CARDS = [
     }
 ];
 
+const BONUS_TRANSCENDENCE_CARDS = [
+    {
+        id: 'trans_thor', name: '뇌신토르', grade: 'transcendence', element: 'light', role: 'dealer',
+        stats: { hp: 530, atk: 110, matk: 150, def: 65, mdef: 85 },
+        trait: {
+            type: 'cond_sanctuary_atk_def',
+            val: 100,
+            desc: '성역 상태에서 물리공격력, 방어력 100% 증가'
+        },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '묠니르', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '디바인 1스택 소모하여 대미지 2배', effects: [{ type: 'consume_debuff_fixed', debuff: 'divine', count: 1, mult: 2.0 }] },
+            {
+                name: '썬더러쉬', type: 'mag', tier: 3, cost: 30, val: 4.0,
+                desc: '사용 후 3턴 뒤에 4~8배율 마법공격, 적에게 디바인 1스택 부여',
+                effects: [{ type: 'delayed_random_attack', turns: 3, min: 4.0, max: 8.0 }, { type: 'debuff', id: 'divine', stack: 1 }]
+            }
+        ]
+    },
+    {
+        id: 'trans_ares', name: '투신아레스', grade: 'transcendence', element: 'fire', role: 'dealer',
+        stats: { hp: 560, atk: 130, matk: 100, def: 85, mdef: 75 },
+        trait: {
+            type: 'syn_fire_3_atk_boost',
+            val: 100,
+            desc: '덱에 불 3장 이상 시 공격력 100% 증가'
+        },
+        skills: [
+            { name: '앱솔루트아머', type: 'sup', tier: 3, cost: 30, desc: '3턴간 받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 3 }] },
+            { name: '테라소드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '필드버프 아레나, 트윙클파티 발동', effects: [{ type: 'field_buff', id: 'arena' }, { type: 'field_buff', id: 'twinkle_party' }] },
+            { name: '마그마이럽션', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열을 전부 소모하고, 소모한 작열 1스택당 배율 2.5 증가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.5 }] }
+        ]
+    },
+    {
+        id: 'trans_poseidon', name: '해신포세이돈', grade: 'transcendence', element: 'water', role: 'balancer',
+        stats: { hp: 550, atk: 115, matk: 140, def: 80, mdef: 95 },
+        trait: {
+            type: 'guard_stun_double_dmg',
+            val: 2.0,
+            desc: '가드 사용 시 적에게 기절 부여 / 기절 상태의 적에게 대미지 2배'
+        },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '트라이던트', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '전투 시작 후 5턴 이내일 때 대미지 2배', effects: [{ type: 'dmg_boost_turn_limit', maxTurn: 5, mult: 2.0 }] },
+            { name: '어비스프레셔', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프 1개를 제거하고 대미지 2배', effects: [{ type: 'remove_field_buff_dmg', mult: 2.0 }] }
+        ]
+    }
+];
+
 ENEMIES.push(
     {
-        id: 'thor', name: '뇌신 토르', element: 'light', hiddenBossFor: 'iris_curse',
+        id: 'thor', name: '뇌신 토르', element: 'light', hiddenBossFor: 'iris_curse', bonusTranscendenceReward: 'trans_thor',
         stats: { hp: 900, atk: 100, matk: 50, def: 100, mdef: 50 },
         skills: [
             { name: '묠니르', type: 'mag', rate: 0.2, val: 2.0, desc: '마법공격 2배율', effects: [] },
@@ -1044,7 +1093,7 @@ ENEMIES.push(
         ]
     },
     {
-        id: 'poseidon', name: '해신 포세이돈', element: 'water', hiddenBossFor: 'pharaoh',
+        id: 'poseidon', name: '해신 포세이돈', element: 'water', hiddenBossFor: 'pharaoh', bonusTranscendenceReward: 'trans_poseidon',
         stats: { hp: 1100, atk: 100, matk: 80, def: 80, mdef: 100 },
         skills: [
             { name: '트라이던트', type: 'phy', rate: 0.2, val: 2.0, desc: '물리공격 2배율', effects: [] },
@@ -1054,7 +1103,7 @@ ENEMIES.push(
         ]
     },
     {
-        id: 'ares', name: '투신 아레스', element: 'fire', hiddenBossFor: 'demon_god',
+        id: 'ares', name: '투신 아레스', element: 'fire', hiddenBossFor: 'demon_god', bonusTranscendenceReward: 'trans_ares',
         stats: { hp: 1500, atk: 120, matk: 120, def: 100, mdef: 100 },
         skills: [
             { name: '스피어레인', type: 'mag', rate: 0.2, val: 2.0, desc: '마법공격 2배율', effects: [] },

--- a/card/index.html
+++ b/card/index.html
@@ -504,6 +504,43 @@
             color: #ddd;
         }
 
+        .bonus-preset-row {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 8px;
+            margin: 0 0 10px 0;
+        }
+
+        .bonus-preset-btn {
+            padding: 8px 6px;
+            border: 1px solid #4fc3f7;
+            border-radius: 8px;
+            background: #17202a;
+            color: #b3e5fc;
+            cursor: pointer;
+            font-size: 0.82rem;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .bonus-preset-btn span {
+            font-size: 0.72rem;
+            color: #81d4fa;
+        }
+
+        .bonus-preset-btn.is-active {
+            border-color: #ffd54f;
+            background: #3a2f12;
+            color: #fff8e1;
+        }
+
+        .bonus-preset-btn.is-active span {
+            color: #ffe082;
+        }
+
         .title-loading {
             width: 100%;
             max-width: 320px;
@@ -912,7 +949,9 @@
             <p style="font-size:0.85rem; color:#aaa; margin:0 0 6px 0;">
                 기본 카드는 항상 포함됩니다. 체크된 보너스 카드는 이번 런의 랜덤 풀에서 비활성화됩니다.
             </p>
-            <p id="bonus-pool-editor-summary" style="font-size:0.8rem; color:#81d4fa; margin:0 0 8px 0;">활성 0 / 0</p>
+            <p id="bonus-pool-editor-summary" style="font-size:0.8rem; color:#81d4fa; margin:0 0 8px 0;">세팅 1 · 활성 0 / 0</p>
+            <div id="bonus-pool-preset-list" class="bonus-preset-row"></div>
+            <p id="bonus-pool-preset-status" style="font-size:0.78rem; color:#b3e5fc; margin:0 0 8px 0;">다음 런 적용 세팅: 1</p>
             <div id="bonus-pool-editor-list" class="modal-scroll"></div>
             <button class="menu-btn" onclick="RPG.enableAllBonusPoolCards()"
                 style="margin-bottom:8px; border-color:#66bb6a; color:#66bb6a;">모두 활성화</button>
@@ -1619,10 +1658,13 @@
             global: {
                 unlocked_modes: ['origin'],
                 unlocked_bonus_cards: [],
+                unlocked_bonus_transcendence_cards: [],
                 achievements: { origin: false },
                 chaosTickets: 0,
                 lastRewardDate: null,
                 pendingTranscendenceCards: [],
+                bonusPoolPresets: [null, null, null],
+                activeBonusPoolPresetIndex: 0,
                 tutoringEventEnabled: true,
                 hiddenStudyReady: false,
                 hiddenStudyPracticeCount: 0,
@@ -1717,6 +1759,7 @@
                 if (data) {
                     this.global = { ...this.global, ...data };
                 }
+                this.ensureBonusPoolPresetState();
             },
             saveGlobalData() {
                 Storage.save(Storage.keys.GLOBAL, this.global);
@@ -1957,6 +2000,14 @@
                 return BONUS_CARDS.filter(card => unlocked.has(card.id));
             },
 
+            getUnlockedBonusTranscendenceCards() {
+                const unlocked = new Set(this.global.unlocked_bonus_transcendence_cards || []);
+                const bonusTranscendenceCards = typeof BONUS_TRANSCENDENCE_CARDS !== 'undefined'
+                    ? BONUS_TRANSCENDENCE_CARDS
+                    : [];
+                return bonusTranscendenceCards.filter(card => unlocked.has(card.id));
+            },
+
             normalizeActiveBonusPoolIds(ids) {
                 const unlockedIds = this.getUnlockedBonusCards().map(card => card.id);
                 if (unlockedIds.length === 0) return [];
@@ -1970,8 +2021,147 @@
                 return normalized;
             },
 
+            ensureBonusPoolPresetState() {
+                const maxPresets = GAME_CONSTANTS.MAX_BONUS_POOL_PRESETS || 3;
+                const presets = Array.isArray(this.global.bonusPoolPresets)
+                    ? this.global.bonusPoolPresets.slice(0, maxPresets)
+                    : [];
+
+                while (presets.length < maxPresets) {
+                    presets.push(null);
+                }
+
+                this.global.bonusPoolPresets = presets.map(preset => {
+                    if (!Array.isArray(preset)) return null;
+                    const deduped = [];
+                    preset.forEach(id => {
+                        if (!deduped.includes(id)) deduped.push(id);
+                    });
+                    return deduped;
+                });
+
+                const activeIndex = Number.isInteger(this.global.activeBonusPoolPresetIndex)
+                    ? this.global.activeBonusPoolPresetIndex
+                    : 0;
+                this.global.activeBonusPoolPresetIndex = Math.min(maxPresets - 1, Math.max(0, activeIndex));
+
+                if (!Array.isArray(this.global.unlocked_bonus_transcendence_cards)) {
+                    this.global.unlocked_bonus_transcendence_cards = [];
+                }
+            },
+
+            getActiveBonusPoolPresetIndex() {
+                this.ensureBonusPoolPresetState();
+                return this.global.activeBonusPoolPresetIndex;
+            },
+
+            getBonusPoolPresetIds(index = this.getActiveBonusPoolPresetIndex()) {
+                this.ensureBonusPoolPresetState();
+                return this.normalizeActiveBonusPoolIds(this.global.bonusPoolPresets[index]);
+            },
+
+            syncPendingActiveBonusPoolIds() {
+                this.pendingActiveBonusPoolIds = [...this.getBonusPoolPresetIds()];
+            },
+
+            persistPendingActiveBonusPoolIds() {
+                this.ensureBonusPoolPresetState();
+                const activeIndex = this.getActiveBonusPoolPresetIndex();
+                const normalizedIds = this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds);
+                this.global.bonusPoolPresets[activeIndex] = [...normalizedIds];
+                this.pendingActiveBonusPoolIds = [...normalizedIds];
+                this.saveGlobalData();
+            },
+
+            selectBonusPoolPreset(index) {
+                this.ensureBonusPoolPresetState();
+                if (index < 0 || index >= this.global.bonusPoolPresets.length) return;
+
+                this.global.activeBonusPoolPresetIndex = index;
+                this.syncPendingActiveBonusPoolIds();
+                this.saveGlobalData();
+                this.renderBonusPoolEditor();
+                this.updateBonusPoolEditorButton();
+            },
+
+            renderBonusPoolPresetButtons() {
+                const container = document.getElementById('bonus-pool-preset-list');
+                if (!container) return;
+
+                this.ensureBonusPoolPresetState();
+                const activeIndex = this.getActiveBonusPoolPresetIndex();
+                const total = this.getUnlockedBonusCards().length;
+                container.innerHTML = '';
+
+                this.global.bonusPoolPresets.forEach((preset, index) => {
+                    const btn = document.createElement('button');
+                    const activeCount = this.getBonusPoolPresetIds(index).length;
+                    btn.type = 'button';
+                    btn.className = `bonus-preset-btn${index === activeIndex ? ' is-active' : ''}`;
+                    btn.innerHTML = `세팅 ${index + 1}<span>${activeCount}/${total}</span>`;
+                    btn.onclick = () => this.selectBonusPoolPreset(index);
+                    container.appendChild(btn);
+                });
+            },
+
+            buildChaosRoulettePool() {
+                return GameUtils.buildTranscendencePool(this.global, {
+                    excludeIds: this.global.pendingTranscendenceCards || []
+                });
+            },
+
+            tryUnlockBonusTranscendence() {
+                const enemy = this.battle ? this.battle.enemy : null;
+                const rewardId = enemy ? enemy.bonusTranscendenceReward : null;
+                if (!rewardId) return '';
+
+                this.ensureBonusPoolPresetState();
+                if (this.global.unlocked_bonus_transcendence_cards.includes(rewardId)) return '';
+                if (Math.random() >= 0.1) return '';
+
+                this.global.unlocked_bonus_transcendence_cards.push(rewardId);
+                this.saveGlobalData();
+
+                const unlockedCard = this.getCardData(rewardId);
+                if (!unlockedCard) return '<b>[보너스초월]</b> 새로운 초월 카드가 카오스 룰렛에 추가되었습니다!';
+                return `<b>[보너스초월]</b> ${unlockedCard.name}이(가) 카오스 룰렛에 해금되었습니다!`;
+            },
+
+            isWeightedTranscendenceRunMode() {
+                return this.state.gameType === 'endless' && ['chaos', 'draft'].includes(this.state.mode);
+            },
+
+            drawRunPoolCards(pool, count, options = {}) {
+                if (!Array.isArray(pool) || pool.length === 0 || count <= 0) return [];
+
+                if (this.isWeightedTranscendenceRunMode()) {
+                    return GameUtils.drawWeightedCards(
+                        pool,
+                        count,
+                        card => (card.grade === 'transcendence' ? 0.5 : 1.0),
+                        options
+                    );
+                }
+
+                if (options.allowDuplicates) {
+                    const picks = [];
+                    for (let i = 0; i < count; i++) {
+                        picks.push(pool[Math.floor(Math.random() * pool.length)]);
+                    }
+                    return picks;
+                }
+
+                return [...pool]
+                    .sort(() => Math.random() - 0.5)
+                    .slice(0, count);
+            },
+
+            buildChaosPoolCardIds(pool) {
+                return this.drawRunPoolCards(pool, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(card => card.id);
+            },
+
             resetPendingActiveBonusPoolIds() {
-                this.pendingActiveBonusPoolIds = this.normalizeActiveBonusPoolIds();
+                this.syncPendingActiveBonusPoolIds();
                 this.updateBonusPoolEditorButton();
             },
 
@@ -1979,8 +2169,10 @@
                 const btn = document.getElementById('btn-bonus-pool-editor');
                 if (!btn) return;
 
+                this.ensureBonusPoolPresetState();
                 const total = this.getUnlockedBonusCards().length;
-                const active = this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds).length;
+                const active = this.getBonusPoolPresetIds().length;
+                const presetNo = this.getActiveBonusPoolPresetIndex() + 1;
                 const subText = total > 0
                     ? `이번 런 활성 ${active}/${total}장`
                     : '해금된 보너스 카드가 아직 없습니다';
@@ -2062,12 +2254,106 @@
                 this.updateBonusPoolEditorButton();
             },
 
+            updateBonusPoolEditorButton() {
+                const btn = document.getElementById('btn-bonus-pool-editor');
+                if (!btn) return;
+
+                this.ensureBonusPoolPresetState();
+                const total = this.getUnlockedBonusCards().length;
+                const active = this.getBonusPoolPresetIds().length;
+                const presetNo = this.getActiveBonusPoolPresetIndex() + 1;
+                const subText = total > 0
+                    ? `세팅 ${presetNo} 적용중 · 활성 ${active}/${total}`
+                    : '해금된 보너스 카드가 없습니다';
+
+                btn.innerHTML = `덱 편집<br><span style="font-size:0.8rem; color:#b3e5fc;">${subText}</span>`;
+            },
+
+            openBonusPoolEditor() {
+                this.syncPendingActiveBonusPoolIds();
+                this.renderBonusPoolEditor();
+                document.getElementById('modal-bonus-pool-editor').classList.add('active');
+            },
+
+            renderBonusPoolEditor() {
+                const list = document.getElementById('bonus-pool-editor-list');
+                const summary = document.getElementById('bonus-pool-editor-summary');
+                const presetStatus = document.getElementById('bonus-pool-preset-status');
+                const cards = this.sortCardDataByGrade(this.getUnlockedBonusCards());
+                const activeIds = new Set(this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds));
+                const activePresetIndex = this.getActiveBonusPoolPresetIndex();
+
+                this.pendingActiveBonusPoolIds = [...activeIds];
+                this.renderBonusPoolPresetButtons();
+                list.innerHTML = "";
+
+                if (presetStatus) {
+                    presetStatus.innerText = `다음 런 적용 세팅: ${activePresetIndex + 1}`;
+                }
+
+                if (cards.length === 0) {
+                    summary.innerText = '해금된 보너스 카드가 없습니다.';
+                    list.innerHTML = '<div style="padding:12px; border:1px solid #444; border-radius:8px; background:#2a2a2a; color:#aaa; font-size:0.85rem;">아직 해금된 보너스 카드가 없습니다.</div>';
+                    return;
+                }
+
+                summary.innerText = `세팅 ${activePresetIndex + 1} · 활성 ${activeIds.size} / ${cards.length}`;
+
+                const grid = document.createElement('div');
+                grid.className = 'bonus-pool-grid';
+
+                cards.forEach(card => {
+                    const isActive = activeIds.has(card.id);
+                    const item = document.createElement('label');
+                    item.className = `bonus-pool-item${isActive ? '' : ' is-disabled'}`;
+                    item.innerHTML = `
+                        <div class="portrait"><img src="${card.name}.png" onerror="this.style.display='none'"></div>
+                        <div class="bonus-pool-name">${card.name}</div>
+                        <div class="bonus-pool-grade">${card.grade.toUpperCase()} / ${card.role}</div>
+                        <div class="bonus-pool-toggle">
+                            <input type="checkbox" ${isActive ? 'checked' : ''}>
+                            <span>사용</span>
+                        </div>
+                    `;
+
+                    const checkbox = item.querySelector('input');
+                    checkbox.addEventListener('change', () => {
+                        this.setPendingBonusCardActive(card.id, checkbox.checked);
+                    });
+
+                    grid.appendChild(item);
+                });
+
+                list.appendChild(grid);
+            },
+
+            setPendingBonusCardActive(cardId, isActive) {
+                let ids = this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds);
+                if (isActive) {
+                    if (!ids.includes(cardId)) ids.push(cardId);
+                } else {
+                    ids = ids.filter(id => id !== cardId);
+                }
+                this.pendingActiveBonusPoolIds = ids;
+                this.persistPendingActiveBonusPoolIds();
+                this.renderBonusPoolEditor();
+                this.updateBonusPoolEditorButton();
+            },
+
+            enableAllBonusPoolCards() {
+                this.pendingActiveBonusPoolIds = this.normalizeActiveBonusPoolIds();
+                this.persistPendingActiveBonusPoolIds();
+                this.renderBonusPoolEditor();
+                this.updateBonusPoolEditorButton();
+            },
+
             getMissingRequiredData() {
                 const requiredData = [
                     { name: 'CARDS', ref: typeof CARDS !== 'undefined' ? CARDS : null },
                     { name: 'ENEMIES', ref: typeof ENEMIES !== 'undefined' ? ENEMIES : null },
                     { name: 'BONUS_CARDS', ref: typeof BONUS_CARDS !== 'undefined' ? BONUS_CARDS : null },
                     { name: 'TRANSCENDENCE_CARDS', ref: typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS : null },
+                    { name: 'BONUS_TRANSCENDENCE_CARDS', ref: typeof BONUS_TRANSCENDENCE_CARDS !== 'undefined' ? BONUS_TRANSCENDENCE_CARDS : null },
                     { name: 'VOCAB_DATA', ref: typeof VOCAB_DATA !== 'undefined' ? VOCAB_DATA : null },
                     { name: 'COLLOCATION_DATA', ref: typeof COLLOCATION_DATA !== 'undefined' ? COLLOCATION_DATA : null },
                     { name: 'GRAMMAR_DATA', ref: typeof GRAMMAR_DATA !== 'undefined' ? GRAMMAR_DATA : null },
@@ -2355,8 +2641,7 @@
                         activeEventCards: this.state.activeEventCards
                     });
 
-                    allCards.sort(() => Math.random() - 0.5);
-                    const picks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
+                    const picks = this.buildChaosPoolCardIds(allCards);
 
                     this.state.chaosPool = picks;
                     this.state.inventory = [...picks];
@@ -2484,7 +2769,7 @@
             spinChaosRoulette() {
                 if ((this.global.chaosTickets || 0) < 1) return this.showAlert("티켓이 부족합니다.");
 
-                let pool = TRANSCENDENCE_CARDS.filter(c => !this.global.pendingTranscendenceCards.includes(c.id));
+                let pool = this.buildChaosRoulettePool();
 
                 if (pool.length === 0) return this.showAlert("이미 모든 초월 카드를 보유하고 있습니다. (다음 오리진 게임에서 사용하세요)");
 
@@ -2737,8 +3022,7 @@
                             activeEventCards: this.state.activeEventCards
                         });
 
-                        allCards.sort(() => Math.random() - 0.5);
-                        const newPicks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
+                        const newPicks = this.buildChaosPoolCardIds(allCards);
 
                         this.state.chaosPool = newPicks;
                         this.state.inventory = [...newPicks];
@@ -3226,11 +3510,7 @@
                     activeEventCards: this.state.activeEventCards
                 });
 
-                let options = [];
-                for (let i = 0; i < 4; i++) {
-                    const pick = pool[Math.floor(Math.random() * pool.length)];
-                    options.push(pick.id);
-                }
+                const options = this.drawRunPoolCards(pool, 4, { allowDuplicates: true }).map(card => card.id);
                 this.state.draft.currentOptions = options;
             },
 
@@ -3337,6 +3617,10 @@
                 this.state.tickets += reward;
                 this.state.enemyScale++;
                 this.clearPendingEnemySelection();
+                const bonusTransUnlockMsg = this.tryUnlockBonusTranscendence();
+                if (bonusTransUnlockMsg) {
+                    deadMsg = deadMsg ? `${deadMsg}<br>${bonusTransUnlockMsg}` : bonusTransUnlockMsg;
+                }
 
                 // Reset Chaos Blessing
                 this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
@@ -3368,9 +3652,7 @@
                         // [목적] 전투 승리 후 카오스 풀 초기화 시 획득한 이벤트 카드를 포함
                         activeEventCards: this.state.activeEventCards
                     });
-                    allCards.sort(() => Math.random() - 0.5);
-
-                    const nextPicks = allCards.slice(0, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(c => c.id);
+                    const nextPicks = this.buildChaosPoolCardIds(allCards);
                     this.state.chaosPool = nextPicks;
                     this.state.inventory = [...nextPicks];
                 }

--- a/card/logic.js
+++ b/card/logic.js
@@ -103,6 +103,7 @@ const GAME_CONSTANTS = {
     MAX_ARTIFACTS: 4,
     SAGE_BLESSING_PICK_COUNT: 12,
     DEFAULT_BLESSING_USES: 3,
+    MAX_BONUS_POOL_PRESETS: 3,
 
     // Costs
     COSTS: {
@@ -232,6 +233,77 @@ const ARTIFACT_LIST = [
 // ─── Game Utilities ───────────────────────────────────────────────────────────
 
 const GameUtils = {
+    getAllTranscendenceCards() {
+        return [
+            ...(typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS : []),
+            ...(typeof BONUS_TRANSCENDENCE_CARDS !== 'undefined' ? BONUS_TRANSCENDENCE_CARDS : [])
+        ];
+    },
+
+    getUnlockedBonusTranscendenceCards(globalData) {
+        const unlocked = new Set(
+            globalData && Array.isArray(globalData.unlocked_bonus_transcendence_cards)
+                ? globalData.unlocked_bonus_transcendence_cards
+                : []
+        );
+        return (typeof BONUS_TRANSCENDENCE_CARDS !== 'undefined' ? BONUS_TRANSCENDENCE_CARDS : [])
+            .filter(card => unlocked.has(card.id));
+    },
+
+    buildTranscendencePool(globalData, options = {}) {
+        let pool = [...(typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS : [])];
+
+        if (options.includeUnlockedBonus !== false) {
+            pool = pool.concat(this.getUnlockedBonusTranscendenceCards(globalData));
+        }
+
+        if (Array.isArray(options.excludeIds) && options.excludeIds.length > 0) {
+            const excluded = new Set(options.excludeIds);
+            pool = pool.filter(card => !excluded.has(card.id));
+        }
+
+        return pool;
+    },
+
+    drawWeightedCards(pool, count, weightFn = () => 1, options = {}) {
+        if (!Array.isArray(pool) || pool.length === 0 || count <= 0) return [];
+
+        const allowDuplicates = !!options.allowDuplicates;
+        const source = allowDuplicates ? pool : [...pool];
+        const picks = [];
+
+        while (picks.length < count && source.length > 0) {
+            const totalWeight = source.reduce((sum, card) => {
+                const weight = Number(weightFn(card));
+                return sum + (Number.isFinite(weight) && weight > 0 ? weight : 0);
+            }, 0);
+
+            if (totalWeight <= 0) break;
+
+            let roll = Math.random() * totalWeight;
+            let pickedIndex = source.length - 1;
+
+            for (let i = 0; i < source.length; i++) {
+                const weight = Number(weightFn(source[i]));
+                const safeWeight = Number.isFinite(weight) && weight > 0 ? weight : 0;
+                roll -= safeWeight;
+                if (roll < 0) {
+                    pickedIndex = i;
+                    break;
+                }
+            }
+
+            const pickedCard = source[pickedIndex];
+            picks.push(pickedCard);
+
+            if (!allowDuplicates) {
+                source.splice(pickedIndex, 1);
+            }
+        }
+
+        return picks;
+    },
+
     /**
      * Get all collectible cards in lookup order.
      * @returns {Array}
@@ -240,7 +312,7 @@ const GameUtils = {
         return [
             ...CARDS,
             ...BONUS_CARDS,
-            ...(typeof TRANSCENDENCE_CARDS !== 'undefined' ? TRANSCENDENCE_CARDS : [])
+            ...this.getAllTranscendenceCards()
         ];
     },
 
@@ -335,7 +407,7 @@ const GameUtils = {
 
         // Add transcendence cards if requested
         if (options.includeTranscendence && options.activeTranscendenceCards && options.activeTranscendenceCards.length > 0) {
-            const transObjs = TRANSCENDENCE_CARDS.filter(c => options.activeTranscendenceCards.includes(c.id));
+            const transObjs = this.getAllTranscendenceCards().filter(c => options.activeTranscendenceCards.includes(c.id));
             pool = pool.concat(transObjs);
         }
 
@@ -673,6 +745,18 @@ const DAMAGE_EFFECT_HANDLERS = {
         }
     }
 };
+
+const DAMAGE_EFFECT_HANDLERS_EXTRA = {
+    'dmg_boost_turn_limit': (ctx, eff) => {
+        const maxTurn = eff.maxTurn || eff.turn || 0;
+        if (ctx.turn && maxTurn > 0 && ctx.turn <= maxTurn) {
+            ctx.mult *= eff.mult;
+            ctx.logFn(`[孖ｹ・ｱ] ${maxTurn}奓ｴ ・､﨑・ ・・･ ${eff.mult}・ｰ!`);
+        }
+    }
+};
+
+Object.assign(DAMAGE_EFFECT_HANDLERS, DAMAGE_EFFECT_HANDLERS_EXTRA);
 
 const SideEffects = {
     handlers: {
@@ -1081,6 +1165,11 @@ const Logic = {
             m.atk += boost;
             m.def += boost;
         }
+        if (trait && trait.type === 'cond_sanctuary_atk_def' && fieldBuffs.some(b => b.name === 'sanctuary')) {
+            const boost = (trait.val || 0) / 100;
+            m.atk += boost;
+            m.def += boost;
+        }
 
         // Field Buffs (Only apply to Allies)
         if (isPlayer) {
@@ -1304,6 +1393,11 @@ const Logic = {
             }
         }
 
+        if (t && t.type === 'guard_stun_double_dmg' && target.buffs['stun']) {
+            dmgBonus += (t.val - 1.0);
+            logFn("[孖ｹ・ｱ] ・ｰ・・ ・・乱・・・・ｸ・ 2・ｰ!");
+        }
+
         if (t && t.type === 'burn_stack_phy_pen' && skill.type === 'phy' && target.buffs['burn']) {
             const ignoreRate = target.buffs['burn'] * (t.val || 0);
             if (ignoreRate > 0) {
@@ -1482,6 +1576,7 @@ const Logic = {
             else if (t.type === 'syn_silver_rabbit' && deckCtx.hasAnyCard(['snow_rabbit', 'night_rabbit'])) active = true;
             else if (t.type === 'syn_water_3_atk_matk' && deckCtx.countElement('water') >= 3) active = true;
             else if (t.type === 'syn_fire_3_crit_burn' && deckCtx.countElement('fire') >= 3) active = true;
+            else if (t.type === 'syn_fire_3_atk_boost' && deckCtx.countElement('fire') >= 3) active = true;
             else if (t.type === 'syn_dark_3_matk_boost' && deckCtx.countElement('dark') >= 3) active = true;
             else if (t.type === 'syn_dark_3_party_atk' && deckCtx.countElement('dark') >= 3) active = true;
             else if (t.type === 'syn_water_2_moon_twinkle' && deckCtx.countElement('water') >= 2) active = true;
@@ -1502,6 +1597,7 @@ const Logic = {
                 if (t.type === 'syn_silver_rabbit') { p.atk *= 1.5; p.matk *= 1.5; }
                 if (t.type === 'syn_water_3_atk_matk') { p.atk *= 1.5; p.matk *= 1.5; }
                 if (t.type === 'syn_fire_3_crit_burn') p.baseCrit += t.val;
+                if (t.type === 'syn_fire_3_atk_boost') p.atk *= (1 + t.val / 100);
                 if (t.type === 'syn_dark_3_matk_boost') p.matk *= (1 + t.val / 100);
                 if (t.type === 'syn_dark_full_party_crit') p.baseCrit += t.val;
 

--- a/scripts/verify_card_smoke.js
+++ b/scripts/verify_card_smoke.js
@@ -22,13 +22,35 @@ function run() {
     'openToeicReview()',
     'id="btn-bonus-pool-editor"',
     'id="modal-bonus-pool-editor"',
+    'id="bonus-pool-preset-list"',
     'pendingActiveBonusPoolIds:',
     'activeBonusPoolIds: this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds)',
-    'openBonusPoolEditor()'
+    'openBonusPoolEditor()',
+    'bonusPoolPresets:',
+    'activeBonusPoolPresetIndex:',
+    'buildChaosRoulettePool()',
+    'buildChaosPoolCardIds(pool)',
+    'drawRunPoolCards(pool, count, options = {})'
   ]);
 
-  mustContain(path.join(cardRoot, 'logic.js'), ['const Storage', 'activeBonusPoolIds']);
-  mustContain(path.join(cardRoot, 'data.js'), ['const CARDS']);
+  mustContain(path.join(cardRoot, 'logic.js'), [
+    'const Storage',
+    'activeBonusPoolIds',
+    'MAX_BONUS_POOL_PRESETS',
+    'buildTranscendencePool(globalData, options = {})',
+    'drawWeightedCards(pool, count, weightFn = () => 1, options = {})',
+    'dmg_boost_turn_limit'
+  ]);
+  mustContain(path.join(cardRoot, 'data.js'), [
+    'const CARDS',
+    'const BONUS_TRANSCENDENCE_CARDS = [',
+    "id: 'trans_thor'",
+    "id: 'trans_ares'",
+    "id: 'trans_poseidon'",
+    "bonusTranscendenceReward: 'trans_thor'",
+    "bonusTranscendenceReward: 'trans_ares'",
+    "bonusTranscendenceReward: 'trans_poseidon'"
+  ]);
   mustContain(path.join(cardRoot, 'toeic.js'), ['const TOEIC_DATA']);
 
   console.log('Card smoke verification passed.');


### PR DESCRIPTION
## Summary
- replay yesterday's bonus transcendence card patch on top of the latest main
- keep the bonus transcendence pool, unlock/roulette logic, transcendence weight updates, and bonus card preset support
- include the existing verification smoke updates for the new behavior

## Verification
- npm run verify