### PR TITLE
Split card RPG feature methods into module

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1471,7 +1471,8 @@
                 { src: 'toeic_explanations.js', label: '토익 해설' },
                 { src: 'api.js', label: 'API 모듈' },
                 { src: 'logic.js', label: '게임 로직' },
-                { src: 'battle_runtime.js', label: '전투 런타임' }
+                { src: 'battle_runtime.js', label: '전투 런타임' },
+                { src: 'rpg_features.js', label: 'RPG Feature Modules' }
             ];
             var idx = 0;
 
@@ -1896,10 +1897,18 @@
             lumiChatSessions: { general: null },
             activeLumiChatSessionKey: 'general',
             isLumiChatLoading: false,
+            _featuresInstalled: false,
 
             // Constants
             NORMAL_ATTACK: { name: '일반 공격', type: 'phy', tier: 1, cost: 0, val: 1.0, desc: '기본 물리 공격', effects: [] },
 
+
+            hydrateModules() {
+                if (this._featuresInstalled) return;
+                if (typeof RPGFeatureModules === 'undefined') return;
+                RPGFeatureModules.install(this);
+                this._featuresInstalled = true;
+            },
 
             // --- Core Functions ---
 
@@ -1914,162 +1923,6 @@
 
             getCardData(id) {
                 return GameUtils.getCardById(id);
-            },
-
-            loadStudyProgress() {
-                const vocab = Storage.load(Storage.keys.VOCAB);
-                if (vocab) this.state.wrongWords = vocab;
-
-                const col = Storage.load(Storage.keys.COLLOCATION);
-                if (col) this.state.wrongCollocations = col;
-            },
-
-            saveStudyProgress() {
-                Storage.save(Storage.keys.VOCAB, this.state.wrongWords || []);
-                if (this.state.wrongCollocations) {
-                    Storage.save(Storage.keys.COLLOCATION, this.state.wrongCollocations);
-                }
-            },
-
-            getRandomGrammarQuiz() {
-                let allQuizzes = [];
-                GRAMMAR_DATA.forEach(lecture => {
-                    allQuizzes = allQuizzes.concat(lecture.quizzes);
-                });
-                if (allQuizzes.length === 0) return null;
-                return allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
-            },
-
-            // --- Global Data ---
-            loadGlobalData() {
-                const data = Storage.load(Storage.keys.GLOBAL);
-                if (data) {
-                    this.global = { ...this.global, ...data };
-                }
-                const changed = this.ensureDefaultUnlockedBonusCards();
-                this.ensureBonusPoolPresetState();
-                if (changed) this.saveGlobalData();
-            },
-            saveGlobalData() {
-                Storage.save(Storage.keys.GLOBAL, this.global);
-            },
-
-            ensureDefaultUnlockedBonusCards() {
-                if (!Array.isArray(this.global.unlocked_bonus_cards)) {
-                    this.global.unlocked_bonus_cards = [];
-                }
-
-                const defaults = (typeof GameUtils !== 'undefined' && typeof GameUtils.getDefaultUnlockedBonusCardIds === 'function')
-                    ? GameUtils.getDefaultUnlockedBonusCardIds()
-                    : [];
-
-                let changed = false;
-                defaults.forEach(id => {
-                    if (!this.global.unlocked_bonus_cards.includes(id)) {
-                        this.global.unlocked_bonus_cards.push(id);
-                        changed = true;
-                    }
-                });
-                return changed;
-            },
-
-            getStandardBonusCards() {
-                if (typeof GameUtils !== 'undefined' && typeof GameUtils.getBonusCards === 'function') {
-                    return GameUtils.getBonusCards().filter(card => card.unlockSource !== 'hidden');
-                }
-                return BONUS_CARDS.filter(card => card.unlockSource !== 'hidden');
-            },
-
-            getHiddenBonusCards() {
-                if (typeof GameUtils !== 'undefined' && typeof GameUtils.getBonusCards === 'function') {
-                    return GameUtils.getBonusCards().filter(card => card.unlockSource === 'hidden');
-                }
-                return BONUS_CARDS.filter(card => card.unlockSource === 'hidden');
-            },
-
-            getGradeSortValue(grade) {
-                const gradeOrder = {
-                    transcendence: 0,
-                    legend: 1,
-                    epic: 2,
-                    rare: 3,
-                    normal: 4,
-                    event: 5
-                };
-                return gradeOrder[grade] ?? 99;
-            },
-
-            sortCardDataByGrade(cards) {
-                return [...cards].sort((a, b) => {
-                    const gradeDiff = this.getGradeSortValue(a.grade) - this.getGradeSortValue(b.grade);
-                    if (gradeDiff !== 0) return gradeDiff;
-                    return a.name.localeCompare(b.name, 'ko');
-                });
-            },
-
-            sortCardIdsByGrade(ids) {
-                return [...ids].sort((a, b) => {
-                    const cardA = this.getCardData(a);
-                    const cardB = this.getCardData(b);
-                    if (!cardA && !cardB) return 0;
-                    if (!cardA) return 1;
-                    if (!cardB) return -1;
-                    const gradeDiff = this.getGradeSortValue(cardA.grade) - this.getGradeSortValue(cardB.grade);
-                    if (gradeDiff !== 0) return gradeDiff;
-                    return cardA.name.localeCompare(cardB.name, 'ko');
-                });
-            },
-
-            sortBlessingsByGrade(blessings) {
-                return [...blessings].sort((a, b) => {
-                    const gradeDiff = this.getGradeSortValue(a.grade) - this.getGradeSortValue(b.grade);
-                    if (gradeDiff !== 0) return gradeDiff;
-                    return a.name.localeCompare(b.name, 'ko');
-                });
-            },
-
-            getCurrentMonthKey() {
-                const now = new Date();
-                return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-            },
-
-            createMonthlyMissionState() {
-                const hiddenCards = this.getHiddenBonusCards();
-                const lockedHidden = hiddenCards.filter(card => !(this.global.unlocked_bonus_cards || []).includes(card.id));
-                const rewardPool = lockedHidden.length > 0 ? lockedHidden : hiddenCards;
-                const rewardCard = rewardPool[Math.floor(Math.random() * rewardPool.length)] || null;
-                return {
-                    monthKey: this.getCurrentMonthKey(),
-                    rewardCardId: rewardCard ? rewardCard.id : null,
-                    claimed: false,
-                    missions: {
-                        endless40: { label: '무한 모드 40 스테이지 돌파', progress: 0, target: 1 },
-                        challenge3: { label: '챌린지 모드 클리어 3회', progress: 0, target: 3 },
-                        toeic3: { label: '실전마법연습 3회 플레이', progress: 0, target: 3 }
-                    }
-                };
-            },
-
-            ensureMonthlyMissionState() {
-                const currentKey = this.getCurrentMonthKey();
-                if (!this.global.monthlyMission || this.global.monthlyMission.monthKey !== currentKey) {
-                    this.global.monthlyMission = this.createMonthlyMissionState();
-                    this.saveGlobalData();
-                }
-                return this.global.monthlyMission;
-            },
-
-            incrementMonthlyMissionProgress(id, amount = 1) {
-                const monthly = this.ensureMonthlyMissionState();
-                const mission = monthly.missions ? monthly.missions[id] : null;
-                if (!mission) return;
-                mission.progress = Math.min(mission.target, (mission.progress || 0) + amount);
-                this.saveGlobalData();
-            },
-
-            areAllMonthlyMissionsCleared() {
-                const monthly = this.ensureMonthlyMissionState();
-                return Object.values(monthly.missions || {}).every(mission => (mission.progress || 0) >= mission.target);
             },
 
             openMonthlyMission() {
@@ -2119,187 +1972,6 @@
                 claimBtn.innerText = monthly.claimed ? '보상 수령 완료' : '보상받기';
             },
 
-            claimMonthlyMissionReward() {
-                const monthly = this.ensureMonthlyMissionState();
-                if (monthly.claimed) return this.showAlert('이번 달 보상은 이미 수령했습니다.');
-                if (!this.areAllMonthlyMissionsCleared()) return this.showAlert('모든 월간 미션을 완료해야 보상을 받을 수 있습니다.');
-                const reward = monthly.rewardCardId ? this.getCardData(monthly.rewardCardId) : null;
-                if (!reward) return this.showAlert('이번 달 보상 카드가 없습니다.');
-
-                if (!this.global.unlocked_bonus_cards.includes(reward.id)) {
-                    this.global.unlocked_bonus_cards.push(reward.id);
-                }
-                monthly.claimed = true;
-                this.saveGlobalData();
-                this.updateBonusPoolEditorButton();
-                this.renderMonthlyMission();
-                this.openInfoModal('월간 미션 보상', `<b>${reward.name}</b> 이(가) 보너스 카드로 해금되었습니다!`);
-            },
-
-            registerToeicPracticeAttempt(options = {}) {
-                if (options.countMonthly !== false) {
-                    this.incrementMonthlyMissionProgress('toeic3', 1);
-                }
-
-                if (options.countHiddenUnlock === false || this.state.mode === 'dream_corridor') {
-                    return false;
-                }
-
-                let unlocked = false;
-                if (this.global.tutoringEventEnabled === false) {
-                    this.global.hiddenStudyPracticeCount = (this.global.hiddenStudyPracticeCount || 0) + 1;
-                    if (!this.global.hiddenStudyReady && this.global.hiddenStudyPracticeCount >= 5) {
-                        this.global.hiddenStudyReady = true;
-                        unlocked = true;
-                    }
-                } else {
-                    this.global.hiddenStudyPracticeCount = 0;
-                }
-                this.saveGlobalData();
-                return unlocked;
-            },
-
-            clearPendingEnemySelection() {
-                this.state.pendingEnemyId = null;
-                this.state.pendingEnemyStage = null;
-            },
-
-            getEnemyDataById(id) {
-                return ENEMIES.find(enemy => enemy.id === id) || ENEMIES[0];
-            },
-
-            getCurrentStageEnemyData() {
-                if (this.state.pendingEnemyStage === this.state.enemyScale && this.state.pendingEnemyId) {
-                    return this.getEnemyDataById(this.state.pendingEnemyId);
-                }
-
-                const rotation = (typeof ENDLESS_ENEMY_ROTATION !== 'undefined' && ENDLESS_ENEMY_ROTATION.length > 0)
-                    ? ENDLESS_ENEMY_ROTATION
-                    : ENEMIES.slice(0, 6).map(enemy => enemy.id);
-                const baseId = rotation[this.state.enemyScale % rotation.length];
-                const stageNumber = this.state.enemyScale + 1;
-                const hiddenBossMap = {
-                    iris_curse: 'thor',
-                    pharaoh: 'poseidon',
-                    demon_god: 'ares'
-                };
-
-                let enemyId = baseId;
-                if (this.state.gameType === 'endless' && stageNumber > 36 && hiddenBossMap[baseId] && Math.random() < 0.3) {
-                    enemyId = hiddenBossMap[baseId];
-                }
-
-                this.state.pendingEnemyStage = this.state.enemyScale;
-                this.state.pendingEnemyId = enemyId;
-                return this.getEnemyDataById(enemyId);
-            },
-
-            checkDailyChaosTicket() {
-                const today = new Date().toDateString();
-                if (this.global.lastRewardDate !== today) {
-                    this.global.lastRewardDate = today;
-                    this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
-                    this.saveGlobalData();
-                    this.showAlert("출석 보상: 카오스 티켓 1장을 획득했습니다!");
-                }
-            },
-
-            checkAllBonusUnlocked() {
-                if (!this.global.unlocked_bonus_cards) return false;
-                return this.getStandardBonusCards().every(c => this.global.unlocked_bonus_cards.includes(c.id));
-            },
-
-            getUnlockedBonusCards() {
-                const unlocked = new Set(this.global.unlocked_bonus_cards || []);
-                return this.getStandardBonusCards()
-                    .concat(this.getHiddenBonusCards())
-                    .filter(card => unlocked.has(card.id));
-            },
-
-            getUnlockedBonusTranscendenceCards() {
-                const unlocked = new Set(this.global.unlocked_bonus_transcendence_cards || []);
-                const bonusTranscendenceCards = typeof BONUS_TRANSCENDENCE_CARDS !== 'undefined'
-                    ? BONUS_TRANSCENDENCE_CARDS
-                    : [];
-                return bonusTranscendenceCards.filter(card => unlocked.has(card.id));
-            },
-
-            normalizeActiveBonusPoolIds(ids) {
-                const unlockedIds = this.getUnlockedBonusCards().map(card => card.id);
-                if (unlockedIds.length === 0) return [];
-                if (!Array.isArray(ids)) return [...unlockedIds];
-
-                const allowed = new Set(unlockedIds);
-                const normalized = [];
-                ids.forEach(id => {
-                    if (allowed.has(id) && !normalized.includes(id)) normalized.push(id);
-                });
-                return normalized;
-            },
-
-            ensureBonusPoolPresetState() {
-                const maxPresets = GAME_CONSTANTS.MAX_BONUS_POOL_PRESETS || 3;
-                const presets = Array.isArray(this.global.bonusPoolPresets)
-                    ? this.global.bonusPoolPresets.slice(0, maxPresets)
-                    : [];
-
-                while (presets.length < maxPresets) {
-                    presets.push(null);
-                }
-
-                this.global.bonusPoolPresets = presets.map(preset => {
-                    if (!Array.isArray(preset)) return null;
-                    const deduped = [];
-                    preset.forEach(id => {
-                        if (!deduped.includes(id)) deduped.push(id);
-                    });
-                    return deduped;
-                });
-
-                const activeIndex = Number.isInteger(this.global.activeBonusPoolPresetIndex)
-                    ? this.global.activeBonusPoolPresetIndex
-                    : 0;
-                this.global.activeBonusPoolPresetIndex = Math.min(maxPresets - 1, Math.max(0, activeIndex));
-
-                if (!Array.isArray(this.global.unlocked_bonus_transcendence_cards)) {
-                    this.global.unlocked_bonus_transcendence_cards = [];
-                }
-            },
-
-            getActiveBonusPoolPresetIndex() {
-                this.ensureBonusPoolPresetState();
-                return this.global.activeBonusPoolPresetIndex;
-            },
-
-            getBonusPoolPresetIds(index = this.getActiveBonusPoolPresetIndex()) {
-                this.ensureBonusPoolPresetState();
-                return this.normalizeActiveBonusPoolIds(this.global.bonusPoolPresets[index]);
-            },
-
-            syncPendingActiveBonusPoolIds() {
-                this.pendingActiveBonusPoolIds = [...this.getBonusPoolPresetIds()];
-            },
-
-            persistPendingActiveBonusPoolIds() {
-                this.ensureBonusPoolPresetState();
-                const activeIndex = this.getActiveBonusPoolPresetIndex();
-                const normalizedIds = this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds);
-                this.global.bonusPoolPresets[activeIndex] = [...normalizedIds];
-                this.pendingActiveBonusPoolIds = [...normalizedIds];
-                this.saveGlobalData();
-            },
-
-            selectBonusPoolPreset(index) {
-                this.ensureBonusPoolPresetState();
-                if (index < 0 || index >= this.global.bonusPoolPresets.length) return;
-
-                this.global.activeBonusPoolPresetIndex = index;
-                this.syncPendingActiveBonusPoolIds();
-                this.saveGlobalData();
-                this.renderBonusPoolEditor();
-                this.updateBonusPoolEditorButton();
-            },
-
             renderBonusPoolPresetButtons() {
                 const container = document.getElementById('bonus-pool-preset-list');
                 if (!container) return;
@@ -2320,153 +1992,8 @@
                 });
             },
 
