### PR TITLE
Trigger Poseidon stun on actual guard success (not on guard use)

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -441,8 +441,12 @@ const BattleRuntime = {
                 return;
             }
 
+            const guardSucceeded = !!target.buffs.guard;
             let dmg = val * mult * (100 / (100 + def));
-            if (target.buffs.guard) dmg *= 0.5;
+            if (guardSucceeded) {
+                dmg *= 0.5;
+                rpg.log(`${target.name} 가드 성공! 피해 반감.`);
+            }
             dmg = Math.floor(dmg);
             target.hp -= dmg;
             if (dmg > 0) {
@@ -477,6 +481,15 @@ const BattleRuntime = {
                     rpg.loseBattle();
                     return;
                 }
+            } else if (
+                guardSucceeded &&
+                target.proto &&
+                target.proto.trait &&
+                target.proto.trait.type === 'guard_stun_double_dmg' &&
+                !enemy.buffs.stun
+            ) {
+                enemy.buffs.stun = 1;
+                rpg.log(`[특성] ${target.name}: 가드 성공! 적에게 [기절] 부여.`);
             }
 
             if (enemy.hp <= 0) rpg.winBattle();
@@ -767,16 +780,6 @@ const BattleRuntime = {
                 SideEffects.apply(ctx, effect);
             }
         });
-
-        if (
-            source.proto &&
-            source.proto.trait &&
-            source.proto.trait.type === 'guard_stun_double_dmg' &&
-            skill.effects.some(effect => effect.type === 'buff' && effect.id === 'guard')
-        ) {
-            target.buffs.stun = 1;
-            rpg.log(`[특성] ${source.name}: 가드 사용으로 적을 기절시켰다!`);
-        }
 
         if (rpg.battle.activeTraits.includes('syn_water_nature') && skill.name === '문라이트세레나') {
             rpg.log("루미의 특성 발동! 트윙클파티 추가!");

--- a/card/data.js
+++ b/card/data.js
@@ -1115,7 +1115,7 @@ const BONUS_TRANSCENDENCE_CARDS = [
         trait: {
             type: 'guard_stun_double_dmg',
             val: 2.0,
-            desc: '가드 사용 시 적에게 기절 부여 / 기절 상태의 적에게 대미지 2배'
+            desc: '가드 성공 시 적에게 기절 부여 / 기절 상태의 적에게 대미지 2배'
         },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },

--- a/card_remaster/battle_runtime.js
+++ b/card_remaster/battle_runtime.js
@@ -441,8 +441,12 @@ const BattleRuntime = {
                 return;
             }
 
+            const guardSucceeded = !!target.buffs.guard;
             let dmg = val * mult * (100 / (100 + def));
-            if (target.buffs.guard) dmg *= 0.5;
+            if (guardSucceeded) {
+                dmg *= 0.5;
+                rpg.log(`${target.name} 가드 성공! 피해 반감.`);
+            }
             dmg = Math.floor(dmg);
             target.hp -= dmg;
             if (dmg > 0) {
@@ -477,6 +481,15 @@ const BattleRuntime = {
                     rpg.loseBattle();
                     return;
                 }
+            } else if (
+                guardSucceeded &&
+                target.proto &&
+                target.proto.trait &&
+                target.proto.trait.type === 'guard_stun_double_dmg' &&
+                !enemy.buffs.stun
+            ) {
+                enemy.buffs.stun = 1;
+                rpg.log(`[특성] ${target.name}: 가드 성공! 적에게 [기절] 부여.`);
             }
 
             if (enemy.hp <= 0) rpg.winBattle();
@@ -767,16 +780,6 @@ const BattleRuntime = {
                 SideEffects.apply(ctx, effect);
             }
         });
-
-        if (
-            source.proto &&
-            source.proto.trait &&
-            source.proto.trait.type === 'guard_stun_double_dmg' &&
-            skill.effects.some(effect => effect.type === 'buff' && effect.id === 'guard')
-        ) {
-            target.buffs.stun = 1;
-            rpg.log(`[특성] ${source.name}: 가드 사용으로 적을 기절시켰다!`);
-        }
 
         if (rpg.battle.activeTraits.includes('syn_water_nature') && skill.name === '문라이트세레나') {
             rpg.log("루미의 특성 발동! 트윙클파티 추가!");

--- a/card_remaster/data.js
+++ b/card_remaster/data.js
@@ -1105,7 +1105,7 @@ const BONUS_TRANSCENDENCE_CARDS = [
         trait: {
             type: 'guard_stun_double_dmg',
             val: 2.0,
-            desc: '가드 사용 시 적에게 기절 부여 / 기절 상태의 적에게 대미지 2배'
+            desc: '가드 성공 시 적에게 기절 부여 / 기절 상태의 적에게 대미지 2배'
         },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },


### PR DESCRIPTION
### Motivation
- Align Poseidon's trait with its intended trigger so the stun activates only when guard actually mitigates damage, not merely when the guard skill is cast.
- Prevent incorrect early stun application that occurred in the skill-effect phase and make behaviour consistent with similar traits (e.g., evasion-triggered stun).

### Description
- Updated Poseidon trait description in both `card/data.js` and `card_remaster/data.js` from "가드 사용 시" to "가드 성공 시" to reflect intended behavior.
- In `card/battle_runtime.js` and `card_remaster/battle_runtime.js` added a `guardSucceeded` check in the enemy attack resolution, logged guard success, applied damage halving only when guard actually succeeded, and moved the stun application to after damage processing so it triggers only when the defender survives.
- Removed the previous immediate stun trigger from `applySkillEffects()` which incorrectly stunned the attacker when the guard buff was merely applied.
- Kept the trait type `guard_stun_double_dmg` unchanged so existing double-damage-on-stunned logic in `logic.js` remains functional.

### Testing
- Ran `npm run verify` which performs lint (`node --check` on relevant files) and smoke tests; lint checks passed and smoke tests for `card`, `card_remaster`, and `idle_hero` all passed.
- No automated tests failed during verification and the game smoke checks reported success for all affected modes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67f5e0b24832286e32cf408ed824f)