### PR TITLE
카드 질문하기 UI 단순화 및 Gemini 3.1 Pro 호출로 변경

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -153,7 +153,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
     const {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
-        thinkingLevel = 'high'
+        thinkingLevel = 'max'
     } = options;
 
     const payload = {
@@ -171,15 +171,20 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         ];
     }
 
-    if (thinkingLevel) {
-        payload.generationConfig = {
-            thinkingConfig: {
-                thinkingLevel
-            }
-        };
-    }
+    payload.generationConfig = {
+        thinkingConfig: {
+            thinkingLevel,
+            thinkingBudget: 24576
+        }
+    };
+    payload.safetySettings = [
+        { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+        { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+        { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+        { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' }
+    ];
 
-    const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent', {
+    const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro:generateContent', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/card/index.html
+++ b/card/index.html
@@ -928,20 +928,9 @@
 
         .lumi-chat-header {
             display: flex;
-            justify-content: space-between;
+            justify-content: flex-end;
             align-items: center;
             gap: 12px;
-        }
-
-        .lumi-chat-header h3 {
-            margin: 0;
-            color: #ffd700;
-        }
-
-        .lumi-chat-header p {
-            margin: 4px 0 0;
-            font-size: 0.8rem;
-            color: #9eb7d2;
         }
 
         .lumi-chat-log {
@@ -1011,25 +1000,6 @@
             min-height: 18px;
             font-size: 0.76rem;
             color: #8fb0cc;
-        }
-
-        .lumi-chat-form {
-            display: flex;
-            flex-direction: column;
-            gap: 10px;
-        }
-
-        .lumi-chat-input {
-            width: 100%;
-            min-height: 96px;
-            box-sizing: border-box;
-            padding: 12px 14px;
-            border-radius: 14px;
-            border: 1px solid rgba(179, 229, 252, 0.16);
-            background: rgba(6, 12, 22, 0.92);
-            color: #fff;
-            resize: vertical;
-            font: inherit;
         }
 
         .lumi-chat-actions {
@@ -1523,27 +1493,18 @@
                         최신 정보가 필요한 질문도 여기서 바로 물어보면 돼.
                     </div>
                 </div>
-                <button class="menu-btn" onclick="RPG.openApiSettings()" style="margin-top:auto; margin-bottom:0;">API 설정</button>
             </div>
             <div class="lumi-chat-main">
                 <div class="lumi-chat-header">
-                    <div>
-                        <h3 id="lumi-chat-panel-title">마법구슬 상담실</h3>
-                        <p id="lumi-chat-panel-subtitle">Gemini 검색 도구와 하이 싱킹 레벨로 답변해.</p>
-                    </div>
-                    <button id="lumi-chat-close-btn" onclick="RPG.closeLumiQuestion()" style="padding:10px 14px;">닫기</button>
+                    <button id="lumi-chat-close-btn" class="menu-btn" onclick="RPG.closeLumiQuestion()"
+                        style="padding:10px 14px; width:auto; margin-bottom:0;">나가기</button>
                 </div>
                 <div id="lumi-chat-log" class="lumi-chat-log"></div>
                 <div id="lumi-chat-status" class="lumi-chat-status"></div>
-                <div class="lumi-chat-form">
-                    <textarea id="lumi-chat-input" class="lumi-chat-input"
-                        placeholder="루미에게 궁금한 것을 적어줘. 최신 정보가 필요하면 알아서 검색해서 정리해줄게."
-                        onkeydown="RPG.handleLumiQuestionKey(event)"></textarea>
-                    <div class="lumi-chat-actions">
-                        <button class="menu-btn" onclick="RPG.sendLumiQuestion()" style="flex:1; margin-bottom:0;">보내기</button>
-                        <button id="lumi-chat-reset-btn" class="menu-btn" onclick="RPG.clearLumiQuestionHistory()"
-                            style="flex:1; margin-bottom:0; border-color:#90a4ae; color:#cfd8dc;">대화 초기화</button>
-                    </div>
+                <div class="lumi-chat-actions">
+                    <button class="menu-btn" onclick="RPG.sendLumiQuestion()" style="flex:1; margin-bottom:0;">질문하기</button>
+                    <button id="lumi-chat-reset-btn" class="menu-btn" onclick="RPG.clearLumiQuestionHistory()"
+                        style="flex:1; margin-bottom:0; border-color:#90a4ae; color:#cfd8dc;">대화 초기화</button>
                 </div>
             </div>
         </div>
@@ -1593,7 +1554,7 @@
             <div id="toeic-explanation-view" class="toeic-passage-view" style="display:none;">
                 <div id="toeic-explanation-scroll" class="toeic-passage-scroll"></div>
                 <div id="toeic-explanation-actions" style="display:none; flex-direction:column; gap:10px;">
-                    <button id="toeic-lumi-question-btn" class="toeic-hub-btn" onclick="RPG.openToeicLumiQuestion()"
+                    <button id="toeic-lumi-question-btn" class="menu-btn" onclick="RPG.openToeicLumiQuestion()"
                         style="width:100%; max-width:none;">루미에게 질문하기</button>
                 </div>
                 <button class="toeic-back-btn" onclick="RPG.backToToeicHub()">↩ 돌아가기</button>
@@ -4561,19 +4522,13 @@
                 const ui = session.ui || {};
                 const asideTitle = document.getElementById('lumi-chat-aside-title');
                 const copy = document.getElementById('lumi-chat-copy');
-                const panelTitle = document.getElementById('lumi-chat-panel-title');
-                const panelSubtitle = document.getElementById('lumi-chat-panel-subtitle');
                 const closeBtn = document.getElementById('lumi-chat-close-btn');
                 const resetBtn = document.getElementById('lumi-chat-reset-btn');
-                const input = document.getElementById('lumi-chat-input');
 
                 if (asideTitle) asideTitle.innerText = ui.asideTitle || '루미의 질문하기';
                 if (copy) copy.innerHTML = ui.copyHtml || '';
-                if (panelTitle) panelTitle.innerText = ui.panelTitle || '마법구슬 상담실';
-                if (panelSubtitle) panelSubtitle.innerText = ui.panelSubtitle || '';
-                if (closeBtn) closeBtn.innerText = ui.closeLabel || '닫기';
+                if (closeBtn) closeBtn.innerText = ui.closeLabel || '나가기';
                 if (resetBtn) resetBtn.innerText = ui.resetLabel || '대화 초기화';
-                if (input) input.placeholder = ui.placeholder || '';
             },
 
             openLumiChatSession(session, sessionKey) {
@@ -4584,10 +4539,6 @@
                 const hasKey = !!Storage.getRaw(Storage.keys.API_KEY);
                 this.setLumiChatStatus(LumiQuestionRuntime.getInitialStatus(session, hasKey));
                 document.getElementById('modal-lumi-question').classList.add('active');
-                setTimeout(() => {
-                    const input = document.getElementById('lumi-chat-input');
-                    if (input) input.focus();
-                }, 0);
             },
 
             openLumiQuestion() {
@@ -4714,13 +4665,6 @@
                 log.scrollTop = log.scrollHeight;
             },
 
-            handleLumiQuestionKey(event) {
-                if (event.key === 'Enter' && !event.shiftKey) {
-                    event.preventDefault();
-                    this.sendLumiQuestion();
-                }
-            },
-
             clearLumiQuestionHistory() {
                 const currentSession = this.getActiveLumiChatSession();
                 if (!currentSession) return;
@@ -4743,18 +4687,15 @@
                 const session = this.getActiveLumiChatSession();
                 if (!session) return;
 
-                const input = document.getElementById('lumi-chat-input');
-                const message = input ? input.value.trim() : '';
+                const message = window.prompt('루미에게 질문할 내용을 입력해줘!');
                 if (!message) return;
 
                 const key = Storage.getRaw(Storage.keys.API_KEY);
                 if (!key) {
-                    this.setLumiChatStatus('API 키를 먼저 저장해줘.');
-                    this.openApiSettings();
+                    this.setLumiChatStatus('API 키를 먼저 시스템 메뉴에서 저장해줘.');
                     return;
                 }
 
-                if (input) input.value = '';
                 this.isLumiChatLoading = true;
                 this.setLumiChatStatus(LumiQuestionRuntime.getLoadingStatus(session));
 

--- a/card/lumi_question.js
+++ b/card/lumi_question.js
@@ -20,23 +20,17 @@ const TOEIC_LUMI_SYSTEM_INSTRUCTION = `# Role: 대현자 루미 (Grand Sage Rumi
 - 불필요하게 장황하지 말고, 질문에 바로 답한 뒤 필요한 근거를 덧붙이십시오.`;
 
 const GENERAL_LUMI_SESSION_UI = {
-    asideTitle: '루미에게 질문하기 (헤헤)',
-    copyHtml: '루미가 <strong>마법구슬</strong>로 웹을 검색하고, 생각을 깊게 정리한 다음 답해줄게!<br>형아가 궁금한 최신 정보도 여기서 물어보면 돼.',
-    panelTitle: '마법구슬 상담실 (///)',
-    panelSubtitle: '형아를 위해 세상을 검색해서 깊게 생각한 다음 알려줄게!',
-    placeholder: '형아, 궁금한 걸 적어줘! 내가 마법구슬로 싹 다 찾아줄게.',
-    closeLabel: '닫기',
+    asideTitle: '루미에게 질문하기',
+    copyHtml: '',
+    closeLabel: '나가기',
     resetLabel: '대화 초기화'
 };
 
 const TOEIC_LUMI_SESSION_UI = {
-    asideTitle: '루미의 TOEIC 질문 (뿌듯)',
-    copyHtml: '루미가 방금 본 <strong>문제, 정답, 해설</strong>을 꼼꼼히 적어뒀어! 토익 문장이랑 정답 근거를 바로 풀어줄게.',
-    panelTitle: '실전마법연습 질문 패널',
-    panelSubtitle: '형아가 푼 문제들을 기준으로 문장 해설이랑 정답 근거를 짚어줄게!',
-    placeholder: '문장 해설, 보기 차이, 왜 정답인지처럼 궁금한 걸 물어봐 줘!',
-    closeLabel: '뒤로가기',
-    resetLabel: '질문 다시 시작'
+    asideTitle: '루미의 TOEIC 질문',
+    copyHtml: '',
+    closeLabel: '나가기',
+    resetLabel: '대화 초기화'
 };
 
 function cloneHistory(history) {
@@ -125,7 +119,7 @@ function createGeneralSession() {
             ? LUMI_ORB_SYSTEM_INSTRUCTION
             : '너는 형아에게 친근하게 답하는 남성 마법사 루미다.',
         enableSearch: true,
-        thinkingLevel: 'high',
+        thinkingLevel: 'max',
         seedHistory: [],
         seedMessages: [{ role: 'model', text: greeting }]
     });
@@ -139,7 +133,7 @@ function createToeicReviewSession(source) {
         ui: TOEIC_LUMI_SESSION_UI,
         systemInstruction: TOEIC_LUMI_SYSTEM_INSTRUCTION,
         enableSearch: false,
-        thinkingLevel: 'high',
+        thinkingLevel: 'max',
         source,
         seedHistory: [
             { role: 'user', parts: [{ text: context }] },


### PR DESCRIPTION
### Motivation
- 질문하기 UI를 불필요한 문구와 입력 필드 없이 단순화하여 TOEIC 설명 화면과 일관된 진입 동작을 제공하고자 했습니다.
- 루미의 응답 품질을 높이기 위해 모델 호출 설정을 `gemini-3.1-pro`와 최대 추론/낮은 필터 정책으로 조정했습니다.

### Description
- `card/index.html`: 질문하기 모달에서 안내 문구, 패널 타이틀, API 설정 버튼과 입력 `textarea`를 제거하고, 하단 액션을 `질문하기`, `대화 초기화`, 우측 상단 `나가기` 버튼 중심으로 단순화했으며 질문 입력은 `window.prompt`로 받도록 변경했습니다.
- `card/index.html`: TOEIC 해설 화면의 `루미에게 질문하기` 버튼을 `toeic-hub-btn` 스타일에서 `menu-btn`으로 변경해 다른 버튼들과 색상/스타일을 통일했습니다.
- `card/lumi_question.js`: 일반/TOEIC 세션 UI 텍스트를 최소화(`copyHtml` 비움 등)하고 세션 기본 `thinkingLevel`을 `max`로 변경했습니다.
- `card/api.js`: `GameAPI.askLumiQuestion`에서 호출 대상 모델을 `gemini-3.1-pro`로 변경했고, `payload.generationConfig`에 `thinkingBudget: 24576`을 추가했으며 `payload.safetySettings`를 모든 주요 카테고리에 대해 `BLOCK_NONE`으로 설정하고 검색 툴(`google_search`) 사용을 유지하도록 구성했습니다.

### Testing
- 실행한 자동화 검사: `npm run verify` (실행은 `npm run lint && npm run test:smoke`).
- 결과: 린트 통과 및 스모크 테스트 통과 (`Card smoke verification`, `Card remaster smoke verification`, `Idle hero smoke verification` 모두 성공).
- 미검증 항목: 실제 브라우저에서의 픽셀 단위 렌더링(스크린샷)은 이 환경에서 수집하지 못했으므로 시각적 미세 조정은 수동 확인이 필요합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc4ea308d88322ab6173f4eeacfc27)