### PR TITLE
Fix penetration stacking; make Phoenix burn unconditional; add Weak to Cure Master Meltdown

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -545,8 +545,7 @@ const BattleRuntime = {
             skill.name === rpg.NORMAL_ATTACK.name &&
             source.proto &&
             source.proto.trait &&
-            source.proto.trait.type === 'syn_fire_3_crit_burn' &&
-            rpg.battle.activeTraits.includes('syn_fire_3_crit_burn')
+            source.proto.trait.type === 'syn_fire_3_crit_burn'
         ) {
             const burnAdd = rpg.hasArtifact('over_flame') ? 2 : 1;
             target.buffs.burn = Math.min((target.buffs.burn || 0) + burnAdd, getStackCap(rpg, 'burn'));

--- a/card/data.js
+++ b/card/data.js
@@ -817,7 +817,7 @@ const BONUS_CARD_EXPANSION = [
         trait: { type: 'cure_master_trait', val: 30, desc: '덱에 물 3장 이상 시 마법방어력 50% 증가 / 일반 공격 혹은 피격 시 확률로 스턴 부여' },
         skills: [
             { name: '레모네이드', type: 'sup', tier: 3, cost: 30, desc: '필드버프 스타파우더 부여, 3턴간 받는 대미지 50% 감소', effects: [{ type: 'field_buff', id: 'star_powder' }, { type: 'buff', id: 'guard', duration: 3 }] },
-            { name: '멜트다운', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 기절 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 2.0 }] },
+            { name: '멜트다운', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 약화 부여, 기절 상태의 적에게 대미지 2배', effects: [{ type: 'debuff', id: 'weak' }, { type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 2.0 }] },
             { name: '굿나잇키스', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '마법 2배율, 10의 배수 턴에 대미지 5배', effects: [{ type: 'turn_modulo_dmg', mod: 10, mult: 5.0 }] }
         ]
     },

--- a/card/logic.js
+++ b/card/logic.js
@@ -1418,15 +1418,17 @@ const Logic = {
         }
 
         // Defense
+        const rawDef = Math.max(0, target.def || 0);
+        const rawMdef = Math.max(0, target.mdef || 0);
         let def = (skill.type === 'phy') ? tgtStats.def : tgtStats.mdef;
 
         if (ctx.pendingBurnPenRate && skill.type === 'phy') {
-            def = Math.max(0, def - Math.floor(tgtStats.def * ctx.pendingBurnPenRate));
+            def = Math.max(0, def - Math.floor(rawDef * ctx.pendingBurnPenRate));
             logFn(`[특성] 작열 ${target.buffs['burn']}스택으로 물리방어 ${Math.round(ctx.pendingBurnPenRate * 100)}% 관통!`);
         }
 
         if (ctx.ignoreMdefRate > 0 && skill.type === 'mag') {
-            let ignore = Math.floor(tgtStats.mdef * ctx.ignoreMdefRate);
+            let ignore = Math.floor(rawMdef * ctx.ignoreMdefRate);
             def = Math.max(0, def - ignore);
             logFn(`[효과] 마법방어력 ${Math.round(ctx.ignoreMdefRate * 100)}% 관통!`);
         }
