### PR TITLE
Switch tutoring to Gemini 3.0 Flash and add Lumi Flash/Pro toggles

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -78,8 +78,8 @@ const GameAPI = {
         // 3. 프롬프트 조합
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
-        // 4. API 호출 (질문하기와 동일하게 3.1-pro / high reasoning / BLOCK_NONE 사용)
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+        // 4. API 호출 (3.0 Flash + high reasoning + BLOCK_NONE)
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -160,6 +160,14 @@ function normalizeGroundingSources(candidate) {
 }
 
 const GEMINI_REASONING_LEVELS = new Set(['low', 'medium', 'high']);
+const GEMINI_MODEL_OPTIONS = Object.freeze({
+    FLASH: 'gemini-3-flash-preview',
+    PRO: 'gemini-3.1-pro-preview'
+});
+
+function normalizeGeminiModel(model) {
+    return Object.values(GEMINI_MODEL_OPTIONS).includes(model) ? model : GEMINI_MODEL_OPTIONS.PRO;
+}
 
 function normalizeThinkingLevel(thinkingLevel) {
     return GEMINI_REASONING_LEVELS.has(thinkingLevel) ? thinkingLevel : 'high';
@@ -169,7 +177,8 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
     const {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
-        thinkingLevel = 'high'
+        thinkingLevel = 'high',
+        model = GEMINI_MODEL_OPTIONS.PRO
     } = options;
 
     const payload = {
@@ -200,7 +209,8 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' }
     ];
 
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+    const selectedModel = normalizeGeminiModel(model);
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${selectedModel}:generateContent?key=${encodeURIComponent(apiKey)}`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -385,6 +395,7 @@ function createGeneralSession() {
             : '너는 형아에게 친근하게 답하는 남성 마법사 루미다.',
         enableSearch: true,
         thinkingLevel: 'high',
+        model: GEMINI_MODEL_OPTIONS.PRO,
         seedHistory: [],
         seedMessages: []
     });
@@ -398,6 +409,7 @@ function createToeicReviewSession(source) {
         systemInstruction: TOEIC_LUMI_SYSTEM_INSTRUCTION,
         enableSearch: true,
         thinkingLevel: 'high',
+        model: GEMINI_MODEL_OPTIONS.PRO,
         source,
         seedHistory: [
             { role: 'user', parts: [{ text: context }] }
@@ -506,7 +518,8 @@ const LumiQuestionRuntime = {
         const result = await GameAPI.askLumiQuestion(apiKey, session.history, {
             systemInstruction: session.systemInstruction,
             enableSearch: session.enableSearch,
-            thinkingLevel: session.thinkingLevel
+            thinkingLevel: session.thinkingLevel,
+            model: session.model
         });
 
         if (result && result.content) {
@@ -522,6 +535,17 @@ const LumiQuestionRuntime = {
 
         return result;
     }
+};
+
+LumiQuestionRuntime.MODELS = GEMINI_MODEL_OPTIONS;
+
+LumiQuestionRuntime.getSessionModel = function (session) {
+    return normalizeGeminiModel(session && session.model);
+};
+
+LumiQuestionRuntime.setSessionModel = function (session, model) {
+    if (!session) return;
+    session.model = normalizeGeminiModel(model);
 };
 
 window.LumiQuestionRuntime = LumiQuestionRuntime;

--- a/card/index.html
+++ b/card/index.html
@@ -1362,6 +1362,12 @@
                     <button id="lumi-chat-close-btn" onclick="RPG.closeLumiQuestion()">나가기</button>
                 </div>
             </div>
+            <div style="display:flex; gap:8px; margin-bottom:8px;">
+                <button id="lumi-model-flash-btn" class="menu-btn" onclick="RPG.selectLumiChatModel('flash')"
+                    style="flex:1; margin-bottom:0; padding:8px 10px;">3.0 Flash</button>
+                <button id="lumi-model-pro-btn" class="menu-btn" onclick="RPG.selectLumiChatModel('pro')"
+                    style="flex:1; margin-bottom:0; padding:8px 10px;">3.1 Pro</button>
+            </div>
             <div id="lumi-chat-log" class="lumi-chat-log"></div>
             <div id="lumi-chat-status" class="lumi-chat-status"></div>
             <div class="lumi-chat-input-container">
@@ -3355,6 +3361,33 @@
                         ? '해설에서 궁금한 점을 입력하세요.'
                         : '질문을 입력하세요.';
                 }
+                this.refreshLumiModelButtons(session);
+            },
+
+            refreshLumiModelButtons(session) {
+                const flashBtn = document.getElementById('lumi-model-flash-btn');
+                const proBtn = document.getElementById('lumi-model-pro-btn');
+                if (!flashBtn || !proBtn || !session || !LumiQuestionRuntime.getSessionModel) return;
+
+                const activeModel = LumiQuestionRuntime.getSessionModel(session);
+                const models = LumiQuestionRuntime.MODELS || {};
+                const isFlash = activeModel === models.FLASH;
+                const applyState = (button, active) => {
+                    button.style.borderColor = active ? '#ffd700' : '#555';
+                    button.style.color = active ? '#ffd700' : '#ddd';
+                    button.style.background = active ? '#3c3200' : '#2f2f2f';
+                };
+                applyState(flashBtn, isFlash);
+                applyState(proBtn, !isFlash);
+            },
+
+            selectLumiChatModel(modelType) {
+                const session = this.getActiveLumiChatSession();
+                if (!session || !LumiQuestionRuntime.setSessionModel) return;
+                const models = LumiQuestionRuntime.MODELS || {};
+                const model = modelType === 'flash' ? models.FLASH : models.PRO;
+                LumiQuestionRuntime.setSessionModel(session, model);
+                this.refreshLumiModelButtons(session);
             },
 
             openLumiChatSession(session, sessionKey) {

--- a/card_remaster/api.js
+++ b/card_remaster/api.js
@@ -78,14 +78,17 @@ const GameAPI = {
         // 3. 프롬프트 조합
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
-        // 4. API 호출 (온도는 0.6~0.7 추천: 창의적인 상황 부여 필요)
+        // 4. API 호출 (3.0 Flash + high reasoning)
         const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 contents: [{ parts: [{ text: fullPrompt }] }],
                 generationConfig: {
-                    temperature: isMisunderstandingMode ? 0.65 : 0.4
+                    temperature: isMisunderstandingMode ? 0.65 : 0.4,
+                    thinkingConfig: {
+                        thinkingLevel: 'high'
+                    }
                 }
             })
         });
@@ -150,6 +153,14 @@ function normalizeGroundingSources(candidate) {
 }
 
 const GEMINI_REASONING_LEVELS = new Set(['low', 'medium', 'high']);
+const GEMINI_MODEL_OPTIONS = Object.freeze({
+    FLASH: 'gemini-3-flash-preview',
+    PRO: 'gemini-3.1-pro-preview'
+});
+
+function normalizeGeminiModel(model) {
+    return Object.values(GEMINI_MODEL_OPTIONS).includes(model) ? model : GEMINI_MODEL_OPTIONS.PRO;
+}
 
 function normalizeThinkingLevel(thinkingLevel) {
     return GEMINI_REASONING_LEVELS.has(thinkingLevel) ? thinkingLevel : 'high';
@@ -159,7 +170,8 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
     const {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
-        thinkingLevel = 'high'
+        thinkingLevel = 'high',
+        model = GEMINI_MODEL_OPTIONS.PRO
     } = options;
 
     const payload = {
@@ -190,7 +202,8 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' }
     ];
 
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+    const selectedModel = normalizeGeminiModel(model);
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${selectedModel}:generateContent?key=${encodeURIComponent(apiKey)}`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -375,6 +388,7 @@ function createGeneralSession() {
             : '너는 형아에게 친근하게 답하는 남성 마법사 루미다.',
         enableSearch: true,
         thinkingLevel: 'high',
+        model: GEMINI_MODEL_OPTIONS.PRO,
         seedHistory: [],
         seedMessages: []
     });
@@ -388,6 +402,7 @@ function createToeicReviewSession(source) {
         systemInstruction: TOEIC_LUMI_SYSTEM_INSTRUCTION,
         enableSearch: true,
         thinkingLevel: 'high',
+        model: GEMINI_MODEL_OPTIONS.PRO,
         source,
         seedHistory: [
             { role: 'user', parts: [{ text: context }] }
@@ -496,7 +511,8 @@ const LumiQuestionRuntime = {
         const result = await GameAPI.askLumiQuestion(apiKey, session.history, {
             systemInstruction: session.systemInstruction,
             enableSearch: session.enableSearch,
-            thinkingLevel: session.thinkingLevel
+            thinkingLevel: session.thinkingLevel,
+            model: session.model
         });
 
         if (result && result.content) {
@@ -512,6 +528,17 @@ const LumiQuestionRuntime = {
 
         return result;
     }
+};
+
+LumiQuestionRuntime.MODELS = GEMINI_MODEL_OPTIONS;
+
+LumiQuestionRuntime.getSessionModel = function (session) {
+    return normalizeGeminiModel(session && session.model);
+};
+
+LumiQuestionRuntime.setSessionModel = function (session, model) {
+    if (!session) return;
+    session.model = normalizeGeminiModel(model);
 };
 
 window.LumiQuestionRuntime = LumiQuestionRuntime;

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -2594,6 +2594,12 @@
                 <div class="lumi-chat-header">
                     <div>
                         <h3>마법구슬 상담실</h3>
+                        <div style="display:flex; gap:8px; margin-top:8px;">
+                            <button id="lumi-model-flash-btn" class="menu-btn" onclick="RPG.selectLumiChatModel('flash')"
+                                style="flex:1; margin-bottom:0; padding:8px 10px;">3.0 Flash</button>
+                            <button id="lumi-model-pro-btn" class="menu-btn" onclick="RPG.selectLumiChatModel('pro')"
+                                style="flex:1; margin-bottom:0; padding:8px 10px;">3.1 Pro</button>
+                        </div>
                     </div>
                     <button id="lumi-chat-close-btn" class="menu-btn" onclick="RPG.closeLumiQuestion()" style="padding:10px 14px; margin-bottom:0;">나가기</button>
                 </div>
@@ -5937,6 +5943,33 @@
                         ? '해설에서 궁금한 점을 적어줘.'
                         : '루미에게 질문을 적어줘.';
                 }
+                this.refreshLumiModelButtons(session);
+            },
+
+            refreshLumiModelButtons(session) {
+                const flashBtn = document.getElementById('lumi-model-flash-btn');
+                const proBtn = document.getElementById('lumi-model-pro-btn');
+                if (!flashBtn || !proBtn || !session || !LumiQuestionRuntime.getSessionModel) return;
+
+                const activeModel = LumiQuestionRuntime.getSessionModel(session);
+                const models = LumiQuestionRuntime.MODELS || {};
+                const isFlash = activeModel === models.FLASH;
+                const applyState = (button, active) => {
+                    button.style.borderColor = active ? '#ffd700' : '#555';
+                    button.style.color = active ? '#ffd700' : '#ddd';
+                    button.style.background = active ? '#3c3200' : '#2f2f2f';
+                };
+                applyState(flashBtn, isFlash);
+                applyState(proBtn, !isFlash);
+            },
+
+            selectLumiChatModel(modelType) {
+                const session = this.getActiveLumiChatSession();
+                if (!session || !LumiQuestionRuntime.setSessionModel) return;
+                const models = LumiQuestionRuntime.MODELS || {};
+                const model = modelType === 'flash' ? models.FLASH : models.PRO;
+                LumiQuestionRuntime.setSessionModel(session, model);
+                this.refreshLumiModelButtons(session);
             },
 
             openLumiChatSession(session, sessionKey) {


### PR DESCRIPTION
### Motivation
- Make the private tutoring API use Gemini 3.0 Flash with high reasoning as requested.
- Allow switching between Flash and Pro models for Lumi chat so users can choose model behavior from the chat modal.
- Ensure TOEIC review and general "루미에게 질문하기" sessions honor the selected model when making API calls.

### Description
- Switched tutoring/generation calls in `card/api.js` and `card_remaster/api.js` to use `gemini-3-flash-preview` and added `thinkingConfig.thinkingLevel = 'high'` for those Flash calls. 
- Introduced `GEMINI_MODEL_OPTIONS`, `normalizeGeminiModel`, and threaded a `model` option through `GameAPI.askLumiQuestion` so the runtime requests the selected Gemini model URL. 
- Added `session.model` defaults and wired session model into `LumiQuestionRuntime` with `MODELS`, `getSessionModel`, and `setSessionModel` helpers so both general and TOEIC sessions store and use the model choice. 
- Updated `card/index.html` and `card_remaster/index.html` to add `3.0 Flash` / `3.1 Pro` toggle buttons in the Lumi chat modal plus `selectLumiChatModel`/`refreshLumiModelButtons` wiring to reflect and change the active model in the UI. 

### Testing
- Ran `npm run verify`, which completed successfully and reported lint checks passed and all smoke verifications passed (`Card smoke`, `Card remaster smoke`, `Idle hero smoke`).
- No automated visual/screenshot checks were performed, so actual in-browser visual appearance and button interaction were not captured in screenshots and remain manually verifiable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd438c752c832283f2a60f44aa6977)