### PR TITLE
fix(card): guard weekly chaos ticket reward label against undefined

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -2002,7 +2002,8 @@
                 monthlySection.style.display = showMonthly ? 'block' : 'none';
                 status.innerText = `${monthly.monthKey} 월 미션`;
                 weeklyStatus.innerText = `${weekly.weekLabel} 주간 미션`;
-                weeklyRewardName.innerText = `카오스 티켓 ${GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD}장`;
+                const weeklyRewardAmount = this.getWeeklyChaosTicketRewardAmount();
+                weeklyRewardName.innerText = `카오스 티켓 ${weeklyRewardAmount}장`;
                 list.innerHTML = '';
                 weeklyList.innerHTML = '';
 

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -256,6 +256,14 @@
     },
 
 
+    getWeeklyChaosTicketRewardAmount() {
+        const reward = GAME_CONSTANTS && Number.isFinite(GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD)
+            ? GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD
+            : 3;
+        return reward;
+    },
+
+
     claimMonthlyMissionReward() {
         const monthly = this.ensureMonthlyMissionState();
         if (monthly.claimed) return this.showAlert('이번 달 보상은 이미 수령했습니다.');
@@ -279,11 +287,12 @@
         if (weekly.claimed) return this.showAlert('이번 주 보상은 이미 수령했습니다.');
         if (!this.areAllWeeklyMissionsCleared()) return this.showAlert('모든 주간 미션을 완료해야 보상을 받을 수 있습니다.');
 
+        const rewardAmount = this.getWeeklyChaosTicketRewardAmount();
         weekly.claimed = true;
-        this.global.chaosTickets = (this.global.chaosTickets || 0) + GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD;
+        this.global.chaosTickets = (this.global.chaosTickets || 0) + rewardAmount;
         this.saveGlobalData();
         this.renderMonthlyMission();
-        this.openInfoModal('주간 미션 보상', `카오스 티켓 ${GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD}장을 획득했습니다!`);
+        this.openInfoModal('주간 미션 보상', `카오스 티켓 ${rewardAmount}장을 획득했습니다!`);
     },
 
 

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -3565,6 +3565,13 @@
                 return Object.values(weekly.missions || {}).every(mission => (mission.progress || 0) >= mission.target);
             },
 
+            getWeeklyChaosTicketRewardAmount() {
+                const reward = GAME_CONSTANTS && Number.isFinite(GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD)
+                    ? GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD
+                    : 3;
+                return reward;
+            },
+
             openMonthlyMission() {
                 this.renderMonthlyMission();
                 document.getElementById('modal-monthly-mission').classList.add('active');
@@ -3595,9 +3602,10 @@
 
                 const allClear = this.areAllMonthlyMissionsCleared();
                 const weeklyAllClear = this.areAllWeeklyMissionsCleared();
+                const weeklyRewardAmount = this.getWeeklyChaosTicketRewardAmount();
                 status.innerText = `${monthly.monthKey} 월 미션`;
                 weeklyStatus.innerText = `${weekly.weekLabel} 주간 미션`;
-                weeklyRewardName.innerText = `카오스 티켓 ${GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD}장`;
+                weeklyRewardName.innerText = `카오스 티켓 ${weeklyRewardAmount}장`;
                 list.innerHTML = '';
                 weeklyList.innerHTML = '';
 
@@ -3661,11 +3669,12 @@
                 if (weekly.claimed) return this.showAlert('이번 주 보상은 이미 수령했습니다.');
                 if (!this.areAllWeeklyMissionsCleared()) return this.showAlert('모든 주간 미션을 완료해야 보상을 받을 수 있습니다.');
 
+                const rewardAmount = this.getWeeklyChaosTicketRewardAmount();
                 weekly.claimed = true;
-                this.global.chaosTickets = (this.global.chaosTickets || 0) + GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD;
+                this.global.chaosTickets = (this.global.chaosTickets || 0) + rewardAmount;
                 this.saveGlobalData();
                 this.renderMonthlyMission();
-                this.openInfoModal('주간 미션 보상', `카오스 티켓 ${GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD}장을 획득했습니다!`);
+                this.openInfoModal('주간 미션 보상', `카오스 티켓 ${rewardAmount}장을 획득했습니다!`);
             },
 
             registerToeicPracticeAttempt(options = {}) {


### PR DESCRIPTION
### Motivation
- 주간 미션 보상 텍스트에서 `GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD`가 없거나 비수치일 때 `undefined`가 출력되는 문제를 수정하기 위함입니다.
- 보상 표시와 실제 지급 로직이 일관되게 동작하도록 `card`와 `card_remaster` 양쪽에 수정을 적용했습니다.

### Description
- `card/rpg_features.js`에 `getWeeklyChaosTicketRewardAmount()` 헬퍼를 추가해 `GAME_CONSTANTS.WEEKLY_CHAOS_TICKET_REWARD`가 유효한 숫자가 아니면 기본값 `3`을 반환하도록 했습니다.
- 주간 미션 UI 렌더링에서 상수를 직접 참조하던 코드를 `getWeeklyChaosTicketRewardAmount()`를 사용하도록 변경해 표시 문구(`weekly-mission-reward-name`)가 `undefined`가 되지 않도록 했습니다 (`card/index.html`, `card_remaster/index.html`).
- 주간 보상 수령 흐름(`claimWeeklyMissionReward`)도 헬퍼 반환값을 사용해 실제 지급 수량과 안내 모달 문구가 일치하도록 수정했습니다.
- UI 텍스트 변경은 코드 수준에서 반영되었으나 실제 화면 캡처 기반의 시각적 검증(스크린샷)은 이번 환경에서 수행하지 못했습니다.

### Testing
- 자동화 검증으로 `npm run verify`(내부적으로 `lint` 및 smoke 테스트)를 실행했고 모든 검증이 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2834ec1208322964e2190fa5d7514)