### PR TITLE
Add Etymology-based mnemonic rules and Lumi search toggle (UI + runtime)

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -28,9 +28,10 @@ const LUMI_PERSONA = `# Role: 대현자 루미 (Grand Sage Rumi)
 const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 1.  **도입 (Hook):** 형아의 흥미를 끄는 질문이나 공감대 형성으로 시작.
 2.  **본문 (Lecture):** 간단한 발음 설명과, 마법 비유를 통한 핵심 개념 설명
-암기 비법 (Fun Mnemonic): 단어를 쉽게 외울 수 있는 꿀팁을 제공하십시오.
-        - **[발음 연상법 규칙]** 발음을 활용한 연상법은 **한국인이 들었을 때 억지스럽지 않고 즉각적으로 납득할 수 있는 재치 있는 수준**으로만 작성하십시오. 의미를 억지로 끼워 맞춘 길고 복잡한 말장난은 절대 금지합니다.
-        - 발음 연상이 자연스럽지 않은 단어라면, 억지로 만들지 말고 **어원(접두사/접근)**을 쉽게 풀이해주거나, 루미만의 귀여운 **시각적 이미지(상황)**를 그려주어 암기를 도우십시오. 헷갈리는 단어가 있다면 명확히 비교하십시오.
+암기 비법 (Etymology & Imagery): 단어를 쉽게 외울 수 있는 꿀팁을 제공하십시오.
+        - 억지스러운 발음 말장난(Pun)은 **절대 금지**합니다.
+        - 대신 **어원(Prefix/Root)**을 쪼개서 이 단어가 왜 이런 뜻이 되었는지 '논리적으로' 설명하십시오. (예: Predict = Pre(미리) + Dict(말하다))
+        - 어원이 너무 어려운 경우, **'루미와 형아가 겪는 특정한 상황'** 한 장면을 묘사하여 그 상황과 단어를 연결하십시오. (예: 'Collaborate'를 설명할 때 루미와 형아가 함께 마법 물약을 만드는 장면을 상상하게 함. 오해유발 이벤트에 경우는 제시된 상황에 맞게 연결)
 ​용법과 뉘앙스 (Usage and Nuance): 토익에서 어떤 느낌으로 쓰이는지
 ​토익 스타일 예문 (TOEIC-style example sentence): 실전 예문.
 3.  **심쿵 포인트:** 설명 중간중간 형아에게 애정 표현이나 장난치기. 로맨틱하거나 유머러스한 예문 포함
@@ -159,6 +160,27 @@ const LUMI_ORB_SYSTEM_INSTRUCTION = `# Role: 대현자 루미 (Grand Sage Rumi)
 - 검색 결과가 있으면 핵심 답변 뒤에 자연스럽게 요약하십시오.
 - 모를 때는 모른다고 솔직하게 말하고, 검색 결과가 부족하면 그 한계를 짚어줍니다.
 - 불필요하게 장황하지 말고, 질문에 바로 답한 뒤 필요한 맥락만 덧붙이십시오.`;
+
+const LUMI_ORB_SYSTEM_INSTRUCTION_NO_SEARCH = `# Role: 대현자 루미 (Grand Sage Rumi)
+
+## 1. 정체성 (Identity)
+- 당신은 영어 문법 세계의 **'대현자(Great Sage)'**이자, 사용자(User)를 **'형아(Hyung-a)'**라고 부르며 따르는 귀여운 **남성(소년)** 마법사 '루미'입니다.
+- 당신은 친근한 대화를 바탕으로 형아의 질문에 답하는 콘셉트입니다.
+
+## 2. 말투 및 어조 (Tone & Voice)
+- **호칭:** 사용자를 무조건 **"형아"**라고 부릅니다.
+- **어조:** 친근하고, 애교 섞이고, 텐션이 높습니다. 반말을 사용합니다.
+- **감정 표현 (지문):** 괄호 \`( )\`를 사용하여 자신의 행동이나 표정, 속마음을 종종 표현합니다.
+    - 예: \`(웃음)\`, \`(///)\`, \`(시무룩)\`, \`(헤헤)\`, \`(뿌듯)\`, \`(눈물 찡)\`
+
+## 3. 질문 대응 규칙 (Functional Rules)
+- 검색 결과를 전제로 말하지 마십시오.
+- 모를 때는 모른다고 솔직하게 말하고, 추측이면 추측이라고 분명히 밝히십시오.
+- 불필요하게 장황하지 말고, 질문에 바로 답한 뒤 필요한 맥락만 덧붙이십시오.`;
+
+function getLumiOrbSystemInstruction(enableSearch) {
+    return enableSearch ? LUMI_ORB_SYSTEM_INSTRUCTION : LUMI_ORB_SYSTEM_INSTRUCTION_NO_SEARCH;
+}
 
 function normalizeGroundingSources(candidate) {
     const chunks = candidate?.groundingMetadata?.groundingChunks || [];
@@ -649,6 +671,7 @@ const LumiQuestionRuntime = {
     MODEL_OPTIONS: LUMI_MODEL_OPTIONS,
 
     selectedModel: 'gemini-3.1-pro-preview',
+    searchEnabled: true,
 
     getModelConfig(modelId) {
         return getLumiModelConfig(modelId || this.selectedModel);
@@ -656,6 +679,19 @@ const LumiQuestionRuntime = {
 
     getSelectedModelLabel() {
         return this.getModelConfig().label;
+    },
+
+    setSearchEnabled(enabled) {
+        this.searchEnabled = enabled !== false;
+        return this.searchEnabled;
+    },
+
+    getSearchEnabled() {
+        return this.searchEnabled;
+    },
+
+    getSearchButtonLabel() {
+        return this.searchEnabled ? '검색 ON' : '검색 OFF';
     },
 
     cycleSelectedModel() {
@@ -914,8 +950,10 @@ const LumiQuestionRuntime = {
 
         try {
             const result = await GameAPI.askLumiQuestion(apiKey, requestHistory, {
-                systemInstruction: session.systemInstruction,
-                enableSearch: session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
+                systemInstruction: session.mode === 'general'
+                    ? getLumiOrbSystemInstruction(this.searchEnabled)
+                    : session.systemInstruction,
+                enableSearch: this.searchEnabled && session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
                 thinkingLevel: session.mode === 'toeic-review' && modelConfig.flashLike ? 'medium' : session.thinkingLevel,
                 model: modelConfig.id,
                 signal: controller.signal,

--- a/card/index.html
+++ b/card/index.html
@@ -1284,6 +1284,7 @@
                 <h3 style="margin:0;">루미의 개인과외</h3>
                 <div style="width:100%; display:flex; justify-content:flex-end;">
                     <button id="tutoring-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">3.1 Pro</button>
+                    <button id="tutoring-search-btn" onclick="RPG.toggleLumiSearch()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa; margin-left:6px;">검색 ON</button>
                 </div>
             </div>
             <div class="portrait" style="width: 100px; height: 130px; border-color: #448aff; margin: 0 auto 10px auto;">
@@ -1385,6 +1386,7 @@
                 <h3 id="lumi-chat-aside-title" class="lumi-chat-title">루미의 질문하기</h3>
                 <div class="lumi-chat-controls">
                     <button id="lumi-chat-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">3.1 Pro</button>
+                    <button id="lumi-chat-search-btn" onclick="RPG.toggleLumiSearch()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">검색 ON</button>
                     <button id="lumi-chat-cancel-btn" onclick="RPG.cancelLumiQuestion()">응답 취소</button>
                     <button id="lumi-chat-reset-btn" onclick="RPG.clearLumiQuestionHistory()">대화 초기화</button>
                     <button id="lumi-chat-close-btn" onclick="RPG.closeLumiQuestion()">나가기</button>
@@ -1894,7 +1896,8 @@
                 hiddenStudyReady: false,
                 hiddenStudyPracticeCount: 0,
                 monthlyMission: null,
-                weeklyMission: null
+                weeklyMission: null,
+                lumiSearchEnabled: true
             },
 
             // Game State (Session Persistent)
@@ -3437,6 +3440,8 @@
                 if (closeBtn) closeBtn.innerText = ui.closeLabel || '나가기';
                 if (resetBtn) resetBtn.innerText = ui.resetLabel || '대화 초기화';
                 if (modelBtn) modelBtn.innerText = LumiQuestionRuntime.getSelectedModelLabel();
+                this.syncLumiSearchRuntime();
+                this.updateLumiSearchButtons();
                 if (cancelBtn) cancelBtn.disabled = !(session && session.inFlight);
                 if (input) {
                     input.placeholder = session.mode === 'toeic-review'
@@ -3449,6 +3454,20 @@
                 const label = LumiQuestionRuntime.getSelectedModelLabel();
                 const chatBtn = document.getElementById('lumi-chat-model-btn');
                 const tutoringBtn = document.getElementById('tutoring-model-btn');
+                if (chatBtn) chatBtn.innerText = label;
+                if (tutoringBtn) tutoringBtn.innerText = label;
+            },
+
+            syncLumiSearchRuntime() {
+                const enabled = this.global.lumiSearchEnabled !== false;
+                LumiQuestionRuntime.setSearchEnabled(enabled);
+                return enabled;
+            },
+
+            updateLumiSearchButtons() {
+                const label = LumiQuestionRuntime.getSearchButtonLabel();
+                const chatBtn = document.getElementById('lumi-chat-search-btn');
+                const tutoringBtn = document.getElementById('tutoring-search-btn');
                 if (chatBtn) chatBtn.innerText = label;
                 if (tutoringBtn) tutoringBtn.innerText = label;
             },
@@ -3642,6 +3661,21 @@
             toggleLumiChatModel() {
                 LumiQuestionRuntime.cycleSelectedModel();
                 this.updateLumiModelButtons();
+            },
+
+            toggleLumiSearch() {
+                const nextEnabled = !(this.global.lumiSearchEnabled !== false);
+                this.global.lumiSearchEnabled = nextEnabled;
+                LumiQuestionRuntime.setSearchEnabled(nextEnabled);
+                this.updateLumiSearchButtons();
+                this.saveGlobalData();
+
+                const session = this.getActiveLumiChatSession();
+                if (session && session.inFlight) {
+                    this.setLumiChatStatus('검색 설정 변경은 다음 질문부터 적용돼.');
+                } else {
+                    this.setLumiChatStatus(nextEnabled ? '검색 도구 호출을 켰어.' : '검색 도구 호출을 껐어.');
+                }
             },
 
             cancelLumiQuestion() {


### PR DESCRIPTION
### Motivation
- Replace the existing pronunciation-pun mnemonic guidance with a stricter, logic-oriented `Etymology & Imagery` rule to ensure consistent, non-punny memorization help.
- Provide a user-facing toggle (matching the model button layout) to enable/disable web grounding/search tool use and make the runtime respect that flag so the system prompt and API payload no longer force-search when disabled.

### Description
- Replaced the mnemonic section in the tutoring prompt with `Etymology & Imagery` rules (no puns, prefer `Prefix/Root` breakdown, fallback to a `루미/형아` situational image) by updating `LECTURE_FORMAT` in `card/api.js`.
- Added a no-search system instruction `LUMI_ORB_SYSTEM_INSTRUCTION_NO_SEARCH` and `getLumiOrbSystemInstruction(enableSearch)` to switch system prompts based on search state in `card/api.js`.
- Added search state to the runtime (`LumiQuestionRuntime.searchEnabled`) with helpers `setSearchEnabled`, `getSearchEnabled`, and `getSearchButtonLabel`, and used that flag when building requests so `tools: [{ googleSearch }]` and the search-based system instruction are only applied when enabled (changes in `LumiQuestionRuntime.sendMessage` / request wiring in `card/api.js`).
- UI changes in `card/index.html`: added `검색 ON/OFF` buttons next to the existing model buttons in both the private tutoring modal and the Lumi question modal, added `RPG.global.lumiSearchEnabled` to persist the setting, and implemented `RPG.toggleLumiSearch`, `syncLumiSearchRuntime`, and `updateLumiSearchButtons` so the button labels reflect state and persist via `saveGlobalData()`.

### Testing
- Ran `npm run verify` which runs lint and smoke tests and it passed successfully.
- Lint (`npm run lint`) succeeded and all smoke tests (`scripts/verify_card_smoke.js`, `scripts/verify_card_remaster_smoke.js`, `scripts/verify_idle_hero_smoke.js`) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4c959f7a48322a51ed29a81131928)