### PR TITLE
Fix seasonal boss IDs to use scripted enemy AI patterns

### DIFF
--- a/card/logic.js
+++ b/card/logic.js
@@ -1893,7 +1893,7 @@ const Logic = {
             if (turn === 7 || turn === 14) skill = enemy.skills.find(s => s.name === '제노사이드');
             else if (r < 0.2) skill = enemy.skills.find(s => s.name === '다크니스');
         }
-        else if (enemy.id === 'flora') {
+        else if (enemy.id === 'flora' || enemy.id === 'flora_valentine') {
             if (turn === 5 || turn === 10) skill = enemy.skills.find(s => s.name === '제네시스블룸');
             else if (r < 0.3) skill = enemy.skills.find(s => s.name === '블러썸템페스트');
         }
@@ -1904,7 +1904,7 @@ const Logic = {
                 skill = enemy.skills.find(s => s.name === skillName);
             }
         }
-        else if (enemy.id === 'thor') {
+        else if (enemy.id === 'thor' || enemy.id === 'thor_swimsuit') {
             if (turn === 10) skill = enemy.skills.find(s => s.name === '썬더러쉬');
             else if (r < 0.2) skill = enemy.skills.find(s => s.name === '묠니르');
         }
@@ -1914,7 +1914,7 @@ const Logic = {
             else if (turn === 15) skill = enemy.skills.find(s => s.name === '디바우러');
             else if (r < 0.2) skill = enemy.skills.find(s => s.name === '트라이던트');
         }
-        else if (enemy.id === 'ares') {
+        else if (enemy.id === 'ares' || enemy.id === 'ares_halloween') {
             if (enemy.isCharging && enemy.chargeSkillId) {
                 const chargedSkill = enemy.skills.find(s => s.name === enemy.chargeSkillId);
                 return chargedSkill ? { ...chargedSkill, chargeReset: true } : { type: 'phy', val: 1.0, name: '일반 공격' };
@@ -1934,7 +1934,7 @@ const Logic = {
             }
             if (r < 0.2) skill = enemy.skills.find(s => s.name === '스피어레인');
         }
-        else if (enemy.id === 'creator_god') {
+        else if (enemy.id === 'creator_god' || enemy.id === 'astea_christmas') {
             if (enemy.isCharging) {
                 const chargedSkill = enemy.skills.find(s => s.name === '디바인블레이드');
                 return { ...chargedSkill, chargeReset: true };


### PR DESCRIPTION
### Motivation
- Seasonal boss variants used new IDs and therefore fell through hardcoded AI branches, causing scripted skills and charge behavior to never trigger.
- Restoring the original scripted behavior for those seasonal IDs preserves intended difficulty and fight patterns for the new feature.

### Description
- Extended `Logic.decideEnemyAction` in `card/logic.js` so seasonal IDs reuse the original boss branches: `flora_valentine` -> `flora`, `thor_swimsuit` -> `thor`, `ares_halloween` -> `ares`, and `astea_christmas` -> `creator_god`.
- This restores timed/turn-based skills and charge sequences such as `제네시스블룸`, `썬더러쉬`, `테라소드`/`마그마이럽션` charge cycles, and `디바인블레이드` charge execution for the seasonal bosses.
- Change is limited to `card/logic.js` with minimal diffs to preserve existing behavior.

### Testing
- Ran `npm run verify` which executes lint and smoke tests and it completed successfully.
- Lint checks passed (`node --check` on relevant JS files) and smoke tests passed for `card`, `card_remaster`, and `idle_hero`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9213e651083229662c9410208da72)