### PR TITLE
card: improve lumi chat request controls

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -38,7 +38,7 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 
 const LUMI_MODEL_OPTIONS = Object.freeze([
     { id: 'gemini-3.1-pro-preview', label: '3.1 Pro', flashLike: false, allowSearch: true },
-    { id: 'gemini-3.0-flash-preview', label: '3.0 Flash', flashLike: true, allowSearch: true },
+    { id: 'gemini-3-flash-preview', label: 'Flash 3', flashLike: true, allowSearch: true },
     { id: 'gemini-3.1-flash-lite-preview', label: '3.1 Flash Lite', flashLike: true, allowSearch: false }
 ]);
 
@@ -184,6 +184,201 @@ function normalizeThinkingLevel(thinkingLevel) {
     return GEMINI_REASONING_LEVELS.has(thinkingLevel) ? thinkingLevel : 'high';
 }
 
+function isAbortError(error) {
+    return !!error && (
+        error.name === 'AbortError' ||
+        String(error.message || '').includes('aborted')
+    );
+}
+
+function isRetryableLumiError(error) {
+    if (!error) return false;
+    const status = Number(error.status || 0);
+    if (status === 500 || status === 503 || status === 504) {
+        return true;
+    }
+    const detail = String(error.message || '');
+    return /\b(500|503|504)\b/.test(detail) || detail.includes('빈 응답');
+}
+
+function sleepWithSignal(delayMs, signal) {
+    return new Promise((resolve, reject) => {
+        if (signal && signal.aborted) {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+            return;
+        }
+
+        let timerId = null;
+        const handleAbort = () => {
+            if (timerId !== null) clearTimeout(timerId);
+            if (signal) signal.removeEventListener('abort', handleAbort);
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+        };
+
+        timerId = setTimeout(() => {
+            if (signal) signal.removeEventListener('abort', handleAbort);
+            resolve();
+        }, delayMs);
+
+        if (signal) {
+            signal.addEventListener('abort', handleAbort, { once: true });
+        }
+    });
+}
+
+function createRequestSignal(signal, timeoutMs) {
+    if (!timeoutMs) {
+        return {
+            signal,
+            didTimeout() {
+                return false;
+            },
+            cleanup() { }
+        };
+    }
+
+    const controller = new AbortController();
+    let timeoutId = null;
+    let timedOut = false;
+
+    const handleAbort = () => {
+        try {
+            controller.abort();
+        } catch (_) { }
+    };
+
+    if (signal) {
+        if (signal.aborted) {
+            handleAbort();
+        } else {
+            signal.addEventListener('abort', handleAbort, { once: true });
+        }
+    }
+
+    timeoutId = setTimeout(() => {
+        timedOut = true;
+        try {
+            controller.abort();
+        } catch (_) { }
+    }, timeoutMs);
+
+    return {
+        signal: controller.signal,
+        didTimeout() {
+            return timedOut;
+        },
+        cleanup() {
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId);
+                timeoutId = null;
+            }
+            if (signal) {
+                signal.removeEventListener('abort', handleAbort);
+            }
+        }
+    };
+}
+
+async function requestLumiQuestion(apiKey, history, options = {}) {
+    const {
+        systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
+        enableSearch = true,
+        thinkingLevel = 'high',
+        model = 'gemini-3.1-pro-preview',
+        signal,
+        timeoutMs = 60000
+    } = options;
+    const modelConfig = getLumiModelConfig(model);
+
+    const payload = {
+        systemInstruction: {
+            parts: [{ text: systemInstruction }]
+        },
+        contents: history
+    };
+
+    if (enableSearch && modelConfig.allowSearch) {
+        payload.tools = [
+            {
+                googleSearch: {}
+            }
+        ];
+    }
+
+    payload.generationConfig = {
+        thinkingConfig: {
+            thinkingLevel: normalizeThinkingLevel(modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
+        }
+    };
+    payload.safetySettings = [
+        { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
+        { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
+        { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_NONE' },
+        { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_NONE' },
+        { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' }
+    ];
+
+    const requestSignal = createRequestSignal(signal, timeoutMs);
+
+    try {
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelConfig.id}:generateContent?key=${encodeURIComponent(apiKey)}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload),
+            signal: requestSignal.signal
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            const requestError = new Error(`API 요청 실패 (${response.status}): ${errorBody}`);
+            requestError.status = response.status;
+            throw requestError;
+        }
+
+        const result = await response.json();
+        if (result.error) {
+            const apiError = new Error(result.error.message);
+            apiError.status = result.error.code;
+            throw apiError;
+        }
+
+        const candidate = result.candidates && result.candidates[0];
+        const content = candidate && candidate.content;
+        const parts = content && Array.isArray(content.parts) ? content.parts : [];
+        const text = parts
+            .filter(part => typeof part.text === 'string')
+            .map(part => part.text)
+            .join('')
+            .trim();
+
+        if (!text) {
+            const emptyError = new Error('API가 빈 응답을 반환했습니다.');
+            emptyError.code = 'LUMI_EMPTY_RESPONSE';
+            emptyError.status = 200;
+            throw emptyError;
+        }
+
+        return {
+            text,
+            content: content ? { ...content, role: content.role || 'model' } : { role: 'model', parts: [{ text }] },
+            sources: normalizeGroundingSources(candidate).slice(0, 4),
+            queries: candidate?.groundingMetadata?.webSearchQueries || []
+        };
+    } catch (error) {
+        if (requestSignal.didTimeout() && isAbortError(error)) {
+            const timeoutError = new Error(`Lumi request timed out after ${timeoutMs}ms.`);
+            timeoutError.code = 'LUMI_TIMEOUT';
+            timeoutError.status = 504;
+            throw timeoutError;
+        }
+        throw error;
+    } finally {
+        requestSignal.cleanup();
+    }
+}
+
 GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
     const {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
@@ -281,6 +476,26 @@ const TOEIC_LUMI_SYSTEM_INSTRUCTION = `# Role: 대현자 루미 (Grand Sage Rumi
 - 추가 근거가 꼭 필요할 때만 웹 검색 결과를 보조로 사용하고, 검색으로 알게 된 내용은 세션 정보와 구분해서 설명하십시오.
 - 불필요하게 장황하지 말고, 질문에 바로 답한 뒤 필요한 근거를 덧붙이십시오.`;
 
+GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
+    const modelConfig = getLumiModelConfig(options.model);
+    const maxAttempts = modelConfig.flashLike ? 2 : 1;
+    let lastError = null;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            return await requestLumiQuestion(apiKey, history, options);
+        } catch (error) {
+            lastError = error;
+            if (isAbortError(error) || !isRetryableLumiError(error) || attempt >= maxAttempts) {
+                throw error;
+            }
+            await sleepWithSignal(700 * attempt, options.signal);
+        }
+    }
+
+    throw lastError || new Error('Lumi request failed.');
+};
+
 const LUMI_SESSION_KEYS = Object.freeze({
     GENERAL: 'general',
     TOEIC: 'toeic'
@@ -317,7 +532,9 @@ function createSession(config) {
     return {
         ...config,
         history: cloneHistory(config.seedHistory),
-        messages: cloneMessages(config.seedMessages)
+        messages: cloneMessages(config.seedMessages),
+        requestSeq: 0,
+        inFlight: null
     };
 }
 
@@ -580,6 +797,168 @@ const LumiQuestionRuntime = {
         });
 
         return result;
+    },
+
+    getModelLabel(modelId) {
+        return this.getModelConfig(modelId).label;
+    },
+
+    setSelectedModel(modelId) {
+        this.selectedModel = this.getModelConfig(modelId).id;
+        return this.selectedModel;
+    },
+
+    getAlternateModel(modelId) {
+        const currentModel = this.getModelConfig(modelId).id;
+        const alternate = this.MODEL_OPTIONS.find(option => option.id !== currentModel);
+        return alternate ? alternate.id : currentModel;
+    },
+
+    getLoadingStatus(session, modelId) {
+        return `답변 생성 중... (${this.getModelLabel(modelId || session?.inFlight?.model || this.selectedModel)})`;
+    },
+
+    getCanceledStatus() {
+        return '응답을 취소했어.';
+    },
+
+    buildErrorMessage(session, error) {
+        if (isAbortError(error)) {
+            return this.getCanceledStatus();
+        }
+        const detail = error && error.message ? error.message : String(error || '');
+        if (isRetryableLumiError(error)) {
+            return `응답이 흔들렸어. 다시 시도하거나 ${this.getModelLabel('gemini-3.1-pro-preview')}로 바꿔볼 수 있어.\n${detail}`;
+        }
+        if (session && session.mode === 'toeic-review') {
+            return `(・ｸ孖ｸ・ｼ ・､・・・俾ｸｰ・ｰ) ・ｩ・・・ｵ・・・・簿ｦｬ﨑俯共・ ・・・・駕・・ｴ.\n${detail}`;
+        }
+        return `(・壱ｲ母ｵｬ・ｬ・・・呷棕・ｼ・ｰ) ・壱ｬｸ・・・簿ｦｬ﨑俯共・ ・・・彧罷豆・ｸ・ｴ.\n${detail}`;
+    },
+
+    getPendingMessageText(modelId) {
+        return `답변 생성 중... (${this.getModelLabel(modelId)})`;
+    },
+
+    buildRequestHistory(session, pendingUserContent, modelId) {
+        if (!session || session.mode !== 'toeic-review') {
+            return [...session.history, pendingUserContent];
+        }
+
+        const modelConfig = this.getModelConfig(modelId);
+        const toeicContext = buildToeicContext(session.source, { compact: modelConfig.flashLike });
+        const priorHistory = modelConfig.flashLike ? session.history.slice(-6) : session.history;
+
+        return [
+            { role: 'user', parts: [{ text: toeicContext }] },
+            ...cloneHistory(priorHistory),
+            pendingUserContent
+        ];
+    },
+
+    cancelPending(session, reason = 'cancel') {
+        if (!session || !session.inFlight) return false;
+
+        const pendingMessage = session.inFlight.pendingMessage;
+        if (pendingMessage && pendingMessage.state === 'pending') {
+            pendingMessage.state = 'canceled';
+            pendingMessage.text = this.getCanceledStatus();
+            pendingMessage.sources = [];
+            pendingMessage.queries = [];
+            pendingMessage.retryable = false;
+        }
+
+        const controller = session.inFlight.controller;
+        session.inFlight = null;
+
+        try {
+            controller.abort(reason);
+        } catch (_) { }
+
+        return true;
+    },
+
+    async sendMessage(apiKey, session, message) {
+        const requestId = (session.requestSeq || 0) + 1;
+        session.requestSeq = requestId;
+
+        const modelConfig = this.getModelConfig(this.selectedModel);
+        const pendingUserContent = { role: 'user', parts: [{ text: message }] };
+        const requestHistory = this.buildRequestHistory(session, pendingUserContent, modelConfig.id);
+        const controller = new AbortController();
+        const pendingReply = {
+            id: `model-${requestId}`,
+            role: 'model',
+            model: modelConfig.id,
+            state: 'pending',
+            text: this.getPendingMessageText(modelConfig.id),
+            sources: [],
+            queries: [],
+            retryable: false,
+            userText: message
+        };
+
+        session.messages.push(
+            { id: `user-${requestId}`, role: 'user', text: message, state: 'done' },
+            pendingReply
+        );
+
+        session.inFlight = {
+            requestId,
+            controller,
+            model: modelConfig.id,
+            startedAt: Date.now(),
+            userText: message,
+            pendingMessage: pendingReply
+        };
+
+        try {
+            const result = await GameAPI.askLumiQuestion(apiKey, requestHistory, {
+                systemInstruction: session.systemInstruction,
+                enableSearch: session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
+                thinkingLevel: session.mode === 'toeic-review' && modelConfig.flashLike ? 'medium' : session.thinkingLevel,
+                model: modelConfig.id,
+                signal: controller.signal,
+                timeoutMs: modelConfig.flashLike ? 45000 : 60000
+            });
+
+            if (!session.inFlight || session.inFlight.requestId !== requestId) {
+                return { ignored: true, stale: true, requestId };
+            }
+
+            session.history.push(pendingUserContent);
+            if (result && result.content) {
+                session.history.push(result.content);
+            }
+
+            pendingReply.state = 'done';
+            pendingReply.text = result.text;
+            pendingReply.sources = result.sources || [];
+            pendingReply.queries = result.queries || [];
+            pendingReply.retryable = false;
+            session.inFlight = null;
+
+            return { ...result, requestId };
+        } catch (error) {
+            const stale = !session.inFlight || session.inFlight.requestId !== requestId;
+            if (stale) {
+                error.stale = true;
+                throw error;
+            }
+
+            pendingReply.state = isAbortError(error) ? 'canceled' : 'error';
+            pendingReply.text = this.buildErrorMessage(session, error);
+            pendingReply.sources = [];
+            pendingReply.queries = [];
+            pendingReply.retryable = !isAbortError(error) && isRetryableLumiError(error);
+            session.inFlight = null;
+
+            error.canceled = isAbortError(error);
+            error.retryable = pendingReply.retryable;
+            error.lumiHandled = true;
+            error.requestId = requestId;
+            throw error;
+        }
     }
 };
 

