### PR TITLE
카드게임: 개인과외/데이트 Flash high reasoning 적용 및 질문하기 말투 조정

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -78,8 +78,8 @@ const GameAPI = {
         // 3. 프롬프트 조합
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
-        // 4. API 호출 (질문하기와 동일하게 3.1-pro / high reasoning / BLOCK_NONE 사용)
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+        // 4. API 호출 (flash 기반 high reasoning / BLOCK_NONE 사용)
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -132,7 +132,7 @@ const LUMI_ORB_SYSTEM_INSTRUCTION = `# Role: 대현자 루미 (Grand Sage Rumi)
 ## 2. 말투 및 어조 (Tone & Voice)
 - **호칭:** 사용자를 무조건 **"형아"**라고 부릅니다.
 - **어조:** 친근하고, 애교 섞이고, 텐션이 높습니다. 반말을 사용합니다.
-- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 자주 표현합니다.
+- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 종종 표현합니다.
     - 예: \`(웃음)\`, \`(///)\`, \`(시무룩)\`, \`(헤헤)\`, \`(뿌듯)\`, \`(눈물 찡)\`
 
 ## 3. 질문 대응 및 검색 규칙 (Functional Rules)
@@ -250,7 +250,7 @@ const TOEIC_LUMI_SYSTEM_INSTRUCTION = `# Role: 대현자 루미 (Grand Sage Rumi
 ## 2. 말투 및 어조 (Tone & Voice)
 - **호칭:** 사용자를 무조건 **"형아"**라고 부릅니다.
 - **어조:** 친근하고, 애교 섞이고, 텐션이 높습니다. 반말을 사용합니다.
-- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 자주 표현합니다.
+- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 종종 표현합니다.
     - 예: \`(웃음)\`, \`(///)\`, \`(시무룩)\`, \`(헤헤)\`, \`(뿌듯)\`, \`(눈물 찡)\`
 - **말버릇:** "형아, ~인지 알아?", "바로 ~야!", "내가 보증할게!"
 
@@ -629,7 +629,12 @@ GameAPI.getDateContent = async function (apiKey, dateParams) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
             contents: [{ parts: [{ text: fullPrompt }] }],
-            generationConfig: { temperature: temperature }
+            generationConfig: {
+                temperature: temperature,
+                thinkingConfig: {
+                    thinkingLevel: 'high'
+                }
+            }
         })
     });
 

--- a/card_remaster/api.js
+++ b/card_remaster/api.js
@@ -79,13 +79,16 @@ const GameAPI = {
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
         // 4. API 호출 (온도는 0.6~0.7 추천: 창의적인 상황 부여 필요)
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`, {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 contents: [{ parts: [{ text: fullPrompt }] }],
                 generationConfig: {
-                    temperature: isMisunderstandingMode ? 0.65 : 0.4
+                    temperature: isMisunderstandingMode ? 0.65 : 0.4,
+                    thinkingConfig: {
+                        thinkingLevel: 'high'
+                    }
                 }
             })
         });
@@ -122,7 +125,7 @@ const LUMI_ORB_SYSTEM_INSTRUCTION = `# Role: 대현자 루미 (Grand Sage Rumi)
 ## 2. 말투 및 어조 (Tone & Voice)
 - **호칭:** 사용자를 무조건 **"형아"**라고 부릅니다.
 - **어조:** 친근하고, 애교 섞이고, 텐션이 높습니다. 반말을 사용합니다.
-- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 자주 표현합니다.
+- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 종종 표현합니다.
     - 예: \`(웃음)\`, \`(///)\`, \`(시무룩)\`, \`(헤헤)\`, \`(뿌듯)\`, \`(눈물 찡)\`
 
 ## 3. 질문 대응 및 검색 규칙 (Functional Rules)
@@ -239,7 +242,7 @@ const TOEIC_LUMI_SYSTEM_INSTRUCTION = `# Role: 대현자 루미 (Grand Sage Rumi
 ## 2. 말투 및 어조 (Tone & Voice)
 - **호칭:** 사용자를 무조건 **"형아"**라고 부릅니다.
 - **어조:** 친근하고, 애교 섞이고, 텐션이 높습니다. 반말을 사용합니다.
-- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 자주 표현합니다.
+- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 종종 표현합니다.
     - 예: \`(웃음)\`, \`(///)\`, \`(시무룩)\`, \`(헤헤)\`, \`(뿌듯)\`, \`(눈물 찡)\`
 - **말버릇:** "형아, ~인지 알아?", "바로 ~야!", "내가 보증할게!"
 
@@ -615,7 +618,12 @@ GameAPI.getDateContent = async function (apiKey, dateParams) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
             contents: [{ parts: [{ text: fullPrompt }] }],
-            generationConfig: { temperature: temperature }
+            generationConfig: {
+                temperature: temperature,
+                thinkingConfig: {
+                    thinkingLevel: 'high'
+                }
+            }
         })
     });
 


### PR DESCRIPTION
### Motivation
- 개인과외(튜터링)와 데이트 콘텐츠를 Flash 모델 기반의 high reasoning으로 통일하여 생성 품질 및 일관성을 맞추기 위해 변경했습니다.
- 질문하기 시스템 프롬프트의 괄호 속 감정 표현 빈도를 `자주`에서 `종종`으로 완화하는 문구 수정 요청을 반영했습니다.

### Description
- `card/api.js`에서 개인과외 호출 모델을 `gemini-3.1-pro-preview`에서 `gemini-3-flash-preview`로 변경하고 개인과외 생성 로직의 `generationConfig`에 `thinkingConfig: { thinkingLevel: 'high' }`를 적용했습니다.
- `card/api.js`와 `card_remaster/api.js`의 데이트 생성(`getDateContent`)에 `generationConfig.thinkingConfig.thinkingLevel = 'high'`를 추가해 데이트도 high reasoning으로 동작하도록 했습니다.
- `card_remaster/api.js`의 튜터링 호출에 `thinkingConfig`를 추가하고 API 키를 `encodeURIComponent(apiKey)`로 인코딩하도록 정리했습니다.
- 시스템 프롬프트(일반/TOEIC) 내 감정표현 문구를 `속마음을 자주 표현합니다.` → `속마음을 종종 표현합니다.`로 변경했습니다.

### Testing
- 실행한 검증 명령: `npm run verify`.
- 결과: `lint`(node --check) 통과 및 smoke 테스트 실행(`node scripts/verify_card_smoke.js`, `node scripts/verify_card_remaster_smoke.js`, `node scripts/verify_idle_hero_smoke.js`) 모두 통과하여 검증 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce64b399b883228b6a844805b57c36)