### PR TITLE
card: add flora bonus pools and lumi model toggle

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -36,8 +36,25 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 3.  **심쿵 포인트:** 설명 중간중간 형아에게 애정 표현이나 장난치기. 로맨틱하거나 유머러스한 예문 포함
 4.강의 마무리 멘트`;
 
+const LUMI_MODEL_OPTIONS = Object.freeze([
+    { id: 'gemini-3.1-pro-preview', label: '3.1 Pro', flashLike: false, allowSearch: true },
+    { id: 'gemini-3.0-flash-preview', label: '3.0 Flash', flashLike: true, allowSearch: true },
+    { id: 'gemini-3.1-flash-lite-preview', label: '3.1 Flash Lite', flashLike: true, allowSearch: false }
+]);
+
+function getLumiModelConfig(modelId) {
+    return LUMI_MODEL_OPTIONS.find(option => option.id === modelId) || LUMI_MODEL_OPTIONS[0];
+}
+
+function truncateContextText(text, maxLength) {
+    const normalized = typeof text === 'string' ? text.trim() : '';
+    if (!maxLength || normalized.length <= maxLength) return normalized;
+    return `${normalized.slice(0, maxLength)}\n...(중략)`;
+}
+
 const GameAPI = {
-    async getTutoringContent(apiKey, targetData, type) {
+    async getTutoringContent(apiKey, targetData, type, options = {}) {
+        const modelConfig = getLumiModelConfig(options.model);
         // 1. 30% 확률 (30스테이지 이상 시 50%) (The 'Accidental' Event)
         const enableEvent = RPG.global.tutoringEventEnabled !== false;
         const prob = (RPG.state.enemyScale >= 30) ? 0.5 : 0.3;
@@ -81,7 +98,7 @@ const GameAPI = {
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
         // 4. API 호출 (flash 기반 high reasoning / BLOCK_NONE 사용)
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelConfig.id}:generateContent?key=${encodeURIComponent(apiKey)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -89,7 +106,7 @@ const GameAPI = {
                 generationConfig: {
                     temperature: isMisunderstandingMode ? 0.65 : 0.4,
                     thinkingConfig: {
-                        thinkingLevel: 'high'
+                        thinkingLevel: modelConfig.flashLike ? 'medium' : 'high'
                     }
                 },
                 safetySettings: [
@@ -174,6 +191,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         thinkingLevel = 'high',
         model = 'gemini-3.1-pro-preview'
     } = options;
+    const modelConfig = getLumiModelConfig(model);
 
     const payload = {
         systemInstruction: {
@@ -182,7 +200,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         contents: history
     };
 
-    if (enableSearch) {
+    if (enableSearch && modelConfig.allowSearch) {
         payload.tools = [
             {
                 googleSearch: {}
@@ -192,7 +210,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
 
     payload.generationConfig = {
         thinkingConfig: {
-            thinkingLevel: normalizeThinkingLevel(thinkingLevel)
+            thinkingLevel: normalizeThinkingLevel(modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
         }
     };
     payload.safetySettings = [
@@ -203,7 +221,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' }
     ];
 
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${encodeURIComponent(apiKey)}`, {
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelConfig.id}:generateContent?key=${encodeURIComponent(apiKey)}`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -332,10 +350,13 @@ function buildToeicQuestionBlock(source, question, index) {
     ].join('\n');
 }
 
-function buildToeicContext(source) {
+function buildToeicContext(source, options = {}) {
+    const compact = !!options.compact;
     const questionBlocks = (source.questions || []).map((question, index) =>
         buildToeicQuestionBlock(source, question, index)
     );
+    const passageText = compact ? truncateContextText(source.passage || '', 2400) : (source.passage || '');
+    const explanationText = compact ? truncateContextText(source.explanationText || '', 1600) : (source.explanationText || '');
 
     return [
         '다음은 형아가 지금 보고 있는 TOEIC 실전마법연습 세트 정보야.',
@@ -345,13 +366,13 @@ function buildToeicContext(source) {
         `[파트] ${source.partLabel || ''}`,
         '',
         '[지문]',
-        source.passage || '지문 없음',
+        passageText || '지문 없음',
         '',
         '[문제와 정답]',
         questionBlocks.join('\n\n'),
         '',
         '[해설]',
-        source.explanationText || '해설 없음',
+        explanationText || '해설 없음',
         '',
         '형아가 토익 문제의 문장 해설, 보기 차이, 정답 근거를 물으면 위 정보만 바탕으로 정확히 설명해 줘.'
     ].join('\n');
@@ -394,7 +415,6 @@ function createGeneralSession() {
 }
 
 function createToeicReviewSession(source) {
-    const context = buildToeicContext(source);
     return createSession({
         mode: 'toeic-review',
         ui: TOEIC_LUMI_SESSION_UI,
@@ -402,17 +422,31 @@ function createToeicReviewSession(source) {
         enableSearch: true,
         thinkingLevel: 'high',
         source,
-        seedHistory: [
-            { role: 'user', parts: [{ text: context }] }
-        ],
+        seedHistory: [],
         seedMessages: []
     });
 }
 
 const LumiQuestionRuntime = {
     SESSION_KEYS: LUMI_SESSION_KEYS,
+    MODEL_OPTIONS: LUMI_MODEL_OPTIONS,
 
     selectedModel: 'gemini-3.1-pro-preview',
+
+    getModelConfig(modelId) {
+        return getLumiModelConfig(modelId || this.selectedModel);
+    },
+
+    getSelectedModelLabel() {
+        return this.getModelConfig().label;
+    },
+
+    cycleSelectedModel() {
+        const currentIndex = this.MODEL_OPTIONS.findIndex(option => option.id === this.selectedModel);
+        const nextIndex = currentIndex >= 0 ? (currentIndex + 1) % this.MODEL_OPTIONS.length : 0;
+        this.selectedModel = this.MODEL_OPTIONS[nextIndex].id;
+        return this.selectedModel;
+    },
 
     shouldShowToeicQuestionButton(set) {
         return !!set && (set.type === 'part6' || set.type === 'part7');
@@ -504,15 +538,34 @@ const LumiQuestionRuntime = {
         });
     },
 
+    buildRequestHistory(session, pendingUserContent) {
+        if (!session || session.mode !== 'toeic-review') {
+            return [...session.history, pendingUserContent];
+        }
+
+        const modelConfig = this.getModelConfig();
+        const toeicContext = buildToeicContext(session.source, { compact: modelConfig.flashLike });
+        const priorHistory = modelConfig.flashLike ? session.history.slice(-6) : session.history;
+
+        return [
+            { role: 'user', parts: [{ text: toeicContext }] },
+            ...cloneHistory(priorHistory),
+            pendingUserContent
+        ];
+    },
+
     async sendMessage(apiKey, session, message) {
         session.messages.push({ role: 'user', text: message });
-        session.history.push({ role: 'user', parts: [{ text: message }] });
+        const pendingUserContent = { role: 'user', parts: [{ text: message }] };
+        const modelConfig = this.getModelConfig();
+        const requestHistory = this.buildRequestHistory(session, pendingUserContent);
+        session.history.push(pendingUserContent);
 
-        const result = await GameAPI.askLumiQuestion(apiKey, session.history, {
+        const result = await GameAPI.askLumiQuestion(apiKey, requestHistory, {
             systemInstruction: session.systemInstruction,
-            enableSearch: session.enableSearch,
-            thinkingLevel: session.thinkingLevel,
-            model: this.selectedModel
+            enableSearch: session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
+            thinkingLevel: session.mode === 'toeic-review' && modelConfig.flashLike ? 'medium' : session.thinkingLevel,
+            model: modelConfig.id
         });
 
         if (result && result.content) {

--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -277,10 +277,10 @@ const BattleRuntime = {
                     battle.enemy.mdef = battle.enemy.baseMdef;
                     if (battle.turn % 2 === 0) {
                         battle.enemy.def = Math.floor(battle.enemy.def * 1.5);
-                        rpg.log("마신의 권능: 짝수 턴 물리방어력 50% 증가.");
+                        rpg.log(`${battle.enemy.name}의 권능: 짝수 턴 물리방어력 50% 증가.`);
                     } else {
                         battle.enemy.mdef = Math.floor(battle.enemy.mdef * 1.5);
-                        rpg.log("마신의 권능: 홀수 턴 마법방어력 50% 증가.");
+                        rpg.log(`${battle.enemy.name}의 권능: 홀수 턴 마법방어력 50% 증가.`);
                     }
                 }
             }
@@ -731,7 +731,7 @@ const BattleRuntime = {
         if (target.id === 'demon_god') {
             const battle = rpg.battle;
             if ((battle.turn % 2 === 0 && skill.type === 'phy') || (battle.turn % 2 !== 0 && skill.type === 'mag')) {
-                rpg.log("(마신의 권능: 방어력 상승 적용중)");
+                rpg.log(`(${target.name}의 권능: 방어력 상승 적용중)`);
             }
         }
 

--- a/card/data.js
+++ b/card/data.js
@@ -857,6 +857,16 @@ const BONUS_CARD_EXPANSION = [
         ]
     },
     {
+        id: 'sylphid', name: '실피드', grade: 'legend', element: 'nature', role: 'dealer', unlockSource: 'bonus',
+        stats: { hp: 480, atk: 150, matk: 100, def: 65, mdef: 60 },
+        trait: { type: 'opening_atk_matk', val: 50, desc: '3턴 이내 공격력/마법공격력 50% 증가' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '실프스탭', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '필드버프 질풍 발동', effects: [{ type: 'field_buff', id: 'gale' }] },
+            { name: '템페스트크로', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '질풍 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'gale', mult: 2.0 }] }
+        ]
+    },
+    {
         id: 'alchemist', name: '연금술사', grade: 'epic', element: 'water', role: 'buffer', unlockSource: 'hidden',
         stats: { hp: 400, atk: 70, matk: 70, def: 80, mdef: 80 },
         trait: { type: 'reverse_atk_matk_party', desc: '덱의 모든 카드의 물리공격과 마법공격이 뒤바뀐다' },
@@ -964,7 +974,7 @@ const ENEMIES = [
         ]
     },
     {
-        id: 'demon_god', name: '마신', element: 'dark',
+        id: 'demon_god', name: '마신 벨제뷔트', element: 'dark',
         stats: { hp: 1400, atk: 110, matk: 110, def: 100, mdef: 100 },
         skills: [
             { name: '다크니스', type: 'mag', rate: 0.2, val: 2.0, desc: '2배 마법 피해', effects: [] },
@@ -984,16 +994,6 @@ const ENEMIES = [
 ];
 
 const TRANSCENDENCE_CARDS = [
-    {
-        id: 'trans_gray', name: '사신그레이', grade: 'transcendence', element: 'dark', role: 'dealer',
-        stats: { hp: 530, atk: 150, matk: 135, def: 75, mdef: 75 },
-        trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
-        skills: [
-            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
-            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~12배율)', effects: [{ type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 12.0 }] },
-            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{ type: 'turn_modulo_dmg', mod: 4, mult: 2.0 }, { type: 'force_crit_chance', val: 40 }] }
-        ]
-    },
     {
         id: 'trans_executor', name: '종언의집행자', grade: 'transcendence', element: 'dark', role: 'debuffer',
         stats: { hp: 560, atk: 125, matk: 125, def: 70, mdef: 70 },
@@ -1068,6 +1068,16 @@ const TRANSCENDENCE_CARDS = [
 
 const BONUS_TRANSCENDENCE_CARDS = [
     {
+        id: 'trans_gray', name: '사신그레이', grade: 'transcendence', element: 'dark', role: 'dealer',
+        stats: { hp: 530, atk: 150, matk: 135, def: 75, mdef: 75 },
+        trait: { type: 'crit_ignore_def_add', val: 0.5, desc: '치명타 시 적 방어력 50% 추가 무시' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '보이드이터', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '2~4배율 랜덤 (달의축복 시 2~12배율)', effects: [{ type: 'random_mult_moon_boost', min: 2.0, max: 4.0, boostMax: 12.0 }] },
+            { name: '디멘션제로', type: 'phy', tier: 3, cost: 30, val: 3.0, desc: '치명타 확률 40%추가 (4의 배수 턴에 대미지 2배)', effects: [{ type: 'turn_modulo_dmg', mod: 4, mult: 2.0 }, { type: 'force_crit_chance', val: 40 }] }
+        ]
+    },
+    {
         id: 'trans_thor', name: '뇌신토르', grade: 'transcendence', element: 'light', role: 'dealer',
         stats: { hp: 530, atk: 110, matk: 150, def: 65, mdef: 85 },
         trait: {
@@ -1112,10 +1122,37 @@ const BONUS_TRANSCENDENCE_CARDS = [
             { name: '트라이던트', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '전투 시작 후 5턴 이내일 때 대미지 2배', effects: [{ type: 'dmg_boost_turn_limit', maxTurn: 5, mult: 2.0 }] },
             { name: '어비스프레셔', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '필드버프 1개를 제거하고 대미지 2배', effects: [{ type: 'remove_field_buff_dmg', mult: 2.0 }] }
         ]
+    },
+    {
+        id: 'trans_flora', name: '플로라', grade: 'transcendence', element: 'nature', role: 'buffer',
+        stats: { hp: 550, atk: 110, matk: 120, def: 85, mdef: 85 },
+        trait: { type: 'syn_nature_3_party_def_mdef', val: 50, desc: '덱에 자연속성 3장 이상일 때 파티 전체 방어력/마법방어력 50% 증가' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '제네시스블룸', type: 'sup', tier: 3, cost: 30, desc: '필드버프 태양의축복, 대지의축복 발동', effects: [{ type: 'field_buff', id: 'sun_bless' }, { type: 'field_buff', id: 'earth_bless' }] },
+            { name: '블러썸템페스트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '반드시 치명타로 적중', effects: [{ type: 'force_crit' }] }
+        ]
     }
 ];
 
 ENEMIES.push(
+    {
+        id: 'flora', name: '꽃의 여신 플로라', element: 'nature', hiddenBossFor: 'artificial_demon_god', bonusTranscendenceReward: 'trans_flora',
+        stats: { hp: 700, atk: 70, matk: 70, def: 70, mdef: 70 },
+        skills: [
+            { name: '제네시스블룸', type: 'sup', rate: 0.0, val: 0, desc: '대미지 반감, 자신에게 걸린 모든 디버프를 해제', effects: [{ type: 'buff', id: 'guard', duration: 1 }, { type: 'clear_self_debuffs' }] },
+            { name: '블러썸템페스트', type: 'mag', rate: 0.3, val: 2.0, desc: '마법공격 2배율', effects: [] }
+        ]
+    },
+    {
+        id: 'gray', name: '사신 그레이', element: 'dark', hiddenBossFor: 'iris_love', bonusTranscendenceReward: 'trans_gray',
+        stats: { hp: 800, atk: 90, matk: 90, def: 60, mdef: 60 },
+        skills: [
+            { name: '영혼절단', type: 'mag', rate: 0.0, val: 2.0, desc: '2~4배율 랜덤 마법공격', effects: [{ type: 'random_mult', min: 2.0, max: 4.0 }] },
+            { name: '차원절단', type: 'phy', rate: 0.0, val: 2.0, desc: '2~4배율 랜덤 물리공격', effects: [{ type: 'random_mult', min: 2.0, max: 4.0 }] },
+            { name: '디멘션제로', type: 'phy', rate: 0.0, val: 4.0, desc: '물리공격 4배율', effects: [] }
+        ]
+    },
     {
         id: 'thor', name: '뇌신 토르', element: 'light', hiddenBossFor: 'iris_curse', bonusTranscendenceReward: 'trans_thor',
         stats: { hp: 900, atk: 100, matk: 50, def: 100, mdef: 50 },

--- a/card/index.html
+++ b/card/index.html
@@ -1276,7 +1276,10 @@
 
     <div id="modal-tutoring" class="modal">
         <div class="modal-content" style="width: 90%; max-width: 600px; height: 80vh;">
-            <h3>루미의 개인과외</h3>
+            <div style="display:flex; justify-content:space-between; align-items:center; gap:10px;">
+                <h3 style="margin:0;">루미의 개인과외</h3>
+                <button id="tutoring-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">3.1 Pro</button>
+            </div>
             <div class="portrait" style="width: 100px; height: 130px; border-color: #448aff; margin: 0 auto 10px auto;">
                 <img src="루미.png" onerror="this.src=''" alt="Rumi">
             </div>
@@ -3423,7 +3426,7 @@
                 if (asideTitle) asideTitle.innerText = ui.asideTitle || '루미의 질문하기';
                 if (closeBtn) closeBtn.innerText = ui.closeLabel || '나가기';
                 if (resetBtn) resetBtn.innerText = ui.resetLabel || '대화 초기화';
-                if (modelBtn) modelBtn.innerText = LumiQuestionRuntime.selectedModel === 'gemini-3.1-pro-preview' ? '3.1 Pro' : '3.0 Flash';
+                if (modelBtn) modelBtn.innerText = LumiQuestionRuntime.getSelectedModelLabel();
                 if (input) {
                     input.placeholder = session.mode === 'toeic-review'
                         ? '해설에서 궁금한 점을 입력하세요.'
@@ -3431,10 +3434,19 @@
                 }
             },
 
+            updateLumiModelButtons() {
+                const label = LumiQuestionRuntime.getSelectedModelLabel();
+                const chatBtn = document.getElementById('lumi-chat-model-btn');
+                const tutoringBtn = document.getElementById('tutoring-model-btn');
+                if (chatBtn) chatBtn.innerText = label;
+                if (tutoringBtn) tutoringBtn.innerText = label;
+            },
+
             openLumiChatSession(session, sessionKey) {
                 if (!session) return;
                 this.activeLumiChatSessionKey = sessionKey;
                 this.configureLumiChatSessionUi(session);
+                this.updateLumiModelButtons();
                 this.renderLumiChatMessages();
                 this.setLumiChatStatus(LumiQuestionRuntime.getInitialStatus(session, !!this.getStoredApiKey()));
                 document.getElementById('modal-lumi-question').classList.add('active');
@@ -3566,15 +3578,8 @@
             },
 
             toggleLumiChatModel() {
-                if (LumiQuestionRuntime.selectedModel === 'gemini-3.1-pro-preview') {
-                    LumiQuestionRuntime.selectedModel = 'gemini-3.0-flash-preview';
-                } else {
-                    LumiQuestionRuntime.selectedModel = 'gemini-3.1-pro-preview';
-                }
-                const btn = document.getElementById('lumi-chat-model-btn');
-                if (btn) {
-                    btn.innerText = LumiQuestionRuntime.selectedModel === 'gemini-3.1-pro-preview' ? '3.1 Pro' : '3.0 Flash';
-                }
+                LumiQuestionRuntime.cycleSelectedModel();
+                this.updateLumiModelButtons();
             },
 
             handleLumiQuestionKey(event) {
@@ -3659,6 +3664,7 @@
                 document.getElementById('tutoring-content').innerText = "수업을 시작하려면 '수업 시작' 버튼을 눌러주세요.";
                 document.getElementById('btn-tutoring-quiz').style.display = 'none';
                 this.currentTutoringItem = null;
+                this.updateLumiModelButtons();
             },
 
             async startTutoringSession() {
@@ -3703,7 +3709,12 @@
                 contentBox.innerHTML = "루미 선생님이 강의를 준비하고 있어요...<br>(잠시만 기다려주세요)";
 
                 try {
-                    const text = await GameAPI.getTutoringContent(key, targetData, isCollocation ? 'collocation' : 'vocab');
+                    const text = await GameAPI.getTutoringContent(
+                        key,
+                        targetData,
+                        isCollocation ? 'collocation' : 'vocab',
+                        { model: LumiQuestionRuntime.selectedModel }
+                    );
 
                     // ✅ 응답 도착 후: 모달이 아직 열려있는지 확인
                     const tutoringModal = document.getElementById('modal-tutoring');
@@ -4177,9 +4188,9 @@
                     this.state.toeicPracticeDone = true;
                 }
 
-                // Reset Sage Blessing
-                this.state.greatSageBlessingUses = 3;
-                if (document.getElementById('sage-uses')) document.getElementById('sage-uses').innerText = 3;
+                // Add Sage Blessing uses instead of fully resetting them.
+                this.state.greatSageBlessingUses = (this.state.greatSageBlessingUses || 0) + getDefaultBlessingUses();
+                if (document.getElementById('sage-uses')) document.getElementById('sage-uses').innerText = this.state.greatSageBlessingUses;
 
                 // Disable exit button during results/commentary
                 const exitBtn = document.getElementById('toeic-exit-btn');
@@ -4227,7 +4238,7 @@
                     msg += `<br>`;
                 }
 
-                msg += `<b style="color:#00e676">대현자의 축복 횟수가 3회로 리셋되었습니다!</b>`;
+                msg += `<b style="color:#00e676">대현자의 축복 횟수가 3회 추가되었습니다! (현재 ${this.state.greatSageBlessingUses}회)</b>`;
 
                 // Open Result Modal
                 document.getElementById('toeic-result-content').innerHTML = msg;

--- a/card/logic.js
+++ b/card/logic.js
@@ -392,6 +392,21 @@ const GameUtils = {
         };
     },
 
+    cardMatchesElement(card, element) {
+        return !!card && !!element && (card.id === 'joker' || card.element === element);
+    },
+
+    cardMatchesAnyId(card, ids) {
+        const targetIds = Array.isArray(ids) ? ids : [ids];
+        return !!card && (card.id === 'joker' || targetIds.includes(card.id));
+    },
+
+    getRunPoolGradeBucket(card) {
+        if (!card) return 'normal';
+        if (card.grade === 'legend' || card.grade === 'transcendence' || card.grade === 'event') return 'legend';
+        return card.grade;
+    },
+
     /**
      * Build a card pool with bonus and transcendence cards.
      * Replaces 6 duplicated card pool construction patterns throughout the codebase.
@@ -1252,6 +1267,11 @@ const Logic = {
             m.atk += boost;
             m.def += boost;
         }
+        if (trait && trait.type === 'opening_atk_matk' && battleTurn <= 3) {
+            const boost = (trait.val || 0) / 100;
+            m.atk += boost;
+            m.matk += boost;
+        }
         if (trait && trait.type === 'cond_sanctuary_atk_def' && effectiveFieldBuffs.some(b => b.name === 'sanctuary')) {
             const boost = (trait.val || 0) / 100;
             m.atk += boost;
@@ -1314,7 +1334,7 @@ const Logic = {
         }
 
         // Artifact: veil_of_darkness — dark element crit/eva +10%
-        if (isPlayer && artifacts.includes('veil_of_darkness') && char.proto && char.proto.element === 'dark') {
+        if (isPlayer && artifacts.includes('veil_of_darkness') && GameUtils.cardMatchesElement(char.proto, 'dark')) {
             stats.crit += 10;
             stats.evasion += 10;
         }
@@ -1322,7 +1342,7 @@ const Logic = {
         // Artifact: rabbit_hole — specific rabbits crit/eva +20%
         if (isPlayer && artifacts.includes('rabbit_hole') && char.proto) {
             const rabbitIds = ['snow_rabbit', 'night_rabbit', 'silver_rabbit'];
-            if (rabbitIds.includes(char.proto.id)) {
+            if (GameUtils.cardMatchesAnyId(char.proto, rabbitIds)) {
                 stats.crit += 20;
                 stats.evasion += 20;
             }
@@ -1686,6 +1706,7 @@ const Logic = {
             else if (t.type === 'syn_dark_3_party_atk' && deckCtx.countElement('dark') >= 3) active = true;
             else if (t.type === 'syn_water_2_moon_twinkle' && deckCtx.countElement('water') >= 2) active = true;
             else if (t.type === 'syn_light_3_party_def_mdef' && deckCtx.countElement('light') >= 3) active = true;
+            else if (t.type === 'syn_nature_3_party_def_mdef' && deckCtx.countElement('nature') >= 3) active = true;
             else if (t.type === 'syn_dark_full_party_crit' && deckCtx.countElement('dark') >= 3) active = true;
 
             if (active) {
@@ -1776,6 +1797,10 @@ const Logic = {
                 partyBoost.def += (tr.val || 0);
                 partyBoost.mdef += (tr.val || 0);
             }
+            else if (tr && tr.type === 'syn_nature_3_party_def_mdef' && deckCtx.countElement('nature') >= 3) {
+                partyBoost.def += (tr.val || 0);
+                partyBoost.mdef += (tr.val || 0);
+            }
             else if (tr && tr.type === 'syn_dark_full_party_crit' && deckCtx.countElement('dark') >= 3) {
                 partyBoost.crit += (tr.val || 0);
             }
@@ -1794,7 +1819,7 @@ const Logic = {
         const artifacts = (typeof RPG !== 'undefined' && RPG.state && RPG.state.artifacts) ? RPG.state.artifacts : [];
         if (artifacts.includes('dragon_heart')) {
             const dragonIds = ['baby_dragon', 'red_dragon', 'gold_dragon', 'ancient_dragon'];
-            if (dragonIds.includes(playerProto.id)) {
+            if (GameUtils.cardMatchesAnyId(playerProto, dragonIds)) {
                 p.matk = Math.floor(p.matk * 2.0);
             }
         }
@@ -1828,6 +1853,17 @@ const Logic = {
             if (turn === 7 || turn === 14) skill = enemy.skills.find(s => s.name === '제노사이드');
             else if (r < 0.2) skill = enemy.skills.find(s => s.name === '다크니스');
         }
+        else if (enemy.id === 'flora') {
+            if (turn === 5 || turn === 10) skill = enemy.skills.find(s => s.name === '제네시스블룸');
+            else if (r < 0.3) skill = enemy.skills.find(s => s.name === '블러썸템페스트');
+        }
+        else if (enemy.id === 'gray') {
+            if (turn === 14) skill = enemy.skills.find(s => s.name === '디멘션제로');
+            else if (turn % 4 === 0) {
+                const skillName = Math.random() < 0.5 ? '영혼절단' : '차원절단';
+                skill = enemy.skills.find(s => s.name === skillName);
+            }
+        }
         else if (enemy.id === 'thor') {
             if (turn === 10) skill = enemy.skills.find(s => s.name === '썬더러쉬');
             else if (r < 0.2) skill = enemy.skills.find(s => s.name === '묠니르');
@@ -1852,8 +1888,8 @@ const Logic = {
                     name: `${chargeSkillId} 차징`,
                     isChargeStart: true,
                     chargeMessage: chargeSkillId === '테라소드'
-                        ? '아레스가 테라소드의 힘을 끌어모읍니다...'
-                        : '아레스가 마그마이럽션의 화염을 응축합니다...'
+                        ? `${enemy.name}가 테라소드의 힘을 끌어모읍니다...`
+                        : `${enemy.name}가 마그마이럽션의 화염을 응축합니다...`
                 };
             }
             if (r < 0.2) skill = enemy.skills.find(s => s.name === '스피어레인');
@@ -1992,13 +2028,13 @@ const Logic = {
         // ─── Artifact Death Effects ─────────────────────────────
 
         // Artifact: reverse — nature element death -> earth_bless field buff
-        if (artifacts.includes('reverse') && victim.proto && victim.proto.element === 'nature') {
+        if (artifacts.includes('reverse') && GameUtils.cardMatchesElement(victim.proto, 'nature')) {
             result.fieldBuffsToAdd.push('earth_bless');
             logFn(`[아티팩트] 리버스: 자연속성 카드 사망! 대지의 축복 부여!`);
         }
 
         // Artifact: frozen_body — water element death -> stun on killer
-        if (artifacts.includes('frozen_body') && victim.proto && victim.proto.element === 'water') {
+        if (artifacts.includes('frozen_body') && GameUtils.cardMatchesElement(victim.proto, 'water')) {
             if (killer) {
                 result.killerDebuffs['stun'] = 1;
                 logFn(`[아티팩트] 프로즌바디: 물속성 카드 사망! 적에게 스턴 부여!`);

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -345,6 +345,8 @@
         const baseId = rotation[this.state.enemyScale % rotation.length];
         const stageNumber = this.state.enemyScale + 1;
         const hiddenBossMap = {
+            artificial_demon_god: 'flora',
+            iris_love: 'gray',
             iris_curse: 'thor',
             pharaoh: 'poseidon',
             demon_god: 'ares'
@@ -538,21 +540,49 @@
     },
 
 
-    isWeightedTranscendenceRunMode() {
-        return this.state.gameType === 'endless' && ['chaos', 'draft'].includes(this.state.mode);
+    isGradeBalancedRunMode() {
+        return ['chaos', 'draft'].includes(this.state.mode);
     },
 
 
     drawRunPoolCards(pool, count, options = {}) {
         if (!Array.isArray(pool) || pool.length === 0 || count <= 0) return [];
 
-        if (this.isWeightedTranscendenceRunMode()) {
-            return GameUtils.drawWeightedCards(
-                pool,
-                count,
-                card => (card.grade === 'transcendence' ? 0.5 : 1.0),
-                options
-            );
+        if (this.isGradeBalancedRunMode()) {
+            const allowDuplicates = !!options.allowDuplicates;
+            const source = allowDuplicates ? [...pool] : [...pool];
+            const picks = [];
+            const grades = ['normal', 'rare', 'epic', 'legend'];
+
+            while (picks.length < count && source.length > 0) {
+                const bucketMap = grades.reduce((acc, grade) => {
+                    acc[grade] = source.filter(card => GameUtils.getRunPoolGradeBucket(card) === grade);
+                    return acc;
+                }, {});
+                const availableGrades = grades.filter(grade => bucketMap[grade].length > 0);
+                if (availableGrades.length === 0) break;
+
+                let selectedGrade = grades[Math.min(grades.length - 1, Math.floor(Math.random() * grades.length))];
+                if (bucketMap[selectedGrade].length === 0) {
+                    selectedGrade = availableGrades[Math.floor(Math.random() * availableGrades.length)];
+                }
+
+                const pick = GameUtils.drawWeightedCards(
+                    bucketMap[selectedGrade],
+                    1,
+                    card => (card.grade === 'transcendence' ? 0.5 : 1.0),
+                    { allowDuplicates: false }
+                )[0];
+                if (!pick) break;
+
+                picks.push(pick);
+                if (!allowDuplicates) {
+                    const pickedIndex = source.findIndex(card => card.id === pick.id);
+                    if (pickedIndex > -1) source.splice(pickedIndex, 1);
+                }
+            }
+
+            return picks;
         }
 
         if (options.allowDuplicates) {


### PR DESCRIPTION
## Summary
- add Flora/Sylphid content, move Gray into the bonus transcendence pool, and wire new hidden boss encounters/rewards
- update chaos and draft card selection to choose grade buckets first with reduced transcendence weight inside legend pulls
- fix Joker artifact tag matching, change Great Sage blessing recovery to +3 uses, and add Lumi model toggles including Flash Lite support
- reduce TOEIC review request weight for flash models so tutoring/question flows stay aligned

## Testing
- npm run verify

## Unverified
- live Gemini API responses for private tutoring, question tab, and TOEIC review were not exercised in smoke tests
