### PR TITLE
card: make Sylphid gale refresh for 3 turns

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -800,7 +800,12 @@ const BattleRuntime = {
     },
 
     applyFieldBuff(rpg, id, options = {}) {
-        if (rpg.battle.fieldBuffs.some(buff => buff.name === id)) {
+        const existingBuff = rpg.battle.fieldBuffs.find(buff => buff.name === id);
+        if (existingBuff) {
+            if (Number.isFinite(options.expiresAtTurn)) {
+                Object.assign(existingBuff, options);
+                return rpg.log(`필드버프 [${BUFF_NAMES[id]}] 지속 턴 갱신!`);
+            }
             return rpg.log(`필드버프 [${BUFF_NAMES[id]}] 이미 존재.`);
         }
 

--- a/card/data.js
+++ b/card/data.js
@@ -862,7 +862,7 @@ const BONUS_CARD_EXPANSION = [
         trait: { type: 'opening_atk_matk', val: 50, desc: '3턴 이내 공격력/마법공격력 50% 증가' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
-            { name: '실프스탭', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '필드버프 질풍 발동', effects: [{ type: 'field_buff', id: 'gale' }] },
+            { name: '실프스탭', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '3턴간 지속되는 필드버프 질풍 발동', effects: [{ type: 'field_buff', id: 'gale', durationTurns: 3 }] },
             { name: '템페스트크로', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '질풍 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'gale', mult: 2.0 }] }
         ]
     },

--- a/card/logic.js
+++ b/card/logic.js
@@ -893,7 +893,12 @@ const SideEffects = {
             }
         },
         'field_buff': (ctx, eff) => {
-            ctx.applyFieldBuff(eff.id);
+            const options = {};
+            if (Number.isFinite(eff.durationTurns) && eff.durationTurns > 0) {
+                options.expiresAtTurn = ctx.battle.turn + eff.durationTurns;
+                options.expireLog = eff.expireLog || null;
+            }
+            ctx.applyFieldBuff(eff.id, options);
         },
         'heal_ratio': (ctx, eff) => {
             const ratio = eff.ratio || eff.val || 0;

--- a/scripts/verify_card_patch.js
+++ b/scripts/verify_card_patch.js
@@ -447,6 +447,36 @@ async function verifyCombatRules(page) {
     });
     const critSkill = { name: '검증용 강타', type: 'phy', tier: 1, cost: 0, val: 1.0, effects: [{ type: 'force_crit' }] };
     BattleRuntime.executeSkill(critRpg, critSource, critTarget, critSkill);
+
+    const sylphid = cloneCard('sylphid');
+    const galeTarget = makeDummy();
+    const galeRpg = makeRpg({
+      deck: ['sylphid', null, null],
+      enemy: galeTarget,
+      players: [sylphid, null, null],
+      turn: 1
+    });
+    BattleRuntime.applySkillEffects(galeRpg, sylphid, galeTarget, sylphid.skills[1]);
+    const galeBuff = galeRpg.battle.fieldBuffs.find(buff => buff.name === 'gale');
+
+    const refreshedSylphid = cloneCard('sylphid');
+    const refreshedRpg = makeRpg({
+      deck: ['sylphid', null, null],
+      enemy: makeDummy(),
+      players: [refreshedSylphid, null, null],
+      turn: 2,
+      fieldBuffs: [{ name: 'gale', expiresAtTurn: 4, expireLog: '[아티팩트] 질풍 종료' }]
+    });
+    BattleRuntime.applySkillEffects(refreshedRpg, refreshedSylphid, refreshedRpg.battle.enemy, refreshedSylphid.skills[1]);
+    const refreshedGale = refreshedRpg.battle.fieldBuffs.find(buff => buff.name === 'gale');
+    const refreshedGaleCount = refreshedRpg.battle.fieldBuffs.length;
+    const refreshedGaleLogs = [...refreshedRpg.logs];
+    refreshedRpg.logs.length = 0;
+    BattleRuntime.expireFieldBuffs(refreshedRpg, 4);
+    const galeRemainsOnTurnFour = refreshedRpg.battle.fieldBuffs.some(buff => buff.name === 'gale');
+    BattleRuntime.expireFieldBuffs(refreshedRpg, 5);
+    const galeRemainsOnTurnFive = refreshedRpg.battle.fieldBuffs.some(buff => buff.name === 'gale');
+
     BattleRuntime.TurnManager.endPlayerTurn = originalEndPlayerTurn;
     Math.random = originalRandom;
 
@@ -478,7 +508,14 @@ async function verifyCombatRules(page) {
       instantDelayedCount: instantRpg.battle.delayedEffects.length,
       instantMessageCount,
       instantTargetHpLoss: 99999 - instantTarget.hp,
-      luckyVickyMp: critSource.mp
+      luckyVickyMp: critSource.mp,
+      galeExpiresAtTurn: galeBuff ? galeBuff.expiresAtTurn : null,
+      galeBuffCount: galeRpg.battle.fieldBuffs.length,
+      refreshedGaleExpiresAtTurn: refreshedGale ? refreshedGale.expiresAtTurn : null,
+      refreshedGaleCount,
+      refreshedGaleLogs,
+      galeRemainsOnTurnFour,
+      galeRemainsOnTurnFive
     };
   });
 
@@ -510,6 +547,10 @@ async function verifyCombatRules(page) {
   assert(result.instantDelayedCount === 0 && result.instantMessageCount === 5 && result.instantTargetHpLoss > 0, '시간의마술사 조합 즉발 처리가 올바르지 않습니다.');
 
   assert(result.luckyVickyMp === 90, `럭키비키 치명타 MP 회복이 유지되지 않았습니다: ${result.luckyVickyMp}`);
+  assert(result.galeExpiresAtTurn === 4 && result.galeBuffCount === 1, `실프스탭 3턴 질풍 부여가 잘못되었습니다: expiresAt=${result.galeExpiresAtTurn}, count=${result.galeBuffCount}`);
+  assert(result.refreshedGaleExpiresAtTurn === 5 && result.refreshedGaleCount === 1, `기존 질풍 갱신이 잘못되었습니다: expiresAt=${result.refreshedGaleExpiresAtTurn}, count=${result.refreshedGaleCount}`);
+  assert(result.refreshedGaleLogs.some(message => message.includes('지속 턴 갱신')), '기존 질풍 갱신 로그가 남지 않았습니다.');
+  assert(result.galeRemainsOnTurnFour === true && result.galeRemainsOnTurnFive === false, '갱신된 질풍의 만료 턴 계산이 잘못되었습니다.');
 
   return result;
 }


### PR DESCRIPTION
## Summary
- change Sylphid's `????` to apply a 3-turn `??` field buff instead of a permanent one
- refresh the existing `??` duration back to 3 turns when a timed `??` source reapplies it
- add regression coverage for timed `??` application and refresh behavior

## Testing
- npm run verify
- node --check scripts/verify_card_patch.js
- targeted Playwright runtime check for `????`/`??` duration refresh (`expiresAtTurn` 4 on first use, 5 after refresh, still active on turn 4, expired on turn 5)

## Notes
- `node scripts/verify_card_patch.js` still stops in the pre-existing weekly mission UI flow because `#btn-claim-weekly-mission` is not visible, so the new `??` behavior was verified separately in the browser runtime.
