### PR TITLE
Simplify Lumi model toggle labels (Pro / Flash / Flash Lite)

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -38,9 +38,9 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 4.강의 마무리 멘트`;
 
 const LUMI_MODEL_OPTIONS = Object.freeze([
-    { id: 'gemini-3.1-pro-preview', label: '3.1 Pro', flashLike: false, allowSearch: true },
-    { id: 'gemini-3-flash-preview', label: 'Flash 3', flashLike: true, allowSearch: true },
-    { id: 'gemini-3.1-flash-lite-preview', label: '3.1 Flash Lite', flashLike: true, allowSearch: false }
+    { id: 'gemini-3.1-pro-preview', label: 'Pro', flashLike: false, allowSearch: true },
+    { id: 'gemini-3-flash-preview', label: 'Flash', flashLike: true, allowSearch: true },
+    { id: 'gemini-3.1-flash-lite-preview', label: 'Flash Lite', flashLike: true, allowSearch: false }
 ]);
 
 function getLumiModelConfig(modelId) {

--- a/card/index.html
+++ b/card/index.html
@@ -1283,7 +1283,7 @@
             <div style="display:flex; flex-direction:column; align-items:flex-start; gap:8px; margin-bottom:10px;">
                 <h3 style="margin:0;">루미의 개인과외</h3>
                 <div style="width:100%; display:flex; justify-content:flex-end;">
-                    <button id="tutoring-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">3.1 Pro</button>
+                    <button id="tutoring-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">Pro</button>
                     <button id="tutoring-search-btn" onclick="RPG.toggleLumiSearch()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa; margin-left:6px;">검색 ON</button>
                 </div>
             </div>
@@ -1385,7 +1385,7 @@
             <div class="lumi-chat-top">
                 <h3 id="lumi-chat-aside-title" class="lumi-chat-title">루미의 질문하기</h3>
                 <div class="lumi-chat-controls">
-                    <button id="lumi-chat-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">3.1 Pro</button>
+                    <button id="lumi-chat-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">Pro</button>
                     <button id="lumi-chat-search-btn" onclick="RPG.toggleLumiSearch()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">검색 ON</button>
                     <button id="lumi-chat-cancel-btn" onclick="RPG.cancelLumiQuestion()">응답 취소</button>
                     <button id="lumi-chat-reset-btn" onclick="RPG.clearLumiQuestionHistory()">대화 초기화</button>


### PR DESCRIPTION
### Motivation
- Display the Lumi model toggle labels without version numbers (use `Pro`, `Flash`, `Flash Lite`) so the UI shows simple English names.

### Description
- Changed the `label` values in `LUMI_MODEL_OPTIONS` in `card/api.js` and updated the model toggle button text in `card/index.html` to `Pro`, while keeping the original model `id`s and API behavior unchanged.

### Testing
- Ran `npm run verify` which ran lint and the smoke tests (`npm run lint` and `npm run test:smoke`) and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4eaa024d083229811c13f5af736b3)