@@ -1434,7 +1436,7 @@ const Logic = {
         // Artifact: flame_piercing — burn stacks x 10% physical defense penetration
         if (artifacts.includes('flame_piercing') && skill.type === 'phy' && target.buffs['burn']) {
             let burnPen = target.buffs['burn'] * 0.1;
-            let ignore = Math.floor(tgtStats.def * burnPen);
+            let ignore = Math.floor(rawDef * burnPen);
             def = Math.max(0, def - ignore);
             logFn(`[아티팩트] 플레임피어싱: 작열 ${target.buffs['burn']}스택! 방어력 ${Math.round(burnPen * 100)}% 관통!`);
         }
@@ -1442,7 +1444,7 @@ const Logic = {
         // Artifact: divine_piercing — divine stacks x 10% magic defense penetration
         if (artifacts.includes('divine_piercing') && skill.type === 'mag' && target.buffs['divine']) {
             let divinePen = target.buffs['divine'] * 0.1;
-            let ignore = Math.floor(tgtStats.mdef * divinePen);
+            let ignore = Math.floor(rawMdef * divinePen);
             def = Math.max(0, def - ignore);
             logFn(`[아티팩트] 디바인피어싱: 디바인 ${target.buffs['divine']}스택! 마법방어력 ${Math.round(divinePen * 100)}% 관통!`);
         }

--- a/card_remaster/battle_runtime.js
+++ b/card_remaster/battle_runtime.js
@@ -545,8 +545,7 @@ const BattleRuntime = {
             skill.name === rpg.NORMAL_ATTACK.name &&
             source.proto &&
             source.proto.trait &&
-            source.proto.trait.type === 'syn_fire_3_crit_burn' &&
-            rpg.battle.activeTraits.includes('syn_fire_3_crit_burn')
+            source.proto.trait.type === 'syn_fire_3_crit_burn'
         ) {
             const burnAdd = rpg.hasArtifact('over_flame') ? 2 : 1;
             target.buffs.burn = Math.min((target.buffs.burn || 0) + burnAdd, getStackCap(rpg, 'burn'));

--- a/card_remaster/data.js
+++ b/card_remaster/data.js
@@ -817,7 +817,7 @@ const BONUS_CARD_EXPANSION = [
         trait: { type: 'cure_master_trait', val: 30, desc: '덱에 물 3장 이상 시 마법방어력 50% 증가 / 일반 공격 혹은 피격 시 확률로 스턴 부여' },
         skills: [
             { name: '레모네이드', type: 'sup', tier: 3, cost: 30, desc: '필드버프 스타파우더 부여, 3턴간 받는 대미지 50% 감소', effects: [{ type: 'field_buff', id: 'star_powder' }, { type: 'buff', id: 'guard', duration: 3 }] },
-            { name: '멜트다운', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 기절 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 2.0 }] },
+            { name: '멜트다운', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 약화 부여, 기절 상태의 적에게 대미지 2배', effects: [{ type: 'debuff', id: 'weak' }, { type: 'dmg_boost', condition: 'target_debuff', debuff: 'stun', mult: 2.0 }] },
             { name: '굿나잇키스', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '마법 2배율, 10의 배수 턴에 대미지 5배', effects: [{ type: 'turn_modulo_dmg', mod: 10, mult: 5.0 }] }
         ]
     },

--- a/card_remaster/logic.js
+++ b/card_remaster/logic.js
@@ -1418,15 +1418,17 @@ const Logic = {
         }
 
         // Defense
+        const rawDef = Math.max(0, target.def || 0);
+        const rawMdef = Math.max(0, target.mdef || 0);
         let def = (skill.type === 'phy') ? tgtStats.def : tgtStats.mdef;
 
         if (ctx.pendingBurnPenRate && skill.type === 'phy') {
-            def = Math.max(0, def - Math.floor(tgtStats.def * ctx.pendingBurnPenRate));
+            def = Math.max(0, def - Math.floor(rawDef * ctx.pendingBurnPenRate));
             logFn(`[특성] 작열 ${target.buffs['burn']}스택으로 물리방어 ${Math.round(ctx.pendingBurnPenRate * 100)}% 관통!`);
         }
 
         if (ctx.ignoreMdefRate > 0 && skill.type === 'mag') {
-            let ignore = Math.floor(tgtStats.mdef * ctx.ignoreMdefRate);
+            let ignore = Math.floor(rawMdef * ctx.ignoreMdefRate);
             def = Math.max(0, def - ignore);
             logFn(`[효과] 마법방어력 ${Math.round(ctx.ignoreMdefRate * 100)}% 관통!`);
         }
@@ -1434,7 +1436,7 @@ const Logic = {
         // Artifact: flame_piercing — burn stacks x 10% physical defense penetration
         if (artifacts.includes('flame_piercing') && skill.type === 'phy' && target.buffs['burn']) {
             let burnPen = target.buffs['burn'] * 0.1;
-            let ignore = Math.floor(tgtStats.def * burnPen);
+            let ignore = Math.floor(rawDef * burnPen);
             def = Math.max(0, def - ignore);
             logFn(`[아티팩트] 플레임피어싱: 작열 ${target.buffs['burn']}스택! 방어력 ${Math.round(burnPen * 100)}% 관통!`);
         }
@@ -1442,7 +1444,7 @@ const Logic = {
         // Artifact: divine_piercing — divine stacks x 10% magic defense penetration
         if (artifacts.includes('divine_piercing') && skill.type === 'mag' && target.buffs['divine']) {
             let divinePen = target.buffs['divine'] * 0.1;
-            let ignore = Math.floor(tgtStats.mdef * divinePen);
+            let ignore = Math.floor(rawMdef * divinePen);
             def = Math.max(0, def - ignore);
             logFn(`[아티팩트] 디바인피어싱: 디바인 ${target.buffs['divine']}스택! 마법방어력 ${Math.round(divinePen * 100)}% 관통!`);
         }


### PR DESCRIPTION
### Motivation
- Ensure defense-penetration effects and defense-reduction debuffs combine additively so requested examples like 40% debuff + 50% penetration = 90% total reduction hold. 
- Make Phoenix's normal-attack burn effect apply always while keeping deck-synergy only for the stat bonus. 
- Add a `weak` application to Cure Master's `멜트다운` skill per design request.

### Description
- Change penetration math to subtract from the raw base defenses (`target.def` / `target.mdef`) so penetration and debuff-based defense reductions sum correctly by introducing `rawDef` and `rawMdef` and using them when computing ignored defense; updates applied in `card/logic.js` and `card_remaster/logic.js`.
- Make Phoenix normal-attack burn unconditional by removing the extra `activeTraits` check in `card/battle_runtime.js` and `card_remaster/battle_runtime.js` so the burn is applied on normal attacks while deck synergy remains used for stat bonuses.
- Add `weak` debuff to Cure Master `멜트다운` skill and update its description in `card/data.js` and `card_remaster/data.js` (skill now includes `{ type: 'debuff', id: 'weak' }`).
- Files modified: `card/logic.js`, `card_remaster/logic.js`, `card/battle_runtime.js`, `card_remaster/battle_runtime.js`, `card/data.js`, `card_remaster/data.js`.

### Testing
- Ran `npm run verify` which executes lint and smoke tests, and it passed.
- Smoke test breakdown: `Card smoke verification` passed, `Card remaster smoke verification` passed, `Idle hero smoke verification` passed.
- No UI screenshot checks were performed because the changes are combat-logic/data focused; browser UI integration was not visually verified but automated smoke tests covered the logic paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb8dfd084883229928ab98ddd49dde)