-            buildChaosRoulettePool() {
-                return GameUtils.buildTranscendencePool(this.global, {
-                    excludeIds: this.global.pendingTranscendenceCards || []
-                });
-            },
-
-            tryUnlockBonusTranscendence() {
-                const enemy = this.battle ? this.battle.enemy : null;
-                const rewardId = enemy ? enemy.bonusTranscendenceReward : null;
-                if (!rewardId) return '';
-
-                this.ensureBonusPoolPresetState();
-                if (this.global.unlocked_bonus_transcendence_cards.includes(rewardId)) return '';
-                if (Math.random() >= 0.1) return '';
-
-                this.global.unlocked_bonus_transcendence_cards.push(rewardId);
-                this.saveGlobalData();
-
-                const unlockedCard = this.getCardData(rewardId);
-                if (!unlockedCard) return '<b>[보너스초월]</b> 새로운 초월 카드가 카오스 룰렛에 추가되었습니다!';
-                return `<b>[보너스초월]</b> ${unlockedCard.name}이(가) 카오스 룰렛에 해금되었습니다!`;
-            },
-
-            isWeightedTranscendenceRunMode() {
-                return this.state.gameType === 'endless' && ['chaos', 'draft'].includes(this.state.mode);
-            },
-
-            drawRunPoolCards(pool, count, options = {}) {
-                if (!Array.isArray(pool) || pool.length === 0 || count <= 0) return [];
-
-                if (this.isWeightedTranscendenceRunMode()) {
-                    return GameUtils.drawWeightedCards(
-                        pool,
-                        count,
-                        card => (card.grade === 'transcendence' ? 0.5 : 1.0),
-                        options
-                    );
-                }
-
-                if (options.allowDuplicates) {
-                    const picks = [];
-                    for (let i = 0; i < count; i++) {
-                        picks.push(pool[Math.floor(Math.random() * pool.length)]);
-                    }
-                    return picks;
-                }
-
-                return [...pool]
-                    .sort(() => Math.random() - 0.5)
-                    .slice(0, count);
-            },
-
-            buildChaosPoolCardIds(pool) {
-                return this.drawRunPoolCards(pool, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(card => card.id);
-            },
-
-            resetPendingActiveBonusPoolIds() {
-                this.syncPendingActiveBonusPoolIds();
-                this.updateBonusPoolEditorButton();
-            },
-
-            updateBonusPoolEditorButton() {
-                const btn = document.getElementById('btn-bonus-pool-editor');
-                if (!btn) return;
-
-                this.ensureBonusPoolPresetState();
-                const total = this.getUnlockedBonusCards().length;
-                const active = this.getBonusPoolPresetIds().length;
-                const presetNo = this.getActiveBonusPoolPresetIndex() + 1;
-                const subText = total > 0
-                    ? `이번 런 활성 ${active}/${total}장`
-                    : '해금된 보너스 카드가 아직 없습니다';
-
-                btn.innerHTML = `덱 편집<br><span style="font-size:0.8rem; color:#b3e5fc;">${subText}</span>`;
-            },
-
-            openBonusPoolEditor() {
-                this.pendingActiveBonusPoolIds = this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds);
-                this.renderBonusPoolEditor();
-                document.getElementById('modal-bonus-pool-editor').classList.add('active');
-            },
-
             closeBonusPoolEditor() {
                 document.getElementById('modal-bonus-pool-editor').classList.remove('active');
-                this.updateBonusPoolEditorButton();
-            },
-
-            renderBonusPoolEditor() {
-                const list = document.getElementById('bonus-pool-editor-list');
-                const summary = document.getElementById('bonus-pool-editor-summary');
-                const cards = this.sortCardDataByGrade(this.getUnlockedBonusCards());
-                const activeIds = new Set(this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds));
-
-                this.pendingActiveBonusPoolIds = [...activeIds];
-                list.innerHTML = "";
-
-                if (cards.length === 0) {
-                    summary.innerText = '활성화할 해금 보너스 카드가 없습니다.';
-                    list.innerHTML = '<div style="padding:12px; border:1px solid #444; border-radius:8px; background:#2a2a2a; color:#aaa; font-size:0.85rem;">아직 해금된 보너스 카드가 없습니다.</div>';
-                    return;
-                }
-
-                summary.innerText = `활성 ${activeIds.size} / ${cards.length}`;
-
-                const grid = document.createElement('div');
-                grid.className = 'bonus-pool-grid';
-
-                cards.forEach(card => {
-                    const disabled = !activeIds.has(card.id);
-                    const item = document.createElement('label');
-                    item.className = `bonus-pool-item${disabled ? ' is-disabled' : ''}`;
-                    item.innerHTML = `
-                        <div class="portrait"><img src="${card.name}.png" onerror="this.style.display='none'"></div>
-                        <div class="bonus-pool-name">${card.name}</div>
-                        <div class="bonus-pool-grade">${card.grade.toUpperCase()} / ${card.role}</div>
-                        <div class="bonus-pool-toggle">
-                            <input type="checkbox" ${disabled ? 'checked' : ''}>
-                            <span>비활성화</span>
-                        </div>
-                    `;
-
-                    const checkbox = item.querySelector('input');
-                    checkbox.addEventListener('change', () => {
-                        this.setPendingBonusCardActive(card.id, !checkbox.checked);
-                    });
-
-                    grid.appendChild(item);
-                });
-
-                list.appendChild(grid);
-            },
-
-            setPendingBonusCardActive(cardId, isActive) {
-                let ids = this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds);
-                if (isActive) {
-                    if (!ids.includes(cardId)) ids.push(cardId);
-                } else {
-                    ids = ids.filter(id => id !== cardId);
-                }
-                this.pendingActiveBonusPoolIds = ids;
-                this.renderBonusPoolEditor();
-                this.updateBonusPoolEditorButton();
-            },
-
-            enableAllBonusPoolCards() {
-                this.pendingActiveBonusPoolIds = this.normalizeActiveBonusPoolIds();
-                this.renderBonusPoolEditor();
                 this.updateBonusPoolEditorButton();
             },
 
@@ -2579,7 +2106,8 @@
                     { name: 'BattleRuntime', ref: typeof BattleRuntime !== 'undefined' ? BattleRuntime : null },
                     { name: 'QuizEngine', ref: typeof QuizEngine !== 'undefined' ? QuizEngine : null },
                     { name: 'TOEIC_DATA', ref: typeof TOEIC_DATA !== 'undefined' ? TOEIC_DATA : null },
-                    { name: 'GameAPI', ref: typeof GameAPI !== 'undefined' ? GameAPI : null }
+                    { name: 'GameAPI', ref: typeof GameAPI !== 'undefined' ? GameAPI : null },
+                    { name: 'RPGFeatureModules', ref: typeof RPGFeatureModules !== 'undefined' ? RPGFeatureModules : null }
                 ];
                 return requiredData.filter(d => !d.ref || (Array.isArray(d.ref) && d.ref.length === 0));
             },
@@ -2623,6 +2151,7 @@
 
                     const missing = this.getMissingRequiredData();
                     if (missing.length === 0) {
+                        this.hydrateModules();
                         this.setStartButtonsEnabled(true);
                         return;
                     }
@@ -2652,50 +2181,6 @@
 
                 this.setStartButtonsEnabled(false);
                 checkReady();
-            },
-
-            startGame(mode, retryCount = 0) {
-                const missing = this.getMissingRequiredData();
-
-                if (missing.length > 0) {
-                    if (retryCount < GAME_CONSTANTS.LOADING.START_RETRY_LIMIT) {
-                        setTimeout(() => this.startGame(mode, retryCount + 1), GAME_CONSTANTS.LOADING.START_RETRY_DELAY_MS);
-                        return;
-                    }
-                    const names = missing.map(d => d.name).join(', ');
-                    this.showAlert(`게임 데이터 로드 실패: ${names}<br><br>파일이 같은 폴더에 있는지 확인하고 게임을 새로고침 해주세요.`);
-                    return; // 게임 진입 차단
-                }
-
-                this.loadGlobalData();
-                this.ensureMonthlyMissionState();
-                this.checkDailyChaosTicket();
-
-                if (mode === 'load') {
-                    const save = Storage.load(Storage.keys.SAVE);
-                    if (save) {
-                        this.state = { ...this.state, ...save };
-                        if (this.state.chaosBlessingUses === undefined) this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
-                        if (this.state.greatSageBlessingUses === undefined) this.state.greatSageBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
-                        if (!this.state.chaosBuffs) this.state.chaosBuffs = [];
-                        if (!this.state.activeChaosBlessing) this.state.activeChaosBlessing = [];
-                        if (!this.state.activeSageBlessing) this.state.activeSageBlessing = [];
-                        if (!this.state.tutoredItems) this.state.tutoredItems = [];
-                        if (!this.state.mode) this.state.mode = 'origin';
-                        if (!this.state.quiz_stats) this.state.quiz_stats = { correct: 0, total: 0 };
-                        if (!this.state.artifacts) this.state.artifacts = [];
-                        if (this.state.pendingEnemyId === undefined) this.state.pendingEnemyId = null;
-                        if (this.state.pendingEnemyStage === undefined) this.state.pendingEnemyStage = null;
-                        this.state.activeBonusPoolIds = this.normalizeActiveBonusPoolIds(this.state.activeBonusPoolIds);
-                        this.loadStudyProgress();
-
-                        this.showAlert("불러오기 완료");
-                        this.toMenu();
-                    } else { this.showAlert("저장된 데이터가 없습니다. 새로 시작합니다."); this.openTypeSelect(); }
-                } else {
-                    // New Game Logic: Show Type Select
-                    this.openTypeSelect();
-                }
             },
 
             openTypeSelect() {
@@ -2801,112 +2286,6 @@
                 modal.classList.add('active');
             },
 
