### PR TITLE
카드 보너스/히든 풀 배치 조정 (time_magician / black_swan)

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -737,7 +737,7 @@ const BONUS_CARDS = [
         ]
     },
     {
-        id: 'time_magician', name: '시간의마술사', grade: 'rare', element: 'dark', role: 'balancer',
+        id: 'time_magician', name: '시간의마술사', grade: 'rare', element: 'dark', role: 'balancer', unlockSource: 'hidden',
         stats: { hp: 350, atk: 75, matk: 95, def: 60, mdef: 60 },
         trait: { type: 'instant_delayed_skills', desc: '덱의 지연 스킬이 즉시 발동' },
         skills: [
@@ -882,7 +882,7 @@ const BONUS_CARD_EXPANSION = [
         ]
     },
     {
-        id: 'black_swan', name: '블랙스완', grade: 'normal', element: 'dark', role: 'dealer', unlockSource: 'hidden',
+        id: 'black_swan', name: '블랙스완', grade: 'normal', element: 'dark', role: 'dealer', unlockSource: 'bonus',
         stats: { hp: 310, atk: 60, matk: 90, def: 50, mdef: 55 },
         trait: { type: 'syn_dark_full_party_crit', val: 20, desc: '덱 전체가 어둠속성인 경우 덱 전체 치명타율 20% 증가' },
         skills: [


### PR DESCRIPTION
### Motivation
- 게임 디자인에 따라 `시간의마술사(time_magician)`을 히든 보너스 탭으로 이동하고 `블랙스완(black_swan)`을 보너스 풀로 이동시키기 위해 데이터 속성만 최소 수정했습니다.

### Description
- `card/data.js` 파일에서 `time_magician`에 `unlockSource: 'hidden'`을 추가하고 `black_swan`의 `unlockSource`를 `'hidden'`에서 `'bonus'`로 변경했습니다.

### Testing
- `npm run verify` 를 실행하여 린트와 스모크 테스트(`verify_card_smoke`, `verify_card_remaster_smoke`, `verify_idle_hero_smoke`)가 모두 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7e7d0084832288799e453fd556fb)