### PR TITLE
Add model toggle to Lumi chat panel

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -169,7 +169,8 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
     const {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
-        thinkingLevel = 'high'
+        thinkingLevel = 'high',
+        model = 'gemini-3.1-pro-preview'
     } = options;
 
     const payload = {
@@ -200,7 +201,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' }
     ];
 
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${encodeURIComponent(apiKey)}`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -409,6 +410,8 @@ function createToeicReviewSession(source) {
 const LumiQuestionRuntime = {
     SESSION_KEYS: LUMI_SESSION_KEYS,
 
+    selectedModel: 'gemini-3.1-pro-preview',
+
     shouldShowToeicQuestionButton(set) {
         return !!set && (set.type === 'part6' || set.type === 'part7');
     },
@@ -506,7 +509,8 @@ const LumiQuestionRuntime = {
         const result = await GameAPI.askLumiQuestion(apiKey, session.history, {
             systemInstruction: session.systemInstruction,
             enableSearch: session.enableSearch,
-            thinkingLevel: session.thinkingLevel
+            thinkingLevel: session.thinkingLevel,
+            model: this.selectedModel
         });
 
         if (result && result.content) {

--- a/card/index.html
+++ b/card/index.html
@@ -1358,6 +1358,7 @@
             <div class="lumi-chat-top">
                 <h3 id="lumi-chat-aside-title" class="lumi-chat-title">루미의 질문하기</h3>
                 <div class="lumi-chat-controls">
+                    <button id="lumi-chat-model-btn" onclick="RPG.toggleLumiChatModel()">3.1 Pro</button>
                     <button id="lumi-chat-reset-btn" onclick="RPG.clearLumiQuestionHistory()">대화 초기화</button>
                     <button id="lumi-chat-close-btn" onclick="RPG.closeLumiQuestion()">나가기</button>
                 </div>
@@ -3346,10 +3347,12 @@
                 const closeBtn = document.getElementById('lumi-chat-close-btn');
                 const resetBtn = document.getElementById('lumi-chat-reset-btn');
                 const input = document.getElementById('lumi-chat-input');
+                const modelBtn = document.getElementById('lumi-chat-model-btn');
 
                 if (asideTitle) asideTitle.innerText = ui.asideTitle || '루미의 질문하기';
                 if (closeBtn) closeBtn.innerText = ui.closeLabel || '나가기';
                 if (resetBtn) resetBtn.innerText = ui.resetLabel || '대화 초기화';
+                if (modelBtn) modelBtn.innerText = LumiQuestionRuntime.selectedModel === 'gemini-3.1-pro-preview' ? '3.1 Pro' : '3.0 Flash';
                 if (input) {
                     input.placeholder = session.mode === 'toeic-review'
                         ? '해설에서 궁금한 점을 입력하세요.'
@@ -3488,6 +3491,18 @@
                 if (input) {
                     input.value = '';
                     input.focus();
+                }
+            },
+
+            toggleLumiChatModel() {
+                if (LumiQuestionRuntime.selectedModel === 'gemini-3.1-pro-preview') {
+                    LumiQuestionRuntime.selectedModel = 'gemini-3.0-flash-preview';
+                } else {
+                    LumiQuestionRuntime.selectedModel = 'gemini-3.1-pro-preview';
+                }
+                const btn = document.getElementById('lumi-chat-model-btn');
+                if (btn) {
+                    btn.innerText = LumiQuestionRuntime.selectedModel === 'gemini-3.1-pro-preview' ? '3.1 Pro' : '3.0 Flash';
                 }
             },
 


### PR DESCRIPTION
This PR implements a toggle button within the "Ask Lumi" (질문하기 / 토익질문) chat panel, allowing users to dynamically switch between the `gemini-3.1-pro-preview` and `gemini-3.0-flash-preview` API models. The selected state is managed locally via `LumiQuestionRuntime` and correctly persists within the session context. UI state correctly updates to show the currently selected model.

---
*PR created automatically by Jules for task [13763565767198287673](https://jules.google.com/task/13763565767198287673) started by @romarin0325-cell*