-            initNewGame(mode = 'origin') {
-                // Record saving logic (Only for Origin mode as per request "Record check only for Origin")
-                // Check previous state
-                if (this.state.mode === 'origin' && this.state.enemyScale > 0) {
-                    this.saveRecord();
-                }
-
-                let initTickets = GameUtils.getInitialTickets(mode);
-
-                this.state = {
-                    mode: mode,
-                    gameType: this.tempGameType || 'challenge',
-                    tickets: initTickets,
-                    inventory: [],
-                    deck: [null, null, null],
-                    enemyScale: 0,
-                    chaosBlessingUses: GAME_CONSTANTS.DEFAULT_BLESSING_USES,
-                    greatSageBlessingUses: GAME_CONSTANTS.DEFAULT_BLESSING_USES,
-                    chaosBuffs: [],
-                    activeChaosBlessing: [],
-                    activeSageBlessing: [],
-                    activeBonusPoolIds: this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds),
-                    tutoredItems: [],
-                    wrongWords: [],
-                    quiz_stats: { correct: 0, total: 0 },
-                    chaosPool: [],
-                    draft: { active: false, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] },
-                    artifacts: [],
-                    pendingEnemyId: null,
-                    pendingEnemyStage: null,
-                    // [목적] 카오스/드래프트 모드에서 해당 런에서만 유효한 이벤트 카드 목록을 초기화
-                    activeEventCards: []
-                };
-
-                if (mode === 'dream_corridor') {
-                    this.global.hiddenStudyReady = false;
-                    this.global.hiddenStudyPracticeCount = 0;
-                    this.saveGlobalData();
-                }
-
-                // Transfer Pending Transcendence to Active State (Endless Only)
-                if (this.state.gameType === 'endless') {
-                    this.state.activeTranscendenceCards = [...(this.global.pendingTranscendenceCards || [])];
-                    this.global.pendingTranscendenceCards = [];
-                    this.saveGlobalData();
-                } else {
-                    this.state.activeTranscendenceCards = [];
-                }
-
-                if (mode === 'chaos') {
-                    let allCards = GameUtils.buildCardPool(this.global, {
-                        includeTranscendence: true,
-                        activeTranscendenceCards: this.state.activeTranscendenceCards,
-                        activeBonusPoolIds: this.state.activeBonusPoolIds,
-                        // [목적] 해당 런에서 획득한 이벤트 카드를 카오스 모드 시작 풀에 포함
-                        activeEventCards: this.state.activeEventCards
-                    });
-
-                    const picks = this.buildChaosPoolCardIds(allCards);
-
-                    this.state.chaosPool = picks;
-                    this.state.inventory = [...picks];
-                }
-
-                // Origin Mode: Add Transcendence Cards directly to Inventory
-                if (mode !== 'chaos' && mode !== 'draft' && this.state.activeTranscendenceCards.length > 0) {
-                    this.state.inventory.push(...this.state.activeTranscendenceCards);
-                    setTimeout(() => this.showAlert(`초월 카드 ${this.state.activeTranscendenceCards.length}장이 인벤토리에 합류했습니다!`), 500);
-                }
-
-                this.loadStudyProgress();
-                this.saveGame();
-            },
-
-            saveGame(showMessage = true) {
-                Storage.save(Storage.keys.SAVE, this.state);
-                this.saveStudyProgress();
-                this.saveGlobalData(); // Also save global just in case
-                if (showMessage) this.showAlert("저장되었습니다.");
-            },
-
-            saveRecord(score = null) {
-                let history = Storage.load(Storage.keys.RECORDS) || [];
-                let currentStage = score !== null ? score : (this.state.enemyScale + 1);
-
-                let stages = history.map(h => {
-                    let m = h.match(/최대 스테이지: (\d+)/);
-                    return m ? parseInt(m[1]) : 0;
-                });
-
-                stages.push(currentStage);
-                stages.sort((a, b) => b - a);
-                stages = stages.slice(0, GAME_CONSTANTS.MAX_RECORDS);
-
-                history = stages.map(s => `최대 스테이지: ${s}`);
-                Storage.save(Storage.keys.RECORDS, history);
-            },
-
-            showRecords() {
-                let history = Storage.load(Storage.keys.RECORDS) || [];
-                if (history.length === 0) return this.showAlert("기록이 없습니다.");
-                let msg = history.map((h, i) => `${i + 1}위. ${h}`).join("<br>");
-                this.openInfoModal("최대 스테이지 기록 (Top 5)", msg);
-            },
-
-            // --- Screen Navigation ---
             toMenu() {
                 this.clearToeicLumiQuestionSession();
                 this.showScreen('screen-menu');
@@ -2952,16 +2331,6 @@
             openSystemMenu() {
                 this.updateSystemMenuUI();
                 document.getElementById('modal-menu').classList.add('active');
-            },
-
-            toggleTutoringEvent() {
-                if (this.global.tutoringEventEnabled === undefined) this.global.tutoringEventEnabled = true;
-                this.global.tutoringEventEnabled = !this.global.tutoringEventEnabled;
-                if (this.global.tutoringEventEnabled) {
-                    this.global.hiddenStudyPracticeCount = 0;
-                }
-                this.saveGlobalData();
-                this.updateSystemMenuUI();
             },
 
             updateSystemMenuUI() {
@@ -3039,18 +2408,6 @@
                 modal.classList.add('active');
                 chaosModal.classList.add('active');
             },
-            checkActiveChaosBlessings() {
-                if (!this.state.chaosBuffs || this.state.chaosBuffs.length === 0) {
-                    return this.showAlert("현재 적용된 축복이 없습니다.");
-                }
-                let msg = "<b>현재 적용된 축복</b><br><br>";
-                this.sortBlessingsByGrade(this.state.chaosBuffs).forEach(b => {
-                    msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}%, 치명타/회피율 증가`;
-                    msg += "<br>";
-                });
-                msg += "<br>(전투 시작 시 해당 카드의 체력이 모두 회복됩니다.)";
-                this.openInfoModal("축복 상태", msg);
-            },
             activateChaos(type) {
                 if (type === 'great_sage') {
                     if (this.state.greatSageBlessingUses <= 0) {
@@ -3103,39 +2460,6 @@
                 }
             },
 
-            startGrammarQuiz(q, successCallback = null, failCallback = null) {
-                const onCorrect = successCallback
-                    ? successCallback
-                    : () => this.applyGreatSageBlessing();
-                const onWrong = failCallback
-                    ? failCallback
-                    : () => {
-                        this.state.greatSageBlessingUses--;
-                        this.showAlert(`틀렸어... 남은 기회: ${this.state.greatSageBlessingUses}회`);
-                    };
-                const config = QuizEngine.buildGrammarQuiz(q, onCorrect, onWrong);
-                QuizEngine.show(config);
-            },
-
-            updateMergedBlessings() {
-                this.state.chaosBuffs = [];
-
-                const addBuffs = (list) => {
-                    list.forEach(nb => {
-                        let existing = this.state.chaosBuffs.find(b => b.id === nb.id);
-                        if (existing) {
-                            existing.multiplier += nb.multiplier;
-                        } else {
-                            this.state.chaosBuffs.push({ ...nb });
-                        }
-                    });
-                };
-
-                if (this.state.activeChaosBlessing) addBuffs(this.state.activeChaosBlessing);
-                if (this.state.activeSageBlessing) addBuffs(this.state.activeSageBlessing);
-                this.state.chaosBuffs = this.sortBlessingsByGrade(this.state.chaosBuffs);
-            },
-
             applyGreatSageBlessing() {
                 this.state.greatSageBlessingUses--;
                 // Update UI immediately
@@ -3180,46 +2504,6 @@
                 this.openInfoModal("축복 성공", msg);
             },
 
-            applyChaosBlessing(count) {
-                this.state.chaosBlessingUses--;
-
-                // 1. Build Pool
-                let pool = GameUtils.buildCardPool(this.global, {
-                    excludeTranscendence: true,
-                    excludeEvent: true,
-                    activeBonusPoolIds: this.state.activeBonusPoolIds,
-                    maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
-                });
-
-                // 2. Shuffle and Pick
-                pool.sort(() => 0.5 - Math.random());
-                let picks = pool.slice(0, count);
-
-                this.state.activeSageBlessing = []; // Clear Sage Blessing
-
-                let newBuffs = picks.map(c => {
-                    let mult = 0;
-                    if (c.grade === 'normal') mult = 0.4;
-                    else if (c.grade === 'rare') mult = 0.3;
-                    else if (c.grade === 'epic') mult = 0.2;
-                    else if (c.grade === 'legend') mult = 0.1;
-                    return { id: c.id, name: c.name, grade: c.grade, multiplier: mult };
-                });
-                newBuffs = this.sortBlessingsByGrade(newBuffs);
-
-                // Set to activeChaosBlessing (Replacing previous)
-                this.state.activeChaosBlessing = newBuffs;
-                this.updateMergedBlessings();
-
-                let msg = "<b>혼돈의 축복 적용!</b><br>새로운 축복이 부여되었습니다.<br><br><b>[새로 적용된 축복]</b><br>";
-                newBuffs.forEach(b => {
-                    msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}%, 치명타/회피율 증가<br>`;
-                });
-                msg += `<br><b>(현재 총 활성화된 축복: ${this.state.chaosBuffs.length}개)</b><br>(전투 시작 시 해당 카드의 체력이 모두 회복됩니다.)`;
-                this.openInfoModal("축복 성공", msg);
-            },
-
-            // --- Gacha & Deck UI ---
             reshuffleChaosPool() {
                 if (this.state.tickets < GAME_CONSTANTS.COSTS.CHAOS_SHUFFLE) {
                     return this.showAlert("셔플할 티켓이 부족합니다.");
@@ -3452,23 +2736,6 @@
                 document.getElementById('modal-wordbook').classList.add('active');
             },
 
-            startCollocationQuiz(callback) {
-                const config = QuizEngine.buildCollocationQuiz(callback);
-                if (!config) return this.showAlert("데이터 로드 오류: Collocation 데이터가 없습니다.");
-                QuizEngine.show(config);
-            },
-
-            startQuiz(callback) {
-                const config = QuizEngine.buildVocabQuiz(callback);
-                if (!config) return this.showAlert("데이터 로드 오류: 단어 데이터가 없습니다.");
-                QuizEngine.show(config);
-            },
-
-            startChaosQuiz(callback) {
-                const config = QuizEngine.buildChaosQuiz(callback);
-                if (!config) return this.showAlert("데이터 로드 오류: 단어 데이터가 없습니다.");
-                QuizEngine.show(config);
-            },
             closeGachaModal() { document.getElementById('modal-gacha').classList.remove('active'); },
 
             openCollection() { this.showScreen('screen-collection'); this.renderCardList('collection-grid', this.state.inventory, (id) => this.showCardInfo(id)); },
@@ -3663,23 +2930,6 @@
             },
 
             // --- Draft Logic ---
-            startDraft() {
-                if (this.state.deck.every(x => x !== null)) {
-                    return this.showAlert("이미 덱이 완성되어 있습니다. 전투에 진입하세요.");
-                }
-
-                if (!this.state.draft) this.state.draft = { active: true, round: 0, rerolls: 3, currentOptions: [] };
-
-                // Find first empty slot
-                this.state.draft.round = this.state.deck.indexOf(null);
-                if (this.state.draft.round === -1) {
-                    this.state.draft.round = 0;
-                }
-
-                this.showScreen('screen-draft');
-                this.renderDraftScreen();
-            },
-
             renderDraftScreen() {
                 const d = this.state.draft;
                 const roles = ['선봉', '중견', '대장'];
@@ -3720,34 +2970,6 @@
                 });
             },
 
