### PR TITLE
Use Gemini 2.5 Pro for tutoring, force Gemini 3.0 Flash for dates, disable tutoring search toggle

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -38,7 +38,7 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 4.강의 마무리 멘트`;
 
 const LUMI_MODEL_OPTIONS = Object.freeze([
-    { id: 'gemini-3.1-pro-preview', label: '3.1 Pro', flashLike: false, allowSearch: true },
+    { id: 'gemini-2.5-pro', label: '2.5 Pro', flashLike: false, allowSearch: true, useThinkingBudget: true, thinkingBudget: 25000 },
     { id: 'gemini-3-flash-preview', label: 'Flash 3', flashLike: true, allowSearch: true },
     { id: 'gemini-3.1-flash-lite-preview', label: '3.1 Flash Lite', flashLike: true, allowSearch: false }
 ]);
@@ -106,9 +106,7 @@ const GameAPI = {
                 contents: [{ parts: [{ text: fullPrompt }] }],
                 generationConfig: {
                     temperature: isMisunderstandingMode ? 0.65 : 0.4,
-                    thinkingConfig: {
-                        thinkingLevel: modelConfig.flashLike ? 'medium' : 'high'
-                    }
+                    thinkingConfig: getThinkingConfig(modelConfig, modelConfig.flashLike ? 'medium' : 'high')
                 },
                 safetySettings: [
                     { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
@@ -180,6 +178,16 @@ const LUMI_ORB_SYSTEM_INSTRUCTION_NO_SEARCH = `# Role: 대현자 루미 (Grand S
 
 function getLumiOrbSystemInstruction(enableSearch) {
     return enableSearch ? LUMI_ORB_SYSTEM_INSTRUCTION : LUMI_ORB_SYSTEM_INSTRUCTION_NO_SEARCH;
+}
+
+
+function getThinkingConfig(modelConfig, thinkingLevel = 'high') {
+    if (modelConfig && modelConfig.useThinkingBudget) {
+        return { thinkingBudget: modelConfig.thinkingBudget || 25000 };
+    }
+    return {
+        thinkingLevel: normalizeThinkingLevel(modelConfig && modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
+    };
 }
 
 function normalizeGroundingSources(candidate) {
@@ -306,7 +314,7 @@ async function requestLumiQuestion(apiKey, history, options = {}) {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
         thinkingLevel = 'high',
-        model = 'gemini-3.1-pro-preview',
+        model = 'gemini-2.5-pro',
         signal,
         timeoutMs = 120000
     } = options;
@@ -328,9 +336,7 @@ async function requestLumiQuestion(apiKey, history, options = {}) {
     }
 
     payload.generationConfig = {
-        thinkingConfig: {
-            thinkingLevel: normalizeThinkingLevel(modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
-        }
+        thinkingConfig: getThinkingConfig(modelConfig, thinkingLevel)
     };
     payload.safetySettings = [
         { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
@@ -406,7 +412,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
         thinkingLevel = 'high',
-        model = 'gemini-3.1-pro-preview'
+        model = 'gemini-2.5-pro'
     } = options;
     const modelConfig = getLumiModelConfig(model);
 
@@ -426,9 +432,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
     }
 
     payload.generationConfig = {
-        thinkingConfig: {
-            thinkingLevel: normalizeThinkingLevel(modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
-        }
+        thinkingConfig: getThinkingConfig(modelConfig, thinkingLevel)
     };
     payload.safetySettings = [
         { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
@@ -670,7 +674,7 @@ const LumiQuestionRuntime = {
     SESSION_KEYS: LUMI_SESSION_KEYS,
     MODEL_OPTIONS: LUMI_MODEL_OPTIONS,
 
-    selectedModel: 'gemini-3.1-pro-preview',
+    selectedModel: 'gemini-2.5-pro',
     searchEnabled: true,
 
     getModelConfig(modelId) {
@@ -1098,7 +1102,7 @@ GameAPI.getDateContent = async function (apiKey, dateParams) {
 
     const temperature = innuendoInstruction ? 0.85 : 0.8;
 
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`, {
+    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.0-flash:generateContent?key=${apiKey}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/card/index.html
+++ b/card/index.html
@@ -1283,8 +1283,8 @@
             <div style="display:flex; flex-direction:column; align-items:flex-start; gap:8px; margin-bottom:10px;">
                 <h3 style="margin:0;">루미의 개인과외</h3>
                 <div style="width:100%; display:flex; justify-content:flex-end;">
-                    <button id="tutoring-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">3.1 Pro</button>
-                    <button id="tutoring-search-btn" onclick="RPG.toggleLumiSearch()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa; margin-left:6px;">검색 ON</button>
+                    <button id="tutoring-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">2.5 Pro</button>
+                    <button id="tutoring-search-btn" disabled style="padding:6px 10px; border:1px solid #555; border-radius:6px; background:#2a2a2a; color:#888; margin-left:6px; cursor:not-allowed;">검색 비활성</button>
                 </div>
             </div>
             <div class="portrait" style="width: 100px; height: 130px; border-color: #448aff; margin: 0 auto 10px auto;">
@@ -1385,7 +1385,7 @@
             <div class="lumi-chat-top">
                 <h3 id="lumi-chat-aside-title" class="lumi-chat-title">루미의 질문하기</h3>
                 <div class="lumi-chat-controls">
-                    <button id="lumi-chat-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">3.1 Pro</button>
+                    <button id="lumi-chat-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">2.5 Pro</button>
                     <button id="lumi-chat-search-btn" onclick="RPG.toggleLumiSearch()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">검색 ON</button>
                     <button id="lumi-chat-cancel-btn" onclick="RPG.cancelLumiQuestion()">응답 취소</button>
                     <button id="lumi-chat-reset-btn" onclick="RPG.clearLumiQuestionHistory()">대화 초기화</button>
@@ -3469,7 +3469,7 @@
                 const chatBtn = document.getElementById('lumi-chat-search-btn');
                 const tutoringBtn = document.getElementById('tutoring-search-btn');
                 if (chatBtn) chatBtn.innerText = label;
-                if (tutoringBtn) tutoringBtn.innerText = label;
+                if (tutoringBtn) tutoringBtn.innerText = tutoringBtn.disabled ? '검색 비활성' : label;
             },
 
             openLumiChatSession(session, sessionKey) {
@@ -3743,7 +3743,7 @@
                     if (error.canceled) {
                         this.setLumiChatStatus(LumiQuestionRuntime.getCanceledStatus());
                     } else if (error.retryable) {
-                        this.setLumiChatStatus('응답이 흔들렸어. 다시 시도하거나 Pro로 바꿔볼 수 있어.');
+                        this.setLumiChatStatus('응답이 흔들렸어. 다시 시도하거나 다른 모델로 바꿔볼 수 있어.');
                     } else {
                     this.setLumiChatStatus('답변 요청에 실패했어.');
                     }


### PR DESCRIPTION
### Motivation
- Tutoring and date flows should use the models and generation settings specified: tutoring should use `gemini-2.5-pro` with a thinking budget, and dates should always run on the 3.0 flash path with high reasoning, while search is not needed for tutoring/date so the tutoring search toggle must be disabled.

### Description
- Replaced model options and default to `gemini-2.5-pro` and added model metadata `useThinkingBudget`/`thinkingBudget` to allow budget-based invocation instead of thinking-level for 2.5. (`card/api.js`).
- Added `getThinkingConfig(modelConfig, thinkingLevel)` and switched generation payloads to call it so models with `useThinkingBudget` send `thinkingBudget: 25000` while flash-like models keep `thinkingLevel` logic. (`card/api.js`).
- Changed the date content generation to call the `gemini-3.0-flash` endpoint with `thinkingLevel: 'high'` so dates always enter flash high-reasoning regardless of UI model selection. (`card/api.js`).
- Disabled the tutoring modal search toggle button in the HTML and updated runtime label logic so the tutoring button shows `검색 비활성`, and adjusted a retry-status message to remove a Pro-specific suggestion. (`card/index.html`).

### Testing
- Ran `npm run verify` (which runs lint and smoke tests) and it completed successfully. 
- All automated smoke checks (`scripts/verify_card_smoke.js`, `scripts/verify_card_remaster_smoke.js`, `scripts/verify_idle_hero_smoke.js`) passed. 
- UI changes (visual button disabled state and runtime behavior in a browser, and end-to-end verification that the tutoring/date flows call the intended remote models during real API runs) were not manually verified in a browser; only automated checks were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ff78b1108322944583460e2126d2)