### PR TITLE
Fix chaos blessing randomness and align private tutoring API to gemini-3.1-pro

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -78,15 +78,25 @@ const GameAPI = {
         // 3. 프롬프트 조합
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
-        // 4. API 호출 (온도는 0.6~0.7 추천: 창의적인 상황 부여 필요)
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`, {
+        // 4. API 호출 (질문하기와 동일하게 3.1-pro / high reasoning / BLOCK_NONE 사용)
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 contents: [{ parts: [{ text: fullPrompt }] }],
                 generationConfig: {
-                    temperature: isMisunderstandingMode ? 0.65 : 0.4
-                }
+                    temperature: isMisunderstandingMode ? 0.65 : 0.4,
+                    thinkingConfig: {
+                        thinkingLevel: 'high'
+                    }
+                },
+                safetySettings: [
+                    { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+                    { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+                    { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+                    { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
+                    { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' }
+                ]
             })
         });
 

--- a/card/index.html
+++ b/card/index.html
@@ -2484,8 +2484,7 @@
                     maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
                 });
 
-                pool.sort(() => 0.5 - Math.random());
-                let picks = pool.slice(0, GAME_CONSTANTS.SAGE_BLESSING_PICK_COUNT);
+                let picks = this.pickUniqueRandomCards(pool, GAME_CONSTANTS.SAGE_BLESSING_PICK_COUNT);
 
                 this.state.activeChaosBlessing = []; // Clear Chaos Blessing
 

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -651,6 +651,15 @@
         this.state.chaosBuffs = this.sortBlessingsByGrade(this.state.chaosBuffs);
     },
 
+    pickUniqueRandomCards(pool, count) {
+        const shuffled = [...pool];
+        for (let i = shuffled.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+        }
+        return shuffled.slice(0, count);
+    },
+
 
     applyChaosBlessing(count) {
         this.state.chaosBlessingUses--;
@@ -663,9 +672,8 @@
             maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
         });
 
-        // 2. Shuffle and Pick
-        pool.sort(() => 0.5 - Math.random());
-        let picks = pool.slice(0, count);
+        // 2. Shuffle and Pick (Fisher-Yates: uniform)
+        let picks = this.pickUniqueRandomCards(pool, count);
 
         this.state.activeSageBlessing = []; // Clear Sage Blessing
 


### PR DESCRIPTION
### Motivation
- Ensure "혼돈의 축복" and related blessing flows pick cards with true uniform probability instead of the biased `sort(() => 0.5 - Math.random())` pattern.
- Make private tutoring API calls use the same runtime/profile as the existing "질문하기" flow (Gemini 3.1-pro, high reasoning, permissive safety thresholds) as requested.

### Description
- Added `pickUniqueRandomCards(pool, count)` (Fisher–Yates) to `card/rpg_features.js` and replaced biased `sort(...).slice(...)` selection in `applyChaosBlessing` to use it for uniform picks. 
- Switched the Great Sage blessing pick path in `card/index.html` to call the same `pickUniqueRandomCards` helper so both blessing flows are consistent.
- Updated `GameAPI.getTutoringContent` in `card/api.js` to call `gemini-3.1-pro-preview` with `thinkingConfig.thinkingLevel: 'high'`, `safetySettings` set to `BLOCK_NONE`, and `encodeURIComponent(apiKey)` for the request URL.

### Testing
- Ran the repository mandatory verification `npm run verify` (runs `lint` + smoke scripts) and it passed (`Card smoke verification passed. Card remaster smoke verification passed. Idle hero smoke verification passed.`).
- Executed a small automated Node sampling script to demonstrate that the previous `sort(() => 0.5 - Math.random())` selection produced a skewed distribution, validating the need for Fisher–Yates (observed non-uniform sample distribution).
- Lint/type checks and the smoke verification scripts completed successfully after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd1e2d43908322957d8fcc92467e29)