-            generateDraftOptions() {
-                let pool = GameUtils.buildCardPool(this.global, {
-                    includeTranscendence: true,
-                    activeTranscendenceCards: this.state.activeTranscendenceCards,
-                    activeBonusPoolIds: this.state.activeBonusPoolIds,
-                    // [목적] 드래프트 선택지에 획득한 이벤트 카드가 등장하도록 함
-                    activeEventCards: this.state.activeEventCards
-                });
-
-                const options = this.drawRunPoolCards(pool, 4, { allowDuplicates: true }).map(card => card.id);
-                this.state.draft.currentOptions = options;
-            },
-
-            selectDraftCard(id) {
-                this.state.inventory.push(id);
-                this.state.deck[this.state.draft.round] = id;
-
-                // Clear options for next round
-                this.state.draft.currentOptions = [];
-
-                if (this.state.deck.indexOf(null) === -1) {
-                    this.showAlert("덱 구성 완료!");
-                    this.toMenu();
-                } else {
-                    this.startDraft();
-                }
-            },
-
             rerollDraft() {
                 if (this.state.draft.rerolls > 0) {
                     this.state.draft.rerolls--;
@@ -3765,214 +2987,6 @@
                         this.showAlert("리롤 횟수와 티켓이 모두 부족합니다.");
                     }
                 }
-            },
-
-            resetDraftState() {
-                // Called when initializing new draft cycle
-                this.state.inventory = [];
-                this.state.deck = [null, null, null];
-                this.state.draft = { active: true, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] };
-            },
-
-            cleanupTranscendenceCards() {
-                if (['draft', 'chaos'].includes(this.state.mode)) return "";
-
-                let removedNames = [];
-                this.battle.players.forEach((p, idx) => {
-                    if (p && p.proto.grade === 'transcendence') {
-                        // Remove from Inventory
-                        const invIdx = this.state.inventory.indexOf(p.id);
-                        if (invIdx > -1) {
-                            this.state.inventory.splice(invIdx, 1);
-                        }
-                        // Remove from Deck
-                        if (this.state.deck[idx] === p.id) {
-                            this.state.deck[idx] = null;
-                        }
-                        removedNames.push(p.name);
-                    }
-                });
-
-                if (removedNames.length > 0) {
-                    const msg = `초월 카드 소멸: ${removedNames.join(', ')}`;
-                    this.log(`<span style="color:#ffd700">[시스템] ${msg}</span>`);
-                    return `<br><span style="color:#ffd700">${msg}</span>`;
-                }
-                return "";
-            },
-
-            handlePermadeath(players) {
-                let deadNames = [];
-                players.forEach(p => {
-                    if (p && p.isDead) {
-                        let idx = this.state.inventory.indexOf(p.id);
-                        if (idx > -1) this.state.inventory.splice(idx, 1);
-                        if (p.pos !== undefined) this.state.deck[p.pos] = null;
-                        deadNames.push(p.name);
-                    }
-                });
-                if (deadNames.length > 0) return `전사자 발생: ${deadNames.join(', ')}<br>(카드가 소멸했습니다)`;
-                return "";
-            },
-
-            winBattle() {
-                let transMsg = this.cleanupTranscendenceCards();
-                let deadMsg = this.handlePermadeath(this.battle.players);
-                if (transMsg) deadMsg += transMsg;
-                let reward = GAME_CONSTANTS.MODE_REWARDS[this.state.mode] !== undefined
-                    ? GAME_CONSTANTS.MODE_REWARDS[this.state.mode]
-                    : GAME_CONSTANTS.MODE_REWARDS.default;
-
-                if (this.battle.players.some(p => p && p.proto.trait.type === 'looter')) {
-                    reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
-                }
-                if (this.state.mode === 'overdrive') {
-                    reward += GAME_CONSTANTS.BONUS_REWARDS.OVERDRIVE;
-                }
-                if (this.battle.enemy && this.battle.enemy.bonusRewardTickets) {
-                    reward += this.battle.enemy.bonusRewardTickets;
-                }
-
-                this.state.tickets += reward;
-                this.state.enemyScale++;
-                this.clearPendingEnemySelection();
-                const bonusTransUnlockMsg = this.tryUnlockBonusTranscendence();
-                if (bonusTransUnlockMsg) {
-                    deadMsg = deadMsg ? `${deadMsg}<br>${bonusTransUnlockMsg}` : bonusTransUnlockMsg;
-                }
-
-                // Reset Chaos Blessing
-                this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
-                this.state.chaosBuffs = [];
-                this.state.activeChaosBlessing = [];
-                this.state.activeSageBlessing = [];
-
-                this.log(`승리 보상: 뽑기권 ${reward}장 획득.`);
-
-                // Victory Condition Check
-                const mode = this.state.mode;
-                const stage = this.state.enemyScale; // current stage (already incremented)
-                const clearStage = GameUtils.getClearStage(mode, this.state.gameType);
-                const gameClear = stage >= clearStage;
-
-                if (this.state.gameType === 'endless' && stage >= 40) {
-                    this.incrementMonthlyMissionProgress('endless40', 1);
-                }
-
-                // Chaos/Draft: Reset Deck/Inventory
-                if (mode === 'chaos') {
-                    this.state.inventory = [];
-                    this.state.deck = [null, null, null];
-
-                    let allCards = GameUtils.buildCardPool(this.global, {
-                        includeTranscendence: true,
-                        activeTranscendenceCards: this.state.activeTranscendenceCards,
-                        activeBonusPoolIds: this.state.activeBonusPoolIds,
-                        // [목적] 전투 승리 후 카오스 풀 초기화 시 획득한 이벤트 카드를 포함
-                        activeEventCards: this.state.activeEventCards
-                    });
-                    const nextPicks = this.buildChaosPoolCardIds(allCards);
-                    this.state.chaosPool = nextPicks;
-                    this.state.inventory = [...nextPicks];
-                }
-
-                if (mode === 'draft') {
-                    this.resetDraftState();
-                }
-
-                // Archive Mode: Mandatory Quiz (Direct to finishWinBattle via callback)
-                if (mode === 'archive') {
-                    const q = this.getRandomGrammarQuiz();
-                    if (!q) {
-                        this.finishWinBattle(deadMsg, gameClear, null);
-                        return;
-                    }
-                    this.state.lastArchiveQuizLectureId = q.lecture_id;
-
-                    this.startGrammarQuiz(q,
-                        () => { // Success
-                            this.state.quiz_stats.correct++;
-                            this.state.quiz_stats.total++;
-                            this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.QUIZ;
-                            setTimeout(() => this.finishWinBattle(deadMsg, gameClear, true), 200);
-                        },
-                        () => { // Fail
-                            this.state.quiz_stats.total++;
-                            setTimeout(() => this.finishWinBattle(deadMsg, gameClear, false), 200);
-                        }
-                    );
-                    return;
-                }
-
-                if (mode === 'dream_corridor') {
-                    this.finishDreamCorridorBattle(deadMsg);
-                    return;
-                }
-
-                this.finishWinBattle(deadMsg, gameClear, null);
-            },
-
-            finishDreamCorridorBattle(deadMsg) {
-                const stage = this.state.enemyScale;
-                const stepIndex = (stage - 1) % 6;
-                const steps = ['word', 'collocation', 'word', 'grammar', 'word', 'toeic'];
-                const step = steps[stepIndex];
-
-                const finishSuccess = (label) => {
-                    let msg = `승리!<br>${label} 성공.`;
-                    if (deadMsg) msg += `<br><br>${deadMsg}`;
-                    this.openInfoModal('꿈의회랑', msg, () => this.toMenu());
-                };
-
-                const fail = (label) => this.failDreamCorridorRun(`${label}에서 오답이 발생해 꿈의회랑이 종료되었습니다.`);
-
-                if (step === 'word') {
-                    this.startQuiz(success => {
-                        if (success) finishSuccess('단어 퀴즈');
-                        else fail('단어 퀴즈');
-                    });
-                    return;
-                }
-
-                if (step === 'collocation') {
-                    this.startCollocationQuiz(success => {
-                        if (success) finishSuccess('숙어 퀴즈');
-                        else fail('숙어 퀴즈');
-                    });
-                    return;
-                }
-
-                if (step === 'grammar') {
-                    const q = this.getRandomGrammarQuiz();
-                    if (!q) {
-                        finishSuccess('문법 퀴즈');
-                        return;
-                    }
-                    this.startGrammarQuiz(q,
-                        () => finishSuccess('문법 퀴즈'),
-                        () => fail('문법 퀴즈')
-                    );
-                    return;
-                }
-
-                this.startToeicPractice({
-                    ignoreSessionLimit: true,
-                    suppressDate: true,
-                    lockExit: true,
-                    countHiddenUnlock: false,
-                    countMonthly: false,
-                    onComplete: () => finishSuccess('실전마법연습'),
-                    onFailure: () => fail('실전마법연습')
-                });
-            },
-
-            failDreamCorridorRun(message) {
-                this.global.hiddenStudyReady = false;
-                this.global.hiddenStudyPracticeCount = 0;
-                this.saveStudyProgress();
-                this.saveGlobalData();
-                Storage.remove(Storage.keys.SAVE);
-                this.openInfoModal('꿈의회랑 종료', message, () => this.toTitle());
             },
 
             finishWinBattle(deadMsg, gameClear, quizResult) {
@@ -4167,54 +3181,6 @@
                 });
             },
 
-            loseBattle() {
-                let transMsg = this.cleanupTranscendenceCards();
-                // No saveRecord here (User request: only on New Game)
-
-                if (['chaos', 'draft'].includes(this.state.mode)) {
-                    this.saveRecord();
-                }
-
-                if (this.state.mode === 'origin') {
-                    this.global.pendingTranscendenceCards = [];
-                    this.saveGlobalData();
-                }
-
-                if (['chaos', 'draft'].includes(this.state.mode)) {
-                    Storage.remove(Storage.keys.SAVE);
-
-                    let msg = "패배했습니다...<br>이 모드는 패배 시 데이터가 초기화됩니다.";
-                    this.openInfoModal("Game Over", msg, () => {
-                        this.toTitle();
-                    });
-                    return;
-                }
-
-                // Reset Chaos Blessing
-                this.state.chaosBlessingUses = 3;
-                this.state.chaosBuffs = [];
-                this.state.activeChaosBlessing = [];
-                this.state.activeSageBlessing = [];
-
-                let deadMsg = this.handlePermadeath(this.battle.players);
-                if (this.state.mode === 'dream_corridor') {
-                    let msg = "전투에서 패배해 꿈의회랑 런이 종료되었습니다.";
-                    if (deadMsg) msg += `<br><br>${deadMsg}`;
-                    if (transMsg) msg += transMsg;
-                    this.failDreamCorridorRun(msg);
-                    return;
-                }
-
-                let msg = "패배...";
-                if (deadMsg) msg += "<br><br>" + deadMsg;
-                if (transMsg) msg += transMsg;
-                this.openInfoModal("전투 결과", msg, () => this.toMenu());
-            },
-
-            getEffectiveStats(char, fieldBuffs) {
-                return Logic.calculateStats(char, fieldBuffs, this.state.mode, this.state.artifacts || [], this.battle.turn || 1);
-            },
-
             showBattleStat(side, idx) {
                 let char;
                 if (side === 'player') char = this.battle.players[idx];
@@ -4352,17 +3318,6 @@
             },
 
             // --- Lumi Question Chat ---