--- a/card/index.html
+++ b/card/index.html
@@ -1378,7 +1378,12 @@
             <div class="lumi-chat-top">
                 <h3 id="lumi-chat-aside-title" class="lumi-chat-title">루미의 질문하기</h3>
                 <div class="lumi-chat-controls">
-                    <button id="lumi-chat-model-btn" onclick="RPG.toggleLumiChatModel()">3.1 Pro</button>
+                    <select id="lumi-chat-model-select" onchange="RPG.changeLumiModel(this.value)">
+                        <option value="gemini-3.1-pro-preview">3.1 Pro</option>
+                        <option value="gemini-3-flash-preview">Flash 3</option>
+                        <option value="gemini-3.1-flash-lite-preview">3.1 Flash Lite</option>
+                    </select>
+                    <button id="lumi-chat-cancel-btn" onclick="RPG.cancelLumiQuestion()">응답 취소</button>
                     <button id="lumi-chat-reset-btn" onclick="RPG.clearLumiQuestionHistory()">대화 초기화</button>
                     <button id="lumi-chat-close-btn" onclick="RPG.closeLumiQuestion()">나가기</button>
                 </div>
@@ -2371,7 +2376,7 @@
             },
 
             toMenu() {
-                this.clearToeicLumiQuestionSession();
+                this.clearToeicLumiQuestionSession({ abort: true, clearCurrentToeic: true });
                 this.showScreen('screen-menu');
                 document.getElementById('ui-tickets').innerText = this.state.tickets;
                 this.ensureMonthlyMissionState();
@@ -3421,12 +3426,14 @@
                 const closeBtn = document.getElementById('lumi-chat-close-btn');
                 const resetBtn = document.getElementById('lumi-chat-reset-btn');
                 const input = document.getElementById('lumi-chat-input');
-                const modelBtn = document.getElementById('lumi-chat-model-btn');
+                const modelSelect = document.getElementById('lumi-chat-model-select');
+                const cancelBtn = document.getElementById('lumi-chat-cancel-btn');
 
                 if (asideTitle) asideTitle.innerText = ui.asideTitle || '루미의 질문하기';
                 if (closeBtn) closeBtn.innerText = ui.closeLabel || '나가기';
                 if (resetBtn) resetBtn.innerText = ui.resetLabel || '대화 초기화';
-                if (modelBtn) modelBtn.innerText = LumiQuestionRuntime.getSelectedModelLabel();
+                if (modelSelect) modelSelect.value = LumiQuestionRuntime.selectedModel;
+                if (cancelBtn) cancelBtn.disabled = !(session && session.inFlight);
                 if (input) {
                     input.placeholder = session.mode === 'toeic-review'
                         ? '해설에서 궁금한 점을 입력하세요.'
@@ -3436,9 +3443,9 @@
 
             updateLumiModelButtons() {
                 const label = LumiQuestionRuntime.getSelectedModelLabel();
-                const chatBtn = document.getElementById('lumi-chat-model-btn');
+                const chatSelect = document.getElementById('lumi-chat-model-select');
                 const tutoringBtn = document.getElementById('tutoring-model-btn');
-                if (chatBtn) chatBtn.innerText = label;
+                if (chatSelect) chatSelect.value = LumiQuestionRuntime.selectedModel;
                 if (tutoringBtn) tutoringBtn.innerText = label;
             },
 
@@ -3477,6 +3484,9 @@
 
             closeLumiQuestion() {
                 const activeSession = this.getActiveLumiChatSession();
+                if (activeSession && activeSession.inFlight) {
+                    LumiQuestionRuntime.cancelPending(activeSession, 'close_modal');
+                }
                 document.getElementById('modal-lumi-question').classList.remove('active');
                 this.setLumiChatStatus('');
                 const input = document.getElementById('lumi-chat-input');
@@ -3497,9 +3507,12 @@
                 this.showToeicExplanation();
             },
 
-            clearToeicLumiQuestionSession() {
+            clearToeicLumiQuestionSession(options = {}) {
                 const toeicSession = this.state.currentToeicSession;
                 if (toeicSession && toeicSession.lumiQuestionSession) {
+                    if (options.abort !== false) {
+                        LumiQuestionRuntime.cancelPending(toeicSession.lumiQuestionSession, 'dispose_toeic_session');
+                    }
                     delete toeicSession.lumiQuestionSession;
                 }
                 if (this.activeLumiChatSessionKey === LumiQuestionRuntime.SESSION_KEYS.TOEIC) {
@@ -3509,6 +3522,9 @@
                 this.setLumiChatStatus('');
                 const input = document.getElementById('lumi-chat-input');
                 if (input) input.value = '';
+                if (options.clearCurrentToeic) {
+                    this.state.currentToeicSession = null;
+                }
             },
 
             setLumiChatStatus(message = '') {
@@ -3527,10 +3543,18 @@
                 messages.forEach(message => {
                     const bubble = document.createElement('div');
                     bubble.className = `lumi-chat-bubble ${message.role === 'user' ? 'user' : 'model'}`;
+                    if (message.state) bubble.classList.add(`is-${message.state}`);
 
                     const body = document.createElement('div');
                     body.textContent = message.text;
                     bubble.appendChild(body);
+
+                    if (message.model) {
+                        const modelMeta = document.createElement('span');
+                        modelMeta.className = 'lumi-chat-meta';
+                        modelMeta.textContent = LumiQuestionRuntime.getModelLabel(message.model);
+                        bubble.appendChild(modelMeta);
+                    }
 
                     if (message.queries && message.queries.length > 0) {
                         const meta = document.createElement('span');
@@ -3554,16 +3578,39 @@
                         bubble.appendChild(sourceWrap);
                     }
 
+                    if (message.retryable && message.role === 'model') {
+                        const actionWrap = document.createElement('div');
+                        actionWrap.style.display = 'flex';
+                        actionWrap.style.gap = '8px';
+                        actionWrap.style.marginTop = '8px';
+
+                        const retryBtn = document.createElement('button');
+                        retryBtn.textContent = '다시 시도';
+                        retryBtn.onclick = () => this.retryLastLumiQuestion(message.userText, message.model);
+                        actionWrap.appendChild(retryBtn);
+
+                        const alternateModel = LumiQuestionRuntime.getAlternateModel(message.model);
+                        const switchBtn = document.createElement('button');
+                        switchBtn.textContent = `${LumiQuestionRuntime.getModelLabel(alternateModel)}로 재시도`;
+                        switchBtn.onclick = () => this.retryLastLumiQuestion(message.userText, alternateModel);
+                        actionWrap.appendChild(switchBtn);
+
+                        bubble.appendChild(actionWrap);
+                    }
+
                     log.appendChild(bubble);
                 });
 
                 log.scrollTop = log.scrollHeight;
+                const cancelBtn = document.getElementById('lumi-chat-cancel-btn');
+                if (cancelBtn) cancelBtn.disabled = !(session && session.inFlight);
             },
 
             clearLumiQuestionHistory() {
                 const currentSession = this.getActiveLumiChatSession();
                 if (!currentSession) return;
 
+                LumiQuestionRuntime.cancelPending(currentSession, 'reset_session');
                 const resetSession = LumiQuestionRuntime.resetSession(currentSession);
                 LumiQuestionRuntime.storeSession(this.lumiChatSessions, this.state.currentToeicSession, resetSession);
 
@@ -3577,9 +3624,42 @@
                 }
             },
 
+            changeLumiModel(model) {
+                LumiQuestionRuntime.setSelectedModel(model);
+                this.updateLumiModelButtons();
+                const session = this.getActiveLumiChatSession();
+                if (session && session.inFlight) {
+                    this.setLumiChatStatus('모델 변경은 다음 질문부터 적용돼. 지금 응답에 적용하려면 취소 후 다시 시도해줘.');
+                } else {
+                    this.setLumiChatStatus('');
+                }
+            },
+
             toggleLumiChatModel() {
                 LumiQuestionRuntime.cycleSelectedModel();
                 this.updateLumiModelButtons();
+            },
+
+            cancelLumiQuestion() {
+                const session = this.getActiveLumiChatSession();
+                if (!session) return;
+                if (!LumiQuestionRuntime.cancelPending(session, 'user_cancel')) return;
+                this.setLumiChatStatus(LumiQuestionRuntime.getCanceledStatus());
+                this.renderLumiChatMessages();
+            },
+
+            async retryLastLumiQuestion(messageText, modelOverride = null) {
+                if (this.isLumiChatLoading) return;
+                if (typeof messageText !== 'string' || !messageText.trim()) return;
+
+                if (modelOverride) {
+                    LumiQuestionRuntime.setSelectedModel(modelOverride);
+                    this.updateLumiModelButtons();
+                }
+
+                const input = document.getElementById('lumi-chat-input');
+                if (input) input.value = messageText;
+                await this.sendLumiQuestion();
             },
 
             handleLumiQuestionKey(event) {
@@ -3612,19 +3692,23 @@
 
                 if (input) input.value = '';
                 this.isLumiChatLoading = true;
-                this.setLumiChatStatus(LumiQuestionRuntime.getLoadingStatus(session));
+                this.setLumiChatStatus(LumiQuestionRuntime.getLoadingStatus(session, LumiQuestionRuntime.selectedModel));
 
                 try {
                     const pendingReply = LumiQuestionRuntime.sendMessage(key, session, message);
                     this.renderLumiChatMessages();
                     const result = await pendingReply;
+                    if (!result || result.stale) return;
                     this.setLumiChatStatus(LumiQuestionRuntime.getSuccessStatus(session, result));
                 } catch (error) {
-                    session.messages.push({
-                        role: 'model',
-                        text: LumiQuestionRuntime.buildErrorMessage(session, error)
-                    });
+                    if (!error || error.stale) return;
+                    if (error.canceled) {
+                        this.setLumiChatStatus(LumiQuestionRuntime.getCanceledStatus());
+                    } else if (error.retryable) {
+                        this.setLumiChatStatus('응답이 흔들렸어. 다시 시도하거나 Pro로 바꿔볼 수 있어.');
+                    } else {
                     this.setLumiChatStatus('답변 요청에 실패했어.');
+                    }
                 } finally {
                     this.isLumiChatLoading = false;
                     this.renderLumiChatMessages();
@@ -3879,7 +3963,7 @@
                 if (session && session.options && session.options.lockExit) {
                     return;
                 }
-                this.clearToeicLumiQuestionSession();
+                this.clearToeicLumiQuestionSession({ abort: true, clearCurrentToeic: true });
                 document.getElementById('modal-toeic-practice').classList.remove('active');
             },
 
@@ -3894,6 +3978,8 @@
                     onFailure: null,
                     ...options
                 };
+
+                this.clearToeicLumiQuestionSession({ abort: true, clearCurrentToeic: true });
 
                 if (!practiceOptions.ignoreSessionLimit && this.state.toeicPracticeDone) {
                     return this.showAlert("이번 세션에서는 이미 실전 연습을 완료했습니다.\n다음 세션에서 다시 도전해주세요.");
@@ -4432,7 +4518,7 @@
 
                 const key = this.ensureApiKey('데이트를 시작하려면');
                 if (!key) return this.showAlert("API 키가 없어 데이트를 시작할 수 없습니다.");
-                this.clearToeicLumiQuestionSession();
+                this.clearToeicLumiQuestionSession({ abort: true, clearCurrentToeic: true });
 
                 const dateParams = this._getDateParams();
 

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -735,7 +735,9 @@
 
 
     saveGame(showMessage = true) {
-        Storage.save(Storage.keys.SAVE, this.state);
+        const saveState = { ...this.state };
+        delete saveState.currentToeicSession;
+        Storage.save(Storage.keys.SAVE, saveState);
         this.saveStudyProgress();
         this.saveGlobalData(); // Also save global just in case
         if (showMessage) this.showAlert("저장되었습니다.");
@@ -1238,6 +1240,9 @@
 
     resetToeicProgress(options = {}) {
         const reset = () => {
+            if (typeof this.clearToeicLumiQuestionSession === 'function') {
+                this.clearToeicLumiQuestionSession({ abort: true, clearCurrentToeic: true });
+            }
             this.state.completedToeicSets = [];
             this.saveGame(false);
             if (!options.silent) {


### PR DESCRIPTION
## Summary
- add cancel, retry, timeout, and stale-response handling for Lumi question requests
- restore the 3.1 Flash Lite model option in the Lumi question modal while keeping the current select-based UI
- avoid persisting transient TOEIC Lumi session state in saves and clear it on reset

## Verification
- npm run verify