### PR TITLE
Lumi: suggest alternate model on retry and extend timeout to 2 minutes

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -286,7 +286,7 @@ async function requestLumiQuestion(apiKey, history, options = {}) {
         thinkingLevel = 'high',
         model = 'gemini-3.1-pro-preview',
         signal,
-        timeoutMs = 60000
+        timeoutMs = 120000
     } = options;
     const modelConfig = getLumiModelConfig(model);
 
@@ -828,7 +828,9 @@ const LumiQuestionRuntime = {
         }
         const detail = error && error.message ? error.message : String(error || '');
         if (isRetryableLumiError(error)) {
-            return `응답이 흔들렸어. 다시 시도하거나 ${this.getModelLabel('gemini-3.1-pro-preview')}로 바꿔볼 수 있어.\n${detail}`;
+            const currentModel = this.getModelConfig(session?.inFlight?.model || this.selectedModel).id;
+            const alternateModel = this.getAlternateModel(currentModel);
+            return `응답이 흔들렸어. 다시 시도하거나 ${this.getModelLabel(alternateModel)}로 바꿔볼 수 있어.\n${detail}`;
         }
         if (session && session.mode === 'toeic-review') {
             return `(노트를 다시 넘기며) 답변을 정리하다가 잠깐 막혔어.\n${detail}`;
@@ -919,7 +921,7 @@ const LumiQuestionRuntime = {
                 thinkingLevel: session.mode === 'toeic-review' && modelConfig.flashLike ? 'medium' : session.thinkingLevel,
                 model: modelConfig.id,
                 signal: controller.signal,
-                timeoutMs: modelConfig.flashLike ? 45000 : 60000
+                timeoutMs: 120000
             });
 
             if (!session.inFlight || session.inFlight.requestId !== requestId) {


### PR DESCRIPTION
### Motivation
- The retry guidance always recommended the Pro model even when another model would be more appropriate, so the message should suggest the alternate model instead of hardcoding Pro. 
- The previous 1-minute failure timeout was too short for some flows, so the Lumi request/send timeout should be increased to 2 minutes.

### Description
- Updated `card/api.js` to change the default `timeoutMs` in `requestLumiQuestion` from `60000` to `120000` (2 minutes). 
- Aligned the runtime `sendMessage` call to use a `timeoutMs: 120000` for the Lumi request instead of the previous conditional 45s/60s value. 
- Modified `buildErrorMessage` to compute the current model and pick the alternate model via `getAlternateModel(...)`, and to instruct the user to try the alternate model label instead of always recommending the Pro model.

### Testing
- Ran `npm run verify`, which performs `lint` and `test:smoke`, and the command completed successfully. 
- The smoke tests executed `scripts/verify_card_smoke.js`, `scripts/verify_card_remaster_smoke.js`, and `scripts/verify_idle_hero_smoke.js`, and all reported passing. 
- I did not perform manual visual validation in a running browser, so the in-UI rendering of the changed error string was not visually confirmed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c736d694832285fdf930e528fdeb)