-            getToeicExplanationText(set) {
-                if (!set) return "해설 데이터가 없습니다.";
-                return (typeof TOEIC_EXPLANATIONS !== 'undefined' && TOEIC_EXPLANATIONS[set.id])
-                    ? TOEIC_EXPLANATIONS[set.id]
-                    : "해설 데이터가 없습니다.";
-            },
-
-            getStoredApiKey() {
-                return (Storage.getRaw(Storage.keys.API_KEY) || '').trim();
-            },
-
             ensureApiKey(reason = '이 기능을 사용하려면') {
                 let key = this.getStoredApiKey();
                 if (key) return key;
@@ -4375,14 +3330,6 @@
 
                 Storage.setRaw(Storage.keys.API_KEY, key);
                 return key;
-            },
-
-            getActiveLumiChatSession() {
-                return LumiQuestionRuntime.getActiveSession(
-                    this.activeLumiChatSessionKey,
-                    this.lumiChatSessions,
-                    this.state.currentToeicSession
-                );
             },
 
             configureLumiChatSessionUi(session) {
@@ -4758,10 +3705,6 @@
 
             // --- Artifact Helpers ---
 
-            hasArtifact(id) {
-                return (this.state.artifacts || []).includes(id);
-            },
-
             openArtifactSelect() {
                 const owned = this.state.artifacts || [];
                 const available = ARTIFACT_LIST.filter(a => !owned.includes(a.id));
@@ -4825,27 +3768,6 @@
             openToeicMenu() {
                 document.getElementById('modal-library').classList.remove('active');
                 document.getElementById('modal-toeic-menu').classList.add('active');
-            },
-
-            resetToeicProgress(options = {}) {
-                const reset = () => {
-                    this.state.completedToeicSets = [];
-                    this.saveGame(false);
-                    if (!options.silent) {
-                        this.showAlert("초기화되었습니다.");
-                    }
-                };
-
-                if (options.silent) {
-                    reset();
-                    return;
-                }
-
-                this.showDoubleConfirm(
-                    "모든 실전 연습 기록을 초기화하시겠습니까?",
-                    "정말 초기화하시겠습니까?<br>완료한 문제 세트가 다시 등장하게 됩니다.",
-                    reset
-                );
             },
 
             closeToeicPractice() {
@@ -5399,56 +4321,6 @@
                     () => this.startDate(),
                     () => this.toMenu()
                 );
-            },
-
-            _getDateParams() {
-                // Check secret date flag first
-                if (this.global.secretDateFlag) {
-                    const secretSet = SECRET_DATE_SETS[Math.floor(Math.random() * SECRET_DATE_SETS.length)];
-                    const weather = (secretSet.location === 'outdoor')
-                        ? DATE_WEATHER_OUTDOOR[Math.floor(Math.random() * DATE_WEATHER_OUTDOOR.length)]
-                        : '실내';
-                    return {
-                        theme: secretSet.theme,
-                        outfit: secretSet.outfit,
-                        weather: weather,
-                        keyword: secretSet.keyword,
-                        word: secretSet.word,
-                        secret: true,
-                        cardId: secretSet.cardId,
-                        cardName: secretSet.cardName
-                    };
-                }
-
-                // Normal date: random theme
-                const themeData = DATE_THEMES[Math.floor(Math.random() * DATE_THEMES.length)];
-
-                // Weather
-                let weather;
-                if (themeData.location === 'indoor') {
-                    weather = '실내';
-                } else {
-                    weather = DATE_WEATHER_OUTDOOR[Math.floor(Math.random() * DATE_WEATHER_OUTDOOR.length)];
-                }
-
-                // Keyword
-                const keyword = DATE_KEYWORDS[Math.floor(Math.random() * DATE_KEYWORDS.length)];
-
-                // Random word from wordbook
-                let word = 'love'; // fallback
-                if (typeof VOCAB_DATA !== 'undefined' && VOCAB_DATA.length > 0) {
-                    const vocab = VOCAB_DATA[Math.floor(Math.random() * VOCAB_DATA.length)];
-                    word = vocab.word;
-                }
-
-                return {
-                    theme: themeData.theme,
-                    outfit: themeData.outfit,
-                    weather: weather,
-                    keyword: keyword,
-                    word: word,
-                    secret: false
-                };
             },
 
             async startDate() {

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1,0 +1,1134 @@
+(function () {
+    const RPGFeatureMethods = {
+    loadStudyProgress() {
+        const vocab = Storage.load(Storage.keys.VOCAB);
+        if (vocab) this.state.wrongWords = vocab;
+
+        const col = Storage.load(Storage.keys.COLLOCATION);
+        if (col) this.state.wrongCollocations = col;
+    },
+
+
+    saveStudyProgress() {
+        Storage.save(Storage.keys.VOCAB, this.state.wrongWords || []);
+        if (this.state.wrongCollocations) {
+            Storage.save(Storage.keys.COLLOCATION, this.state.wrongCollocations);
+        }
+    },
+
+
+    getRandomGrammarQuiz() {
+        let allQuizzes = [];
+        GRAMMAR_DATA.forEach(lecture => {
+            allQuizzes = allQuizzes.concat(lecture.quizzes);
+        });
+        if (allQuizzes.length === 0) return null;
+        return allQuizzes[Math.floor(Math.random() * allQuizzes.length)];
+    },
+
+    // --- Global Data ---
+
+    loadGlobalData() {
+        const data = Storage.load(Storage.keys.GLOBAL);
+        if (data) {
+            this.global = { ...this.global, ...data };
+        }
+        const changed = this.ensureDefaultUnlockedBonusCards();
+        this.ensureBonusPoolPresetState();
+        if (changed) this.saveGlobalData();
+    },
+
+    saveGlobalData() {
+        Storage.save(Storage.keys.GLOBAL, this.global);
+    },
+
+
+    ensureDefaultUnlockedBonusCards() {
+        if (!Array.isArray(this.global.unlocked_bonus_cards)) {
+            this.global.unlocked_bonus_cards = [];
+        }
+
+        const defaults = (typeof GameUtils !== 'undefined' && typeof GameUtils.getDefaultUnlockedBonusCardIds === 'function')
+            ? GameUtils.getDefaultUnlockedBonusCardIds()
+            : [];
+
+        let changed = false;
+        defaults.forEach(id => {
+            if (!this.global.unlocked_bonus_cards.includes(id)) {
+                this.global.unlocked_bonus_cards.push(id);
+                changed = true;
+            }
+        });
+        return changed;
+    },
+
+
+    getStandardBonusCards() {
+        if (typeof GameUtils !== 'undefined' && typeof GameUtils.getBonusCards === 'function') {
+            return GameUtils.getBonusCards().filter(card => card.unlockSource !== 'hidden');
+        }
+        return BONUS_CARDS.filter(card => card.unlockSource !== 'hidden');
+    },
+
+
+    getHiddenBonusCards() {
+        if (typeof GameUtils !== 'undefined' && typeof GameUtils.getBonusCards === 'function') {
+            return GameUtils.getBonusCards().filter(card => card.unlockSource === 'hidden');
+        }
+        return BONUS_CARDS.filter(card => card.unlockSource === 'hidden');
+    },
+
+
+    getGradeSortValue(grade) {
+        const gradeOrder = {
+            transcendence: 0,
+            legend: 1,
+            epic: 2,
+            rare: 3,
+            normal: 4,
+            event: 5
+        };
+        return gradeOrder[grade] ?? 99;
+    },
+
+
+    sortCardDataByGrade(cards) {
+        return [...cards].sort((a, b) => {
+            const gradeDiff = this.getGradeSortValue(a.grade) - this.getGradeSortValue(b.grade);
+            if (gradeDiff !== 0) return gradeDiff;
+            return a.name.localeCompare(b.name, 'ko');
+        });
+    },
+
+
+    sortCardIdsByGrade(ids) {
+        return [...ids].sort((a, b) => {
+            const cardA = this.getCardData(a);
+            const cardB = this.getCardData(b);
+            if (!cardA && !cardB) return 0;
+            if (!cardA) return 1;
+            if (!cardB) return -1;
+            const gradeDiff = this.getGradeSortValue(cardA.grade) - this.getGradeSortValue(cardB.grade);
+            if (gradeDiff !== 0) return gradeDiff;
+            return cardA.name.localeCompare(cardB.name, 'ko');
+        });
+    },
+
+
+    sortBlessingsByGrade(blessings) {
+        return [...blessings].sort((a, b) => {
+            const gradeDiff = this.getGradeSortValue(a.grade) - this.getGradeSortValue(b.grade);
+            if (gradeDiff !== 0) return gradeDiff;
+            return a.name.localeCompare(b.name, 'ko');
+        });
+    },
+
+
+    getCurrentMonthKey() {
+        const now = new Date();
+        return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    },
+
+
+    createMonthlyMissionState() {
+        const hiddenCards = this.getHiddenBonusCards();
+        const lockedHidden = hiddenCards.filter(card => !(this.global.unlocked_bonus_cards || []).includes(card.id));
+        const rewardPool = lockedHidden.length > 0 ? lockedHidden : hiddenCards;
+        const rewardCard = rewardPool[Math.floor(Math.random() * rewardPool.length)] || null;
+        return {
+            monthKey: this.getCurrentMonthKey(),
+            rewardCardId: rewardCard ? rewardCard.id : null,
+            claimed: false,
+            missions: {
+                endless40: { label: '무한 모드 40 스테이지 돌파', progress: 0, target: 1 },
+                challenge3: { label: '챌린지 모드 클리어 3회', progress: 0, target: 3 },
+                toeic3: { label: '실전마법연습 3회 플레이', progress: 0, target: 3 }
+            }
+        };
+    },
+
+
+    ensureMonthlyMissionState() {
+        const currentKey = this.getCurrentMonthKey();
+        if (!this.global.monthlyMission || this.global.monthlyMission.monthKey !== currentKey) {
+            this.global.monthlyMission = this.createMonthlyMissionState();
+            this.saveGlobalData();
+        }
+        return this.global.monthlyMission;
+    },
+
+
+    incrementMonthlyMissionProgress(id, amount = 1) {
+        const monthly = this.ensureMonthlyMissionState();
+        const mission = monthly.missions ? monthly.missions[id] : null;
+        if (!mission) return;
+        mission.progress = Math.min(mission.target, (mission.progress || 0) + amount);
+        this.saveGlobalData();
+    },
+
+
+    areAllMonthlyMissionsCleared() {
+        const monthly = this.ensureMonthlyMissionState();
+        return Object.values(monthly.missions || {}).every(mission => (mission.progress || 0) >= mission.target);
+    },
+
+
+    claimMonthlyMissionReward() {
+        const monthly = this.ensureMonthlyMissionState();
+        if (monthly.claimed) return this.showAlert('이번 달 보상은 이미 수령했습니다.');
+        if (!this.areAllMonthlyMissionsCleared()) return this.showAlert('모든 월간 미션을 완료해야 보상을 받을 수 있습니다.');
+        const reward = monthly.rewardCardId ? this.getCardData(monthly.rewardCardId) : null;
+        if (!reward) return this.showAlert('이번 달 보상 카드가 없습니다.');
+
+        if (!this.global.unlocked_bonus_cards.includes(reward.id)) {
+            this.global.unlocked_bonus_cards.push(reward.id);
+        }
+        monthly.claimed = true;
+        this.saveGlobalData();
+        this.updateBonusPoolEditorButton();
+        this.renderMonthlyMission();
+        this.openInfoModal('월간 미션 보상', `<b>${reward.name}</b> 이(가) 보너스 카드로 해금되었습니다!`);
+    },
+
+
+    registerToeicPracticeAttempt(options = {}) {
+        if (options.countMonthly !== false) {
+            this.incrementMonthlyMissionProgress('toeic3', 1);
+        }
+
+        if (options.countHiddenUnlock === false || this.state.mode === 'dream_corridor') {
+            return false;
+        }
+
+        let unlocked = false;
+        if (this.global.tutoringEventEnabled === false) {
+            this.global.hiddenStudyPracticeCount = (this.global.hiddenStudyPracticeCount || 0) + 1;
+            if (!this.global.hiddenStudyReady && this.global.hiddenStudyPracticeCount >= 5) {
+                this.global.hiddenStudyReady = true;
+                unlocked = true;
+            }
+        } else {
+            this.global.hiddenStudyPracticeCount = 0;
+        }
+        this.saveGlobalData();
+        return unlocked;
+    },
+
+
+    clearPendingEnemySelection() {
+        this.state.pendingEnemyId = null;
+        this.state.pendingEnemyStage = null;
+    },
+
+
+    getEnemyDataById(id) {
+        return ENEMIES.find(enemy => enemy.id === id) || ENEMIES[0];
+    },
+
+
+    getCurrentStageEnemyData() {
+        if (this.state.pendingEnemyStage === this.state.enemyScale && this.state.pendingEnemyId) {
+            return this.getEnemyDataById(this.state.pendingEnemyId);
+        }
+
+        const rotation = (typeof ENDLESS_ENEMY_ROTATION !== 'undefined' && ENDLESS_ENEMY_ROTATION.length > 0)
+            ? ENDLESS_ENEMY_ROTATION
+            : ENEMIES.slice(0, 6).map(enemy => enemy.id);
+        const baseId = rotation[this.state.enemyScale % rotation.length];
+        const stageNumber = this.state.enemyScale + 1;
+        const hiddenBossMap = {
+            iris_curse: 'thor',
+            pharaoh: 'poseidon',
+            demon_god: 'ares'
+        };
+
+        let enemyId = baseId;
+        if (this.state.gameType === 'endless' && stageNumber > 36 && hiddenBossMap[baseId] && Math.random() < 0.3) {
+            enemyId = hiddenBossMap[baseId];
+        }
+
+        this.state.pendingEnemyStage = this.state.enemyScale;
+        this.state.pendingEnemyId = enemyId;
+        return this.getEnemyDataById(enemyId);
+    },
+
+
+    checkDailyChaosTicket() {
+        const today = new Date().toDateString();
+        if (this.global.lastRewardDate !== today) {
+            this.global.lastRewardDate = today;
+            this.global.chaosTickets = (this.global.chaosTickets || 0) + 1;
+            this.saveGlobalData();
+            this.showAlert("출석 보상: 카오스 티켓 1장을 획득했습니다!");
+        }
+    },
+
+
+    checkAllBonusUnlocked() {
+        if (!this.global.unlocked_bonus_cards) return false;
+        return this.getStandardBonusCards().every(c => this.global.unlocked_bonus_cards.includes(c.id));
+    },
+
+
+    getUnlockedBonusCards() {
+        const unlocked = new Set(this.global.unlocked_bonus_cards || []);
+        return this.getStandardBonusCards()
+            .concat(this.getHiddenBonusCards())
+            .filter(card => unlocked.has(card.id));
+    },
+
+
+    getUnlockedBonusTranscendenceCards() {
+        const unlocked = new Set(this.global.unlocked_bonus_transcendence_cards || []);
+        const bonusTranscendenceCards = typeof BONUS_TRANSCENDENCE_CARDS !== 'undefined'
+            ? BONUS_TRANSCENDENCE_CARDS
+            : [];
+        return bonusTranscendenceCards.filter(card => unlocked.has(card.id));
+    },
+
+
+    normalizeActiveBonusPoolIds(ids) {
+        const unlockedIds = this.getUnlockedBonusCards().map(card => card.id);
+        if (unlockedIds.length === 0) return [];
+        if (!Array.isArray(ids)) return [...unlockedIds];
+
+        const allowed = new Set(unlockedIds);
+        const normalized = [];
+        ids.forEach(id => {
+            if (allowed.has(id) && !normalized.includes(id)) normalized.push(id);
+        });
+        return normalized;
+    },
+
+
+    ensureBonusPoolPresetState() {
+        const maxPresets = GAME_CONSTANTS.MAX_BONUS_POOL_PRESETS || 3;
+        const presets = Array.isArray(this.global.bonusPoolPresets)
+            ? this.global.bonusPoolPresets.slice(0, maxPresets)
+            : [];
+
+        while (presets.length < maxPresets) {
+            presets.push(null);
+        }
+
+        this.global.bonusPoolPresets = presets.map(preset => {
+            if (!Array.isArray(preset)) return null;
+            const deduped = [];
+            preset.forEach(id => {
+                if (!deduped.includes(id)) deduped.push(id);
+            });
+            return deduped;
+        });
+
+        const activeIndex = Number.isInteger(this.global.activeBonusPoolPresetIndex)
+            ? this.global.activeBonusPoolPresetIndex
+            : 0;
+        this.global.activeBonusPoolPresetIndex = Math.min(maxPresets - 1, Math.max(0, activeIndex));
+
+        if (!Array.isArray(this.global.unlocked_bonus_transcendence_cards)) {
+            this.global.unlocked_bonus_transcendence_cards = [];
+        }
+    },
+
+
+    getActiveBonusPoolPresetIndex() {
+        this.ensureBonusPoolPresetState();
+        return this.global.activeBonusPoolPresetIndex;
+    },
+
+
+    getBonusPoolPresetIds(index = this.getActiveBonusPoolPresetIndex()) {
+        this.ensureBonusPoolPresetState();
+        return this.normalizeActiveBonusPoolIds(this.global.bonusPoolPresets[index]);
+    },
+
+
+    syncPendingActiveBonusPoolIds() {
+        this.pendingActiveBonusPoolIds = [...this.getBonusPoolPresetIds()];
+    },
+
+
+    persistPendingActiveBonusPoolIds() {
+        this.ensureBonusPoolPresetState();
+        const activeIndex = this.getActiveBonusPoolPresetIndex();
+        const normalizedIds = this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds);
+        this.global.bonusPoolPresets[activeIndex] = [...normalizedIds];
+        this.pendingActiveBonusPoolIds = [...normalizedIds];
+        this.saveGlobalData();
+    },
+
+
+    selectBonusPoolPreset(index) {
+        this.ensureBonusPoolPresetState();
+        if (index < 0 || index >= this.global.bonusPoolPresets.length) return;
+
+        this.global.activeBonusPoolPresetIndex = index;
+        this.syncPendingActiveBonusPoolIds();
+        this.saveGlobalData();
+        this.renderBonusPoolEditor();
+        this.updateBonusPoolEditorButton();
+    },
+
+
+    buildChaosRoulettePool() {
+        return GameUtils.buildTranscendencePool(this.global, {
+            excludeIds: this.global.pendingTranscendenceCards || []
+        });
+    },
+
+
+    tryUnlockBonusTranscendence() {
+        const enemy = this.battle ? this.battle.enemy : null;
+        const rewardId = enemy ? enemy.bonusTranscendenceReward : null;
+        if (!rewardId) return '';
+
+        this.ensureBonusPoolPresetState();
+        if (this.global.unlocked_bonus_transcendence_cards.includes(rewardId)) return '';
+        if (Math.random() >= 0.1) return '';
+
+        this.global.unlocked_bonus_transcendence_cards.push(rewardId);
+        this.saveGlobalData();
+
+        const unlockedCard = this.getCardData(rewardId);
+        if (!unlockedCard) return '<b>[보너스초월]</b> 새로운 초월 카드가 카오스 룰렛에 추가되었습니다!';
+        return `<b>[보너스초월]</b> ${unlockedCard.name}이(가) 카오스 룰렛에 해금되었습니다!`;
+    },
+
+
+    isWeightedTranscendenceRunMode() {
+        return this.state.gameType === 'endless' && ['chaos', 'draft'].includes(this.state.mode);
+    },
+
+
+    drawRunPoolCards(pool, count, options = {}) {
+        if (!Array.isArray(pool) || pool.length === 0 || count <= 0) return [];
+
+        if (this.isWeightedTranscendenceRunMode()) {
+            return GameUtils.drawWeightedCards(
+                pool,
+                count,
+                card => (card.grade === 'transcendence' ? 0.5 : 1.0),
+                options
+            );
+        }
+
+        if (options.allowDuplicates) {
+            const picks = [];
+            for (let i = 0; i < count; i++) {
+                picks.push(pool[Math.floor(Math.random() * pool.length)]);
+            }
+            return picks;
+        }
+
+        return [...pool]
+            .sort(() => Math.random() - 0.5)
+            .slice(0, count);
+    },
+
+
+    buildChaosPoolCardIds(pool) {
+        return this.drawRunPoolCards(pool, GAME_CONSTANTS.CHAOS_POOL_SIZE).map(card => card.id);
+    },
+
+
+    resetPendingActiveBonusPoolIds() {
+        this.syncPendingActiveBonusPoolIds();
+        this.updateBonusPoolEditorButton();
+    },
+
+
+    startGame(mode, retryCount = 0) {
+        this.hydrateModules();
+        const missing = this.getMissingRequiredData();
+
+        if (missing.length > 0) {
+            if (retryCount < GAME_CONSTANTS.LOADING.START_RETRY_LIMIT) {
+                setTimeout(() => this.startGame(mode, retryCount + 1), GAME_CONSTANTS.LOADING.START_RETRY_DELAY_MS);
+                return;
+            }
+            const names = missing.map(d => d.name).join(', ');
+            this.showAlert(`게임 데이터 로드 실패: ${names}<br><br>파일이 같은 폴더에 있는지 확인하고 게임을 새로고침 해주세요.`);
+            return; // 게임 진입 차단
+        }
+
+        this.loadGlobalData();
+        this.ensureMonthlyMissionState();
+        this.checkDailyChaosTicket();
+
+        if (mode === 'load') {
+            const save = Storage.load(Storage.keys.SAVE);
+            if (save) {
+                this.state = { ...this.state, ...save };
+                if (this.state.chaosBlessingUses === undefined) this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
+                if (this.state.greatSageBlessingUses === undefined) this.state.greatSageBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
+                if (!this.state.chaosBuffs) this.state.chaosBuffs = [];
+                if (!this.state.activeChaosBlessing) this.state.activeChaosBlessing = [];
+                if (!this.state.activeSageBlessing) this.state.activeSageBlessing = [];
+                if (!this.state.tutoredItems) this.state.tutoredItems = [];
+                if (!this.state.mode) this.state.mode = 'origin';
+                if (!this.state.quiz_stats) this.state.quiz_stats = { correct: 0, total: 0 };
+                if (!this.state.artifacts) this.state.artifacts = [];
+                if (this.state.pendingEnemyId === undefined) this.state.pendingEnemyId = null;
+                if (this.state.pendingEnemyStage === undefined) this.state.pendingEnemyStage = null;
+                this.state.activeBonusPoolIds = this.normalizeActiveBonusPoolIds(this.state.activeBonusPoolIds);
+                this.loadStudyProgress();
+
+                this.showAlert("불러오기 완료");
+                this.toMenu();
+            } else { this.showAlert("저장된 데이터가 없습니다. 새로 시작합니다."); this.openTypeSelect(); }
+        } else {
+            // New Game Logic: Show Type Select
+            this.openTypeSelect();
+        }
+    },
+
+
+    initNewGame(mode = 'origin') {
+        // Record saving logic (Only for Origin mode as per request "Record check only for Origin")
+        // Check previous state
+        if (this.state.mode === 'origin' && this.state.enemyScale > 0) {
+            this.saveRecord();
+        }
+
+        let initTickets = GameUtils.getInitialTickets(mode);
+
+        this.state = {
+            mode: mode,
+            gameType: this.tempGameType || 'challenge',
+            tickets: initTickets,
+            inventory: [],
+            deck: [null, null, null],
+            enemyScale: 0,
+            chaosBlessingUses: GAME_CONSTANTS.DEFAULT_BLESSING_USES,
+            greatSageBlessingUses: GAME_CONSTANTS.DEFAULT_BLESSING_USES,
+            chaosBuffs: [],
+            activeChaosBlessing: [],
+            activeSageBlessing: [],
+            activeBonusPoolIds: this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds),
+            tutoredItems: [],
+            wrongWords: [],
+            quiz_stats: { correct: 0, total: 0 },
+            chaosPool: [],
+            draft: { active: false, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] },
+            artifacts: [],
+            pendingEnemyId: null,
+            pendingEnemyStage: null,
+            // [목적] 카오스/드래프트 모드에서 해당 런에서만 유효한 이벤트 카드 목록을 초기화
+            activeEventCards: []
+        };
+
+        if (mode === 'dream_corridor') {
+            this.global.hiddenStudyReady = false;
+            this.global.hiddenStudyPracticeCount = 0;
+            this.saveGlobalData();
+        }
+
+        // Transfer Pending Transcendence to Active State (Endless Only)
+        if (this.state.gameType === 'endless') {
+            this.state.activeTranscendenceCards = [...(this.global.pendingTranscendenceCards || [])];
+            this.global.pendingTranscendenceCards = [];
+            this.saveGlobalData();
+        } else {
+            this.state.activeTranscendenceCards = [];
+        }
+
+        if (mode === 'chaos') {
+            let allCards = GameUtils.buildCardPool(this.global, {
+                includeTranscendence: true,
+                activeTranscendenceCards: this.state.activeTranscendenceCards,
+                activeBonusPoolIds: this.state.activeBonusPoolIds,
+                // [목적] 해당 런에서 획득한 이벤트 카드를 카오스 모드 시작 풀에 포함
+                activeEventCards: this.state.activeEventCards
+            });
+
+            const picks = this.buildChaosPoolCardIds(allCards);
+
+            this.state.chaosPool = picks;
+            this.state.inventory = [...picks];
+        }
+
+        // Origin Mode: Add Transcendence Cards directly to Inventory
+        if (mode !== 'chaos' && mode !== 'draft' && this.state.activeTranscendenceCards.length > 0) {
+            this.state.inventory.push(...this.state.activeTranscendenceCards);
+            setTimeout(() => this.showAlert(`초월 카드 ${this.state.activeTranscendenceCards.length}장이 인벤토리에 합류했습니다!`), 500);
+        }
+
+        this.loadStudyProgress();
+        this.saveGame();
+    },
+
+
+    saveGame(showMessage = true) {
+        Storage.save(Storage.keys.SAVE, this.state);
+        this.saveStudyProgress();
+        this.saveGlobalData(); // Also save global just in case
+        if (showMessage) this.showAlert("저장되었습니다.");
+    },
+
+
+    saveRecord(score = null) {
+        let history = Storage.load(Storage.keys.RECORDS) || [];
+        let currentStage = score !== null ? score : (this.state.enemyScale + 1);
+
+        let stages = history.map(h => {
+            let m = h.match(/최대 스테이지: (\d+)/);
+            return m ? parseInt(m[1]) : 0;
+        });
+
+        stages.push(currentStage);
+        stages.sort((a, b) => b - a);
+        stages = stages.slice(0, GAME_CONSTANTS.MAX_RECORDS);
+
+        history = stages.map(s => `최대 스테이지: ${s}`);
+        Storage.save(Storage.keys.RECORDS, history);
+    },
+
+
+    showRecords() {
+        let history = Storage.load(Storage.keys.RECORDS) || [];
+        if (history.length === 0) return this.showAlert("기록이 없습니다.");
+        let msg = history.map((h, i) => `${i + 1}위. ${h}`).join("<br>");
+        this.openInfoModal("최대 스테이지 기록 (Top 5)", msg);
+    },
+
+    // --- Screen Navigation ---
+
+    toggleTutoringEvent() {
+        if (this.global.tutoringEventEnabled === undefined) this.global.tutoringEventEnabled = true;
+        this.global.tutoringEventEnabled = !this.global.tutoringEventEnabled;
+        if (this.global.tutoringEventEnabled) {
+            this.global.hiddenStudyPracticeCount = 0;
+        }
+        this.saveGlobalData();
+        this.updateSystemMenuUI();
+    },
+
+
+    checkActiveChaosBlessings() {
+        if (!this.state.chaosBuffs || this.state.chaosBuffs.length === 0) {
+            return this.showAlert("현재 적용된 축복이 없습니다.");
+        }
+        let msg = "<b>현재 적용된 축복</b><br><br>";
+        this.sortBlessingsByGrade(this.state.chaosBuffs).forEach(b => {
+            msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}%, 치명타/회피율 증가`;
+            msg += "<br>";
+        });
+        msg += "<br>(전투 시작 시 해당 카드의 체력이 모두 회복됩니다.)";
+        this.openInfoModal("축복 상태", msg);
+    },
+
+    startGrammarQuiz(q, successCallback = null, failCallback = null) {
+        const onCorrect = successCallback
+            ? successCallback
+            : () => this.applyGreatSageBlessing();
+        const onWrong = failCallback
+            ? failCallback
+            : () => {
+                this.state.greatSageBlessingUses--;
+                this.showAlert(`틀렸어... 남은 기회: ${this.state.greatSageBlessingUses}회`);
+            };
+        const config = QuizEngine.buildGrammarQuiz(q, onCorrect, onWrong);
+        QuizEngine.show(config);
+    },
+
+
+    updateMergedBlessings() {
+        this.state.chaosBuffs = [];
+
+        const addBuffs = (list) => {
+            list.forEach(nb => {
+                let existing = this.state.chaosBuffs.find(b => b.id === nb.id);
+                if (existing) {
+                    existing.multiplier += nb.multiplier;
+                } else {
+                    this.state.chaosBuffs.push({ ...nb });
+                }
+            });
+        };
+
+        if (this.state.activeChaosBlessing) addBuffs(this.state.activeChaosBlessing);
+        if (this.state.activeSageBlessing) addBuffs(this.state.activeSageBlessing);
+        this.state.chaosBuffs = this.sortBlessingsByGrade(this.state.chaosBuffs);
+    },
+
+
+    applyChaosBlessing(count) {
+        this.state.chaosBlessingUses--;
+
+        // 1. Build Pool
+        let pool = GameUtils.buildCardPool(this.global, {
+            excludeTranscendence: true,
+            excludeEvent: true,
+            activeBonusPoolIds: this.state.activeBonusPoolIds,
+            maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
+        });
+
+        // 2. Shuffle and Pick
+        pool.sort(() => 0.5 - Math.random());
+        let picks = pool.slice(0, count);
+
+        this.state.activeSageBlessing = []; // Clear Sage Blessing
+
+        let newBuffs = picks.map(c => {
+            let mult = 0;
+            if (c.grade === 'normal') mult = 0.4;
+            else if (c.grade === 'rare') mult = 0.3;
+            else if (c.grade === 'epic') mult = 0.2;
+            else if (c.grade === 'legend') mult = 0.1;
+            return { id: c.id, name: c.name, grade: c.grade, multiplier: mult };
+        });
+        newBuffs = this.sortBlessingsByGrade(newBuffs);
+
+        // Set to activeChaosBlessing (Replacing previous)
+        this.state.activeChaosBlessing = newBuffs;
+        this.updateMergedBlessings();
+
+        let msg = "<b>혼돈의 축복 적용!</b><br>새로운 축복이 부여되었습니다.<br><br><b>[새로 적용된 축복]</b><br>";
+        newBuffs.forEach(b => {
+            msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}%, 치명타/회피율 증가<br>`;
+        });
+        msg += `<br><b>(현재 총 활성화된 축복: ${this.state.chaosBuffs.length}개)</b><br>(전투 시작 시 해당 카드의 체력이 모두 회복됩니다.)`;
+        this.openInfoModal("축복 성공", msg);
+    },
+
+    // --- Gacha & Deck UI ---
+
+    startCollocationQuiz(callback) {
+        const config = QuizEngine.buildCollocationQuiz(callback);
+        if (!config) return this.showAlert("데이터 로드 오류: Collocation 데이터가 없습니다.");
+        QuizEngine.show(config);
+    },
+
+
+    startQuiz(callback) {
+        const config = QuizEngine.buildVocabQuiz(callback);
+        if (!config) return this.showAlert("데이터 로드 오류: 단어 데이터가 없습니다.");
+        QuizEngine.show(config);
+    },
+
+
+    startChaosQuiz(callback) {
+        const config = QuizEngine.buildChaosQuiz(callback);
+        if (!config) return this.showAlert("데이터 로드 오류: 단어 데이터가 없습니다.");
+        QuizEngine.show(config);
+    },
+
+    startDraft() {
+        if (this.state.deck.every(x => x !== null)) {
+            return this.showAlert("이미 덱이 완성되어 있습니다. 전투에 진입하세요.");
+        }
+
+        if (!this.state.draft) this.state.draft = { active: true, round: 0, rerolls: 3, currentOptions: [] };
+
+        // Find first empty slot
+        this.state.draft.round = this.state.deck.indexOf(null);
+        if (this.state.draft.round === -1) {
+            this.state.draft.round = 0;
+        }
+
+        this.showScreen('screen-draft');
+        this.renderDraftScreen();
+    },
+
+
+    generateDraftOptions() {
+        let pool = GameUtils.buildCardPool(this.global, {
+            includeTranscendence: true,
+            activeTranscendenceCards: this.state.activeTranscendenceCards,
+            activeBonusPoolIds: this.state.activeBonusPoolIds,
+            // [목적] 드래프트 선택지에 획득한 이벤트 카드가 등장하도록 함
+            activeEventCards: this.state.activeEventCards
+        });
+
+        const options = this.drawRunPoolCards(pool, 4, { allowDuplicates: true }).map(card => card.id);
+        this.state.draft.currentOptions = options;
+    },
+
+
+    selectDraftCard(id) {
+        this.state.inventory.push(id);
+        this.state.deck[this.state.draft.round] = id;
+
+        // Clear options for next round
+        this.state.draft.currentOptions = [];
+
+        if (this.state.deck.indexOf(null) === -1) {
+            this.showAlert("덱 구성 완료!");
+            this.toMenu();
+        } else {
+            this.startDraft();
+        }
+    },
+
+
+    resetDraftState() {
+        // Called when initializing new draft cycle
+        this.state.inventory = [];
+        this.state.deck = [null, null, null];
+        this.state.draft = { active: true, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] };
+    },
+
+
+    cleanupTranscendenceCards() {
+        if (['draft', 'chaos'].includes(this.state.mode)) return "";
+
+        let removedNames = [];
+        this.battle.players.forEach((p, idx) => {
+            if (p && p.proto.grade === 'transcendence') {
+                // Remove from Inventory
+                const invIdx = this.state.inventory.indexOf(p.id);
+                if (invIdx > -1) {
+                    this.state.inventory.splice(invIdx, 1);
+                }
+                // Remove from Deck
+                if (this.state.deck[idx] === p.id) {
+                    this.state.deck[idx] = null;
+                }
+                removedNames.push(p.name);
+            }
+        });
+
+        if (removedNames.length > 0) {
+            const msg = `초월 카드 소멸: ${removedNames.join(', ')}`;
+            this.log(`<span style="color:#ffd700">[시스템] ${msg}</span>`);
+            return `<br><span style="color:#ffd700">${msg}</span>`;
+        }
+        return "";
+    },
+
+
+    handlePermadeath(players) {
+        let deadNames = [];
+        players.forEach(p => {
+            if (p && p.isDead) {
+                let idx = this.state.inventory.indexOf(p.id);
+                if (idx > -1) this.state.inventory.splice(idx, 1);
+                if (p.pos !== undefined) this.state.deck[p.pos] = null;
+                deadNames.push(p.name);
+            }
+        });
+        if (deadNames.length > 0) return `전사자 발생: ${deadNames.join(', ')}<br>(카드가 소멸했습니다)`;
+        return "";
+    },
+
+
+    winBattle() {
+        let transMsg = this.cleanupTranscendenceCards();
+        let deadMsg = this.handlePermadeath(this.battle.players);
+        if (transMsg) deadMsg += transMsg;
+        let reward = GAME_CONSTANTS.MODE_REWARDS[this.state.mode] !== undefined
+            ? GAME_CONSTANTS.MODE_REWARDS[this.state.mode]
+            : GAME_CONSTANTS.MODE_REWARDS.default;
+
+        if (this.battle.players.some(p => p && p.proto.trait.type === 'looter')) {
+            reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
+        }
+        if (this.state.mode === 'overdrive') {
+            reward += GAME_CONSTANTS.BONUS_REWARDS.OVERDRIVE;
+        }
+        if (this.battle.enemy && this.battle.enemy.bonusRewardTickets) {
+            reward += this.battle.enemy.bonusRewardTickets;
+        }
+
+        this.state.tickets += reward;
+        this.state.enemyScale++;
+        this.clearPendingEnemySelection();
+        const bonusTransUnlockMsg = this.tryUnlockBonusTranscendence();
+        if (bonusTransUnlockMsg) {
+            deadMsg = deadMsg ? `${deadMsg}<br>${bonusTransUnlockMsg}` : bonusTransUnlockMsg;
+        }
+
+        // Reset Chaos Blessing
+        this.state.chaosBlessingUses = GAME_CONSTANTS.DEFAULT_BLESSING_USES;
+        this.state.chaosBuffs = [];
+        this.state.activeChaosBlessing = [];
+        this.state.activeSageBlessing = [];
+
+        this.log(`승리 보상: 뽑기권 ${reward}장 획득.`);
+
+        // Victory Condition Check
+        const mode = this.state.mode;
+        const stage = this.state.enemyScale; // current stage (already incremented)
+        const clearStage = GameUtils.getClearStage(mode, this.state.gameType);
+        const gameClear = stage >= clearStage;
+
+        if (this.state.gameType === 'endless' && stage >= 40) {
+            this.incrementMonthlyMissionProgress('endless40', 1);
+        }
+
+        // Chaos/Draft: Reset Deck/Inventory
+        if (mode === 'chaos') {
+            this.state.inventory = [];
+            this.state.deck = [null, null, null];
+
+            let allCards = GameUtils.buildCardPool(this.global, {
+                includeTranscendence: true,
+                activeTranscendenceCards: this.state.activeTranscendenceCards,
+                activeBonusPoolIds: this.state.activeBonusPoolIds,
+                // [목적] 전투 승리 후 카오스 풀 초기화 시 획득한 이벤트 카드를 포함
+                activeEventCards: this.state.activeEventCards
+            });
+            const nextPicks = this.buildChaosPoolCardIds(allCards);
+            this.state.chaosPool = nextPicks;
+            this.state.inventory = [...nextPicks];
+        }
+
+        if (mode === 'draft') {
+            this.resetDraftState();
+        }
+
+        // Archive Mode: Mandatory Quiz (Direct to finishWinBattle via callback)
+        if (mode === 'archive') {
+            const q = this.getRandomGrammarQuiz();
+            if (!q) {
+                this.finishWinBattle(deadMsg, gameClear, null);
+                return;
+            }
+            this.state.lastArchiveQuizLectureId = q.lecture_id;
+
+            this.startGrammarQuiz(q,
+                () => { // Success
+                    this.state.quiz_stats.correct++;
+                    this.state.quiz_stats.total++;
+                    this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.QUIZ;
+                    setTimeout(() => this.finishWinBattle(deadMsg, gameClear, true), 200);
+                },
+                () => { // Fail
+                    this.state.quiz_stats.total++;
+                    setTimeout(() => this.finishWinBattle(deadMsg, gameClear, false), 200);
+                }
+            );
+            return;
+        }
+
+        if (mode === 'dream_corridor') {
+            this.finishDreamCorridorBattle(deadMsg);
+            return;
+        }
+
+        this.finishWinBattle(deadMsg, gameClear, null);
+    },
+
+
+    finishDreamCorridorBattle(deadMsg) {
+        const stage = this.state.enemyScale;
+        const stepIndex = (stage - 1) % 6;
+        const steps = ['word', 'collocation', 'word', 'grammar', 'word', 'toeic'];
+        const step = steps[stepIndex];
+
+        const finishSuccess = (label) => {
+            let msg = `승리!<br>${label} 성공.`;
+            if (deadMsg) msg += `<br><br>${deadMsg}`;
+            this.openInfoModal('꿈의회랑', msg, () => this.toMenu());
+        };
+
+        const fail = (label) => this.failDreamCorridorRun(`${label}에서 오답이 발생해 꿈의회랑이 종료되었습니다.`);
+
+        if (step === 'word') {
+            this.startQuiz(success => {
+                if (success) finishSuccess('단어 퀴즈');
+                else fail('단어 퀴즈');
+            });
+            return;
+        }
+
+        if (step === 'collocation') {
+            this.startCollocationQuiz(success => {
+                if (success) finishSuccess('숙어 퀴즈');
+                else fail('숙어 퀴즈');
+            });
+            return;
+        }
+
+        if (step === 'grammar') {
+            const q = this.getRandomGrammarQuiz();
+            if (!q) {
+                finishSuccess('문법 퀴즈');
+                return;
+            }
+            this.startGrammarQuiz(q,
+                () => finishSuccess('문법 퀴즈'),
+                () => fail('문법 퀴즈')
+            );
+            return;
+        }
+
+        this.startToeicPractice({
+            ignoreSessionLimit: true,
+            suppressDate: true,
+            lockExit: true,
+            countHiddenUnlock: false,
+            countMonthly: false,
+            onComplete: () => finishSuccess('실전마법연습'),
+            onFailure: () => fail('실전마법연습')
+        });
+    },
+
+
+    failDreamCorridorRun(message) {
+        this.global.hiddenStudyReady = false;
+        this.global.hiddenStudyPracticeCount = 0;
+        this.saveStudyProgress();
+        this.saveGlobalData();
+        Storage.remove(Storage.keys.SAVE);
+        this.openInfoModal('꿈의회랑 종료', message, () => this.toTitle());
+    },
+
+
+    loseBattle() {
+        let transMsg = this.cleanupTranscendenceCards();
+        // No saveRecord here (User request: only on New Game)
+
+        if (['chaos', 'draft'].includes(this.state.mode)) {
+            this.saveRecord();
+        }
+
+        if (this.state.mode === 'origin') {
+            this.global.pendingTranscendenceCards = [];
+            this.saveGlobalData();
+        }
+
+        if (['chaos', 'draft'].includes(this.state.mode)) {
+            Storage.remove(Storage.keys.SAVE);
+
+            let msg = "패배했습니다...<br>이 모드는 패배 시 데이터가 초기화됩니다.";
+            this.openInfoModal("Game Over", msg, () => {
+                this.toTitle();
+            });
+            return;
+        }
+
+        // Reset Chaos Blessing
+        this.state.chaosBlessingUses = 3;
+        this.state.chaosBuffs = [];
+        this.state.activeChaosBlessing = [];
+        this.state.activeSageBlessing = [];
+
+        let deadMsg = this.handlePermadeath(this.battle.players);
+        if (this.state.mode === 'dream_corridor') {
+            let msg = "전투에서 패배해 꿈의회랑 런이 종료되었습니다.";
+            if (deadMsg) msg += `<br><br>${deadMsg}`;
+            if (transMsg) msg += transMsg;
+            this.failDreamCorridorRun(msg);
+            return;
+        }
+
+        let msg = "패배...";
+        if (deadMsg) msg += "<br><br>" + deadMsg;
+        if (transMsg) msg += transMsg;
+        this.openInfoModal("전투 결과", msg, () => this.toMenu());
+    },
+
+
+    getEffectiveStats(char, fieldBuffs) {
+        return Logic.calculateStats(char, fieldBuffs, this.state.mode, this.state.artifacts || [], this.battle.turn || 1);
+    },
+
+
+    getToeicExplanationText(set) {
+        if (!set) return "해설 데이터가 없습니다.";
+        return (typeof TOEIC_EXPLANATIONS !== 'undefined' && TOEIC_EXPLANATIONS[set.id])
+            ? TOEIC_EXPLANATIONS[set.id]
+            : "해설 데이터가 없습니다.";
+    },
+
+
+    getStoredApiKey() {
+        return (Storage.getRaw(Storage.keys.API_KEY) || '').trim();
+    },
+
+
+    getActiveLumiChatSession() {
+        return LumiQuestionRuntime.getActiveSession(
+            this.activeLumiChatSessionKey,
+            this.lumiChatSessions,
+            this.state.currentToeicSession
+        );
+    },
+
+
+    hasArtifact(id) {
+        return (this.state.artifacts || []).includes(id);
+    },
+
+
+    resetToeicProgress(options = {}) {
+        const reset = () => {
+            this.state.completedToeicSets = [];
+            this.saveGame(false);
+            if (!options.silent) {
+                this.showAlert("초기화되었습니다.");
+            }
+        };
+
+        if (options.silent) {
+            reset();
+            return;
+        }
+
+        this.showDoubleConfirm(
+            "모든 실전 연습 기록을 초기화하시겠습니까?",
+            "정말 초기화하시겠습니까?<br>완료한 문제 세트가 다시 등장하게 됩니다.",
+            reset
+        );
+    },
+
+
+    _getDateParams() {
+        // Check secret date flag first
+        if (this.global.secretDateFlag) {
+            const secretSet = SECRET_DATE_SETS[Math.floor(Math.random() * SECRET_DATE_SETS.length)];
+            const weather = (secretSet.location === 'outdoor')
+                ? DATE_WEATHER_OUTDOOR[Math.floor(Math.random() * DATE_WEATHER_OUTDOOR.length)]
+                : '실내';
+            return {
+                theme: secretSet.theme,
+                outfit: secretSet.outfit,
+                weather: weather,
+                keyword: secretSet.keyword,
+                word: secretSet.word,
+                secret: true,
+                cardId: secretSet.cardId,
+                cardName: secretSet.cardName
+            };
+        }
+
+        // Normal date: random theme
+        const themeData = DATE_THEMES[Math.floor(Math.random() * DATE_THEMES.length)];
+
+        // Weather
+        let weather;
+        if (themeData.location === 'indoor') {
+            weather = '실내';
+        } else {
+            weather = DATE_WEATHER_OUTDOOR[Math.floor(Math.random() * DATE_WEATHER_OUTDOOR.length)];
+        }
+
+        // Keyword
+        const keyword = DATE_KEYWORDS[Math.floor(Math.random() * DATE_KEYWORDS.length)];
+
+        // Random word from wordbook
+        let word = 'love'; // fallback
+        if (typeof VOCAB_DATA !== 'undefined' && VOCAB_DATA.length > 0) {
+            const vocab = VOCAB_DATA[Math.floor(Math.random() * VOCAB_DATA.length)];
+            word = vocab.word;
+        }
+
+        return {
+            theme: themeData.theme,
+            outfit: themeData.outfit,
+            weather: weather,
+            keyword: keyword,
+            word: word,
+            secret: false
+        };
+    },
+
+    };
+
+    window.RPGFeatureModules = {
+        install(rpg) {
+            Object.assign(rpg, RPGFeatureMethods);
+        }
+    };
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/toeic.js && node --check card/api.js && node --check card/battle_runtime.js",
+    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/toeic.js && node --check card/api.js && node --check card/battle_runtime.js && node --check card/rpg_features.js",
     "test:smoke": "node scripts/verify_card_smoke.js && node scripts/verify_card_remaster_smoke.js && node scripts/verify_idle_hero_smoke.js",
     "verify": "npm run lint && npm run test:smoke"
   },

--- a/scripts/verify_card_smoke.js
+++ b/scripts/verify_card_smoke.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
 
 function mustContain(filePath, snippets) {
   const content = fs.readFileSync(filePath, 'utf8');
@@ -16,7 +17,10 @@ function run() {
   mustContain(path.join(cardRoot, 'index.html'), [
     'id="modal-toeic-practice"',
     'id="toeic-review-hub"',
-    'initNewGame(mode =',
+    "{ src: 'rpg_features.js'",
+    '_featuresInstalled: false',
+    'hydrateModules() {',
+    'RPGFeatureModules.install(this);',
     'startToeicPractice()',
     'finishToeicSession()',
     'openToeicReview()',
@@ -24,13 +28,21 @@ function run() {
     'id="modal-bonus-pool-editor"',
     'id="bonus-pool-preset-list"',
     'pendingActiveBonusPoolIds:',
-    'activeBonusPoolIds: this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds)',
     'openBonusPoolEditor()',
     'bonusPoolPresets:',
     'activeBonusPoolPresetIndex:',
+    "name: 'RPGFeatureModules'"
+  ]);
+
+  mustContain(path.join(cardRoot, 'rpg_features.js'), [
+    'window.RPGFeatureModules = {',
+    'initNewGame(mode =',
     'buildChaosRoulettePool()',
     'buildChaosPoolCardIds(pool)',
-    'drawRunPoolCards(pool, count, options = {})'
+    'drawRunPoolCards(pool, count, options = {})',
+    'startGame(mode, retryCount = 0)',
+    'claimMonthlyMissionReward()',
+    'activeBonusPoolIds: this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds)'
   ]);
 
   mustContain(path.join(cardRoot, 'logic.js'), [
@@ -52,6 +64,16 @@ function run() {
     "bonusTranscendenceReward: 'trans_poseidon'"
   ]);
   mustContain(path.join(cardRoot, 'toeic.js'), ['const TOEIC_DATA']);
+
+  const htmlPath = path.join(cardRoot, 'index.html');
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const inlineScripts = [...html.matchAll(/<script(?:\s+defer)?>([\s\S]*?)<\/script>/g)].map((match) => match[1]);
+  if (inlineScripts.length < 2) {
+    throw new Error(`${htmlPath} does not contain the expected inline script blocks.`);
+  }
+  inlineScripts.forEach((script, index) => {
+    new vm.Script(script, { filename: `${htmlPath}#script${index + 1}` });
+  });
 
   console.log('Card smoke verification passed.');
 }


### PR DESCRIPTION
## Summary
- split non-UI Card RPG methods out of `card/index.html` into `card/rpg_features.js`
- keep image loading, modal/screen transitions, battle rendering, and other UI shell logic in `card/index.html`
- update loader/hydration and verification so the new module is required and syntax-checked

## Verification
- `npm run verify`
- Playwright browser validation against `card/index.html`
  - boot + feature hydration
  - question flow (`LumiQuestionRuntime.sendMessage` stubbed)
  - mode selection (`challenge` -> `artifact`)
  - game progression (artifact run, battle start, win flow, reward modal)
  - buff/debuff/artifact/trait interaction checks