### PR TITLE
Route tutoring to gemini-2.5-pro with thinkingBudget and disable tutoring search toggle

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -38,7 +38,7 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 4.강의 마무리 멘트`;
 
 const LUMI_MODEL_OPTIONS = Object.freeze([
-    { id: 'gemini-3.1-pro-preview', label: 'Pro', flashLike: false, allowSearch: true },
+    { id: 'gemini-2.5-pro', label: 'Pro', flashLike: false, allowSearch: true, useThinkingBudget: true },
     { id: 'gemini-3-flash-preview', label: 'Flash', flashLike: true, allowSearch: true },
     { id: 'gemini-3.1-flash-lite-preview', label: 'Flash Lite', flashLike: true, allowSearch: false }
 ]);
@@ -106,9 +106,7 @@ const GameAPI = {
                 contents: [{ parts: [{ text: fullPrompt }] }],
                 generationConfig: {
                     temperature: isMisunderstandingMode ? 0.65 : 0.4,
-                    thinkingConfig: {
-                        thinkingLevel: modelConfig.flashLike ? 'medium' : 'high'
-                    }
+                    thinkingConfig: buildThinkingConfig(modelConfig, 'high')
                 },
                 safetySettings: [
                     { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
@@ -204,6 +202,18 @@ const GEMINI_REASONING_LEVELS = new Set(['low', 'medium', 'high']);
 
 function normalizeThinkingLevel(thinkingLevel) {
     return GEMINI_REASONING_LEVELS.has(thinkingLevel) ? thinkingLevel : 'high';
+}
+
+function buildThinkingConfig(modelConfig, thinkingLevel = 'high') {
+    if (modelConfig && modelConfig.useThinkingBudget) {
+        return {
+            thinkingBudget: 25000
+        };
+    }
+
+    return {
+        thinkingLevel: normalizeThinkingLevel(modelConfig && modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
+    };
 }
 
 function isAbortError(error) {
@@ -306,7 +316,7 @@ async function requestLumiQuestion(apiKey, history, options = {}) {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
         thinkingLevel = 'high',
-        model = 'gemini-3.1-pro-preview',
+        model = 'gemini-2.5-pro',
         signal,
         timeoutMs = 120000
     } = options;
@@ -328,9 +338,7 @@ async function requestLumiQuestion(apiKey, history, options = {}) {
     }
 
     payload.generationConfig = {
-        thinkingConfig: {
-            thinkingLevel: normalizeThinkingLevel(modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
-        }
+        thinkingConfig: buildThinkingConfig(modelConfig, thinkingLevel)
     };
     payload.safetySettings = [
         { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
@@ -406,7 +414,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         systemInstruction = LUMI_ORB_SYSTEM_INSTRUCTION,
         enableSearch = true,
         thinkingLevel = 'high',
-        model = 'gemini-3.1-pro-preview'
+        model = 'gemini-2.5-pro'
     } = options;
     const modelConfig = getLumiModelConfig(model);
 
@@ -426,9 +434,7 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
     }
 
     payload.generationConfig = {
-        thinkingConfig: {
-            thinkingLevel: normalizeThinkingLevel(modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
-        }
+        thinkingConfig: buildThinkingConfig(modelConfig, thinkingLevel)
     };
     payload.safetySettings = [
         { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
@@ -670,7 +676,7 @@ const LumiQuestionRuntime = {
     SESSION_KEYS: LUMI_SESSION_KEYS,
     MODEL_OPTIONS: LUMI_MODEL_OPTIONS,
 
-    selectedModel: 'gemini-3.1-pro-preview',
+    selectedModel: 'gemini-2.5-pro',
     searchEnabled: true,
 
     getModelConfig(modelId) {

--- a/card/index.html
+++ b/card/index.html
@@ -1284,7 +1284,7 @@
                 <h3 style="margin:0;">루미의 개인과외</h3>
                 <div style="width:100%; display:flex; justify-content:flex-end;">
                     <button id="tutoring-model-btn" onclick="RPG.toggleLumiChatModel()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa;">Pro</button>
-                    <button id="tutoring-search-btn" onclick="RPG.toggleLumiSearch()" style="padding:6px 10px; border:1px solid #448aff; border-radius:6px; background:#1f1f1f; color:#81d4fa; margin-left:6px;">검색 ON</button>
+                    <button id="tutoring-search-btn" disabled style="padding:6px 10px; border:1px solid #555; border-radius:6px; background:#1f1f1f; color:#777; margin-left:6px; cursor:not-allowed;">검색 OFF</button>
                 </div>
             </div>
             <div class="portrait" style="width: 100px; height: 130px; border-color: #448aff; margin: 0 auto 10px auto;">
@@ -3469,7 +3469,7 @@
                 const chatBtn = document.getElementById('lumi-chat-search-btn');
                 const tutoringBtn = document.getElementById('tutoring-search-btn');
                 if (chatBtn) chatBtn.innerText = label;
-                if (tutoringBtn) tutoringBtn.innerText = label;
+                if (tutoringBtn) { tutoringBtn.innerText = '검색 OFF'; tutoringBtn.disabled = true; }
             },
 
             openLumiChatSession(session, sessionKey) {


### PR DESCRIPTION
### Motivation
- 개인과외(튜터링)는 검색 토글이 필요 없고 Pro 모델은 Gemini 2.5 Pro로 고정해야 한다는 요구를 반영하기 위함. 
- Gemini 2.5 Pro는 `thinkingBudget` 방식으로 호출되어야 하며 기본값(25000)을 적용해야 한다. 
- 데이트 흐름은 모달 선택과 무관하게 Flash 계열(high reasoning)로 유지해야 하므로 관련 호출은 그대로 둠.

### Description
- `card/api.js`: `LUMI_MODEL_OPTIONS`에서 Pro 항목을 `gemini-2.5-pro`로 교체하고 기본 `selectedModel`을 `gemini-2.5-pro`로 변경했습니다. 
- `card/api.js`: 모델별로 생성 옵션을 만들기 위한 `buildThinkingConfig` 헬퍼를 추가해 `gemini-2.5-pro`는 `{ thinkingBudget: 25000 }`을 사용하고 나머지(Flash 계열)는 기존 `thinkingLevel` 로직을 유지하도록 통합했습니다. 
- `card/api.js`: 개인과외/질문용 API 호출들(`getTutoringContent`, `requestLumiQuestion`, `askLumiQuestion` 등)에 새로운 `buildThinkingConfig`를 적용하도록 변경했습니다. 
- `card/index.html`: 개인과외 모달의 검색 토글 버튼을 비활성화(표시 "검색 OFF", `disabled`)하고 UI 갱신 로직에서 개인과외 쪽 버튼은 항상 비활성 상태를 유지하도록 조정했습니다.

### Testing
- 자동화 검증으로 `npm run verify`(`lint` + `test:smoke`)를 실행했고 모두 통과했습니다. 
- 변경된 파일: `card/api.js`, `card/index.html` (커밋에 반영됨). 
- 주의: UI의 실제 시각적 상태(튜터링 모달에서 버튼이 비활성화되어 보이고 토글이 불가능한지)는 브라우저 스크린샷 검증이 수행되지 않아 수동/시각적 확인이 아직 남아있습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d500af02148322bc89137657fea5ca)