### PR TITLE
Add reserve English study data

### DIFF
--- a/card/collocation_reserve_data.js
+++ b/card/collocation_reserve_data.js
@@ -1,0 +1,987 @@
+// Reserve Collocation data for future migration into `card/collocation_data.js`.
+// Intentionally not loaded by the game yet.
+// When this content is approved for production, move the items below into `COLLOCATION_DATA`.
+
+const COLLOCATION_RESERVE_DATA = [
+    {
+        "id": 101,
+        "expression": "apply for",
+        "meaning": "지원하다; 신청하다",
+        "options": [
+            "apply",
+            "appoint",
+            "approve",
+            "appeal"
+        ],
+        "question": "Please _______ for the marketing assistant position through the company Web site by Friday.",
+        "answer": "apply",
+        "translation": "금요일까지 회사 웹사이트를 통해 마케팅 보조 직무에 지원해 주십시오.",
+        "quizzes": [
+            {
+                "question": "Please _______ for the marketing assistant position through the company Web site by Friday.",
+                "options": [
+                    "apply",
+                    "appoint",
+                    "approve",
+                    "appeal"
+                ],
+                "answer": "apply",
+                "translation": "금요일까지 회사 웹사이트를 통해 마케팅 보조 직무에 지원해 주십시오."
+            },
+            {
+                "question": "Employees may _______ for internal training grants once per calendar year.",
+                "options": [
+                    "apply",
+                    "arrive",
+                    "assign",
+                    "avoid"
+                ],
+                "answer": "apply",
+                "translation": "직원들은 1년에 한 번 사내 교육 보조금에 신청할 수 있다."
+            },
+            {
+                "question": "Several graduates plan to _______ for the analyst role after the job fair.",
+                "options": [
+                    "apply",
+                    "attach",
+                    "adapt",
+                    "argue"
+                ],
+                "answer": "apply",
+                "translation": "몇몇 졸업생들은 채용 박람회 후 분석가 직무에 지원할 계획이다."
+            }
+        ]
+    },
+    {
+        "id": 102,
+        "expression": "sign up for",
+        "meaning": "등록하다; 신청하다",
+        "options": [
+            "sign",
+            "set",
+            "show",
+            "sort"
+        ],
+        "question": "All participants must _______ up for the safety workshop in advance.",
+        "answer": "sign",
+        "translation": "모든 참가자는 안전 워크숍에 미리 등록해야 한다.",
+        "quizzes": [
+            {
+                "question": "All participants must _______ up for the safety workshop in advance.",
+                "options": [
+                    "sign",
+                    "set",
+                    "show",
+                    "sort"
+                ],
+                "answer": "sign",
+                "translation": "모든 참가자는 안전 워크숍에 미리 등록해야 한다."
+            },
+            {
+                "question": "Customers can _______ up for delivery alerts by entering their e-mail addresses.",
+                "options": [
+                    "sign",
+                    "stand",
+                    "step",
+                    "store"
+                ],
+                "answer": "sign",
+                "translation": "고객은 이메일 주소를 입력해 배송 알림을 신청할 수 있다."
+            },
+            {
+                "question": "I forgot to _______ up for the optional factory tour after the conference.",
+                "options": [
+                    "sign",
+                    "switch",
+                    "save",
+                    "speed"
+                ],
+                "answer": "sign",
+                "translation": "나는 회의 후 선택형 공장 투어를 신청하는 것을 잊었다."
+            }
+        ]
+    },
+    {
+        "id": 103,
+        "expression": "break down",
+        "meaning": "고장 나다; 작동을 멈추다",
+        "options": [
+            "break",
+            "bring",
+            "build",
+            "burn"
+        ],
+        "question": "A delivery truck could _______ down during severe weather, so please allow extra time for shipping.",
+        "answer": "break",
+        "translation": "악천후에는 배송 트럭이 고장 날 수 있으므로 배송에 추가 시간을 두십시오.",
+        "quizzes": [
+            {
+                "question": "A delivery truck could _______ down during severe weather, so please allow extra time for shipping.",
+                "options": [
+                    "break",
+                    "bring",
+                    "build",
+                    "burn"
+                ],
+                "answer": "break",
+                "translation": "악천후에는 배송 트럭이 고장 날 수 있으므로 배송에 추가 시간을 두십시오."
+            },
+            {
+                "question": "If the photocopier _______ down again, please contact the service center immediately.",
+                "options": [
+                    "breaks",
+                    "brings",
+                    "boosts",
+                    "buries"
+                ],
+                "answer": "breaks",
+                "translation": "복사기가 또 고장 나면 즉시 서비스 센터에 연락해 주세요."
+            },
+            {
+                "question": "Production stopped when one of the packing machines _______ down yesterday afternoon.",
+                "options": [
+                    "broke",
+                    "brought",
+                    "blocked",
+                    "borrowed"
+                ],
+                "answer": "broke",
+                "translation": "어제 오후 포장 기계 중 하나가 고장 나서 생산이 중단되었다."
+            }
+        ]
+    },
+    {
+        "id": 104,
+        "expression": "drop off",
+        "meaning": "내려주다; 맡기다; 두고 가다",
+        "options": [
+            "drop",
+            "draw",
+            "drive",
+            "drift"
+        ],
+        "question": "You may _______ off the signed contract at the reception desk before noon.",
+        "answer": "drop",
+        "translation": "정오 전까지 서명된 계약서를 접수 데스크에 맡기셔도 됩니다.",
+        "quizzes": [
+            {
+                "question": "You may _______ off the signed contract at the reception desk before noon.",
+                "options": [
+                    "drop",
+                    "draw",
+                    "drive",
+                    "drift"
+                ],
+                "answer": "drop",
+                "translation": "정오 전까지 서명된 계약서를 접수 데스크에 맡기셔도 됩니다."
+            },
+            {
+                "question": "The courier will _______ off the samples at our office around 2:00 p.m.",
+                "options": [
+                    "drop",
+                    "drill",
+                    "dress",
+                    "drain"
+                ],
+                "answer": "drop",
+                "translation": "택배 기사가 오후 2시쯤 우리 사무실에 샘플을 내려놓을 것이다."
+            },
+            {
+                "question": "Please _______ off your reimbursement form in the Finance mailbox on the first floor.",
+                "options": [
+                    "drop",
+                    "drag",
+                    "dream",
+                    "dry"
+                ],
+                "answer": "drop",
+                "translation": "1층 재무팀 우편함에 경비 정산 서류를 넣어 주세요."
+            }
+        ]
+    },
+    {
+        "id": 105,
+        "expression": "check out",
+        "meaning": "체크아웃하다; 퇴실하다",
+        "options": [
+            "check",
+            "carry",
+            "count",
+            "cross"
+        ],
+        "question": "Guests should _______ out by 11:00 a.m. unless a late departure has been approved.",
+        "answer": "check",
+        "translation": "늦은 퇴실이 승인되지 않은 경우, 투숙객은 오전 11시까지 체크아웃해야 한다.",
+        "quizzes": [
+            {
+                "question": "Guests should _______ out by 11:00 a.m. unless a late departure has been approved.",
+                "options": [
+                    "check",
+                    "carry",
+                    "count",
+                    "cross"
+                ],
+                "answer": "check",
+                "translation": "늦은 퇴실이 승인되지 않은 경우, 투숙객은 오전 11시까지 체크아웃해야 한다."
+            },
+            {
+                "question": "Mr. Lee will _______ out of the Riverside Hotel on Saturday morning.",
+                "options": [
+                    "check",
+                    "call",
+                    "clean",
+                    "copy"
+                ],
+                "answer": "check",
+                "translation": "이 씨는 토요일 아침 Riverside Hotel에서 체크아웃할 예정이다."
+            },
+            {
+                "question": "Please remember to _______ out at the front desk before leaving for the airport.",
+                "options": [
+                    "check",
+                    "close",
+                    "cover",
+                    "collect"
+                ],
+                "answer": "check",
+                "translation": "공항으로 떠나기 전에 프런트 데스크에서 체크아웃하는 것을 잊지 마세요."
+            }
+        ]
+    },
+    {
+        "id": 106,
+        "expression": "log in to",
+        "meaning": "로그인하다",
+        "options": [
+            "log",
+            "lock",
+            "look",
+            "line"
+        ],
+        "question": "Employees must _______ in to the HR portal to update their contact information.",
+        "answer": "log",
+        "translation": "직원들은 연락처 정보를 수정하려면 인사 포털에 로그인해야 한다.",
+        "quizzes": [
+            {
+                "question": "Employees must _______ in to the HR portal to update their contact information.",
+                "options": [
+                    "log",
+                    "lock",
+                    "look",
+                    "line"
+                ],
+                "answer": "log",
+                "translation": "직원들은 연락처 정보를 수정하려면 인사 포털에 로그인해야 한다."
+            },
+            {
+                "question": "Please _______ in to your account before downloading the invoice.",
+                "options": [
+                    "log",
+                    "lift",
+                    "list",
+                    "load"
+                ],
+                "answer": "log",
+                "translation": "청구서를 다운로드하기 전에 계정에 로그인해 주세요."
+            },
+            {
+                "question": "Customers who cannot _______ in to the payment system should reset their passwords first.",
+                "options": [
+                    "log",
+                    "leave",
+                    "lead",
+                    "launch"
+                ],
+                "answer": "log",
+                "translation": "결제 시스템에 로그인할 수 없는 고객은 먼저 비밀번호를 재설정해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 107,
+        "expression": "hand in",
+        "meaning": "제출하다; 반납하다",
+        "options": [
+            "hand",
+            "hang",
+            "head",
+            "hold"
+        ],
+        "question": "Please _______ in your visitor badge before leaving the building.",
+        "answer": "hand",
+        "translation": "건물을 떠나기 전에 방문증을 반납해 주세요.",
+        "quizzes": [
+            {
+                "question": "Please _______ in your visitor badge before leaving the building.",
+                "options": [
+                    "hand",
+                    "hang",
+                    "head",
+                    "hold"
+                ],
+                "answer": "hand",
+                "translation": "건물을 떠나기 전에 방문증을 반납해 주세요."
+            },
+            {
+                "question": "All applicants must _______ in their writing samples with the completed application form.",
+                "options": [
+                    "hand",
+                    "hire",
+                    "hide",
+                    "heat"
+                ],
+                "answer": "hand",
+                "translation": "모든 지원자는 작성된 지원서와 함께 작문 샘플을 제출해야 한다."
+            },
+            {
+                "question": "Team leaders were asked to _______ in the weekly sales reports by 5:00 p.m.",
+                "options": [
+                    "hand",
+                    "hunt",
+                    "highlight",
+                    "host"
+                ],
+                "answer": "hand",
+                "translation": "팀장들은 오후 5시까지 주간 판매 보고서를 제출하라는 요청을 받았다."
+            }
+        ]
+    },
+    {
+        "id": 108,
+        "expression": "hand out",
+        "meaning": "배부하다; 나눠주다",
+        "options": [
+            "hand",
+            "hang",
+            "hear",
+            "hide"
+        ],
+        "question": "Volunteers will _______ out name tags at the registration table.",
+        "answer": "hand",
+        "translation": "자원봉사자들이 등록 테이블에서 명찰을 나눠 줄 것이다.",
+        "quizzes": [
+            {
+                "question": "Volunteers will _______ out name tags at the registration table.",
+                "options": [
+                    "hand",
+                    "hang",
+                    "hear",
+                    "hide"
+                ],
+                "answer": "hand",
+                "translation": "자원봉사자들이 등록 테이블에서 명찰을 나눠 줄 것이다."
+            },
+            {
+                "question": "The instructor began to _______ out course packets before the orientation started.",
+                "options": [
+                    "hand",
+                    "hold",
+                    "heat",
+                    "help"
+                ],
+                "answer": "hand",
+                "translation": "강사는 오리엔테이션이 시작되기 전에 수업 자료를 배부하기 시작했다."
+            },
+            {
+                "question": "Please do not _______ out the discount vouchers until the store opens.",
+                "options": [
+                    "hand",
+                    "have",
+                    "hire",
+                    "hint"
+                ],
+                "answer": "hand",
+                "translation": "매장이 열리기 전까지 할인 쿠폰을 배부하지 마세요."
+            }
+        ]
+    },
+    {
+        "id": 109,
+        "expression": "look over",
+        "meaning": "검토하다; 훑어보다",
+        "options": [
+            "look",
+            "leave",
+            "link",
+            "lift"
+        ],
+        "question": "Could you _______ over the draft proposal before I send it to the client?",
+        "answer": "look",
+        "translation": "그 제안서를 고객에게 보내기 전에 초안을 검토해 주시겠어요?",
+        "quizzes": [
+            {
+                "question": "Could you _______ over the draft proposal before I send it to the client?",
+                "options": [
+                    "look",
+                    "leave",
+                    "link",
+                    "lift"
+                ],
+                "answer": "look",
+                "translation": "그 제안서를 고객에게 보내기 전에 초안을 검토해 주시겠어요."
+            },
+            {
+                "question": "The attorney will _______ over the revised contract this afternoon.",
+                "options": [
+                    "look",
+                    "lock",
+                    "launch",
+                    "lower"
+                ],
+                "answer": "look",
+                "translation": "변호사가 오늘 오후 수정된 계약서를 검토할 것이다."
+            },
+            {
+                "question": "Please _______ over these figures once more to make sure there are no errors.",
+                "options": [
+                    "look",
+                    "lean",
+                    "label",
+                    "list"
+                ],
+                "answer": "look",
+                "translation": "오류가 없는지 확인하기 위해 이 수치를 한 번 더 검토해 주세요."
+            }
+        ]
+    },
+    {
+        "id": 110,
+        "expression": "send out",
+        "meaning": "발송하다; 보내다",
+        "options": [
+            "send",
+            "set",
+            "show",
+            "shut"
+        ],
+        "question": "The company will _______ out renewal notices two weeks before each contract expires.",
+        "answer": "send",
+        "translation": "회사는 각 계약이 만료되기 2주 전에 갱신 안내문을 발송할 것이다.",
+        "quizzes": [
+            {
+                "question": "The company will _______ out renewal notices two weeks before each contract expires.",
+                "options": [
+                    "send",
+                    "set",
+                    "show",
+                    "shut"
+                ],
+                "answer": "send",
+                "translation": "회사는 각 계약이 만료되기 2주 전에 갱신 안내문을 발송할 것이다."
+            },
+            {
+                "question": "Please _______ out the updated schedule to all department heads.",
+                "options": [
+                    "send",
+                    "seek",
+                    "sell",
+                    "save"
+                ],
+                "answer": "send",
+                "translation": "업데이트된 일정을 모든 부서장에게 보내 주세요."
+            },
+            {
+                "question": "Marketing plans to _______ out a product announcement later this week.",
+                "options": [
+                    "send",
+                    "spin",
+                    "spill",
+                    "solve"
+                ],
+                "answer": "send",
+                "translation": "마케팅팀은 이번 주 후반에 제품 발표 공지를 발송할 계획이다."
+            }
+        ]
+    },
+    {
+        "id": 111,
+        "expression": "shut down",
+        "meaning": "폐쇄하다; 가동을 중단하다",
+        "options": [
+            "shut",
+            "show",
+            "settle",
+            "shape"
+        ],
+        "question": "The payment system will _______ down temporarily for maintenance at midnight.",
+        "answer": "shut",
+        "translation": "결제 시스템은 자정에 유지보수를 위해 일시적으로 중단될 것이다.",
+        "quizzes": [
+            {
+                "question": "The payment system will _______ down temporarily for maintenance at midnight.",
+                "options": [
+                    "shut",
+                    "show",
+                    "settle",
+                    "shape"
+                ],
+                "answer": "shut",
+                "translation": "결제 시스템은 자정에 유지보수를 위해 일시적으로 중단될 것이다."
+            },
+            {
+                "question": "Management decided to _______ down the old warehouse after the lease expired.",
+                "options": [
+                    "shut",
+                    "shake",
+                    "share",
+                    "shine"
+                ],
+                "answer": "shut",
+                "translation": "경영진은 임대 계약이 만료된 후 오래된 창고를 폐쇄하기로 결정했다."
+            },
+            {
+                "question": "Please save your work before we _______ down the server for upgrades.",
+                "options": [
+                    "shut",
+                    "shift",
+                    "shop",
+                    "scan"
+                ],
+                "answer": "shut",
+                "translation": "업그레이드를 위해 서버를 중단하기 전에 작업 내용을 저장해 주세요."
+            }
+        ]
+    },
+    {
+        "id": 112,
+        "expression": "back up",
+        "meaning": "백업하다; 지원하다",
+        "options": [
+            "back",
+            "bring",
+            "book",
+            "bump"
+        ],
+        "question": "Please _______ up all project files to the cloud at the end of each day.",
+        "answer": "back",
+        "translation": "매일 업무 종료 시 모든 프로젝트 파일을 클라우드에 백업해 주세요.",
+        "quizzes": [
+            {
+                "question": "Please _______ up all project files to the cloud at the end of each day.",
+                "options": [
+                    "back",
+                    "bring",
+                    "book",
+                    "bump"
+                ],
+                "answer": "back",
+                "translation": "매일 업무 종료 시 모든 프로젝트 파일을 클라우드에 백업해 주세요."
+            },
+            {
+                "question": "The IT team will _______ up the customer database before installing the new software patch.",
+                "options": [
+                    "back",
+                    "boil",
+                    "borrow",
+                    "brush"
+                ],
+                "answer": "back",
+                "translation": "IT 팀은 새 소프트웨어 패치를 설치하기 전에 고객 데이터베이스를 백업할 것이다."
+            },
+            {
+                "question": "We always _______ up the accounting records before performing system maintenance.",
+                "options": [
+                    "back",
+                    "box",
+                    "balance",
+                    "block"
+                ],
+                "answer": "back",
+                "translation": "우리는 시스템 점검 전에 항상 회계 기록을 백업한다."
+            }
+        ]
+    },
+    {
+        "id": 113,
+        "expression": "take part in",
+        "meaning": "참여하다",
+        "options": [
+            "take",
+            "turn",
+            "throw",
+            "trade"
+        ],
+        "question": "More than 200 employees will _______ part in this year’s charity run.",
+        "answer": "take",
+        "translation": "200명 이상의 직원이 올해 자선 달리기에 참여할 것이다.",
+        "quizzes": [
+            {
+                "question": "More than 200 employees will _______ part in this year’s charity run.",
+                "options": [
+                    "take",
+                    "turn",
+                    "throw",
+                    "trade"
+                ],
+                "answer": "take",
+                "translation": "200명 이상의 직원이 올해 자선 달리기에 참여할 것이다."
+            },
+            {
+                "question": "Staff members are encouraged to _______ part in the voluntary mentoring program.",
+                "options": [
+                    "take",
+                    "talk",
+                    "trace",
+                    "tear"
+                ],
+                "answer": "take",
+                "translation": "직원들은 자발적 멘토링 프로그램에 참여하도록 권장된다."
+            },
+            {
+                "question": "Only registered visitors may _______ part in the guided factory tour.",
+                "options": [
+                    "take",
+                    "treat",
+                    "track",
+                    "transfer"
+                ],
+                "answer": "take",
+                "translation": "등록된 방문객만 가이드 공장 투어에 참여할 수 있다."
+            }
+        ]
+    },
+    {
+        "id": 114,
+        "expression": "report to",
+        "meaning": "~에게 보고하다; ~의 지휘를 받다",
+        "options": [
+            "report",
+            "reply",
+            "refer",
+            "return"
+        ],
+        "question": "New interns will _______ to the operations manager on their first day.",
+        "answer": "report",
+        "translation": "신입 인턴들은 첫날 운영 관리자에게 보고하게 된다.",
+        "quizzes": [
+            {
+                "question": "New interns will _______ to the operations manager on their first day.",
+                "options": [
+                    "report",
+                    "reply",
+                    "refer",
+                    "return"
+                ],
+                "answer": "report",
+                "translation": "신입 인턴들은 첫날 운영 관리자에게 보고하게 된다."
+            },
+            {
+                "question": "Employees at the branch office still _______ to the regional director.",
+                "options": [
+                    "report",
+                    "rest",
+                    "roll",
+                    "race"
+                ],
+                "answer": "report",
+                "translation": "지점 사무소 직원들도 여전히 지역 책임자에게 보고한다."
+            },
+            {
+                "question": "Any safety incident should be _______ to a supervisor immediately.",
+                "options": [
+                    "reported",
+                    "repeated",
+                    "reduced",
+                    "replaced"
+                ],
+                "answer": "reported",
+                "translation": "모든 안전 사고는 즉시 관리자에게 보고되어야 한다."
+            }
+        ]
+    },
+    {
+        "id": 115,
+        "expression": "go ahead with",
+        "meaning": "진행하다; 계속하다",
+        "options": [
+            "go",
+            "get",
+            "give",
+            "grow"
+        ],
+        "question": "The company decided to _______ ahead with the software upgrade after the final review.",
+        "answer": "go",
+        "translation": "회사는 최종 검토 후 소프트웨어 업그레이드를 진행하기로 결정했다.",
+        "quizzes": [
+            {
+                "question": "The company decided to _______ ahead with the software upgrade after the final review.",
+                "options": [
+                    "go",
+                    "get",
+                    "give",
+                    "grow"
+                ],
+                "answer": "go",
+                "translation": "회사는 최종 검토 후 소프트웨어 업그레이드를 진행하기로 결정했다."
+            },
+            {
+                "question": "Please do not _______ ahead with the printing order until the client approves the design.",
+                "options": [
+                    "go",
+                    "grab",
+                    "glance",
+                    "guard"
+                ],
+                "answer": "go",
+                "translation": "고객이 디자인을 승인할 때까지 인쇄 주문을 진행하지 마세요."
+            },
+            {
+                "question": "Management chose to _______ ahead with the branch opening despite the weather forecast.",
+                "options": [
+                    "go",
+                    "gain",
+                    "guide",
+                    "group"
+                ],
+                "answer": "go",
+                "translation": "경영진은 일기 예보에도 불구하고 지점 개점을 진행하기로 했다."
+            }
+        ]
+    },
+    {
+        "id": 116,
+        "expression": "work on",
+        "meaning": "작업하다; 공들이다",
+        "options": [
+            "work",
+            "wait",
+            "walk",
+            "write"
+        ],
+        "question": "The design team will _______ on the revised packaging layout this afternoon.",
+        "answer": "work",
+        "translation": "디자인 팀은 오늘 오후 수정된 포장 배치 작업을 할 것이다.",
+        "quizzes": [
+            {
+                "question": "The design team will _______ on the revised packaging layout this afternoon.",
+                "options": [
+                    "work",
+                    "wait",
+                    "walk",
+                    "write"
+                ],
+                "answer": "work",
+                "translation": "디자인 팀은 오늘 오후 수정된 포장 배치 작업을 할 것이다."
+            },
+            {
+                "question": "Our technicians are currently _______ing on the air-conditioning system in Conference Room B.",
+                "options": [
+                    "working",
+                    "waiting",
+                    "walking",
+                    "writing"
+                ],
+                "answer": "working",
+                "translation": "우리 기술자들은 현재 B 회의실의 공조 시스템 작업을 하고 있다."
+            },
+            {
+                "question": "She spent the weekend _______ing on a proposal for the new client.",
+                "options": [
+                    "working",
+                    "wearing",
+                    "welcoming",
+                    "wrapping"
+                ],
+                "answer": "working",
+                "translation": "그녀는 주말 내내 신규 고객 제안서를 작업했다."
+            }
+        ]
+    },
+    {
+        "id": 117,
+        "expression": "refer to",
+        "meaning": "언급하다; 참조하다",
+        "options": [
+            "refer",
+            "reply",
+            "relate",
+            "replace"
+        ],
+        "question": "Please _______ to page 6 for details about the revised refund policy.",
+        "answer": "refer",
+        "translation": "수정된 환불 정책에 대한 자세한 내용은 6페이지를 참조해 주세요.",
+        "quizzes": [
+            {
+                "question": "Please _______ to page 6 for details about the revised refund policy.",
+                "options": [
+                    "refer",
+                    "reply",
+                    "relate",
+                    "replace"
+                ],
+                "answer": "refer",
+                "translation": "수정된 환불 정책에 대한 자세한 내용은 6페이지를 참조해 주세요."
+            },
+            {
+                "question": "The memo does not _______ to the warehouse expansion project.",
+                "options": [
+                    "refer",
+                    "remove",
+                    "record",
+                    "receive"
+                ],
+                "answer": "refer",
+                "translation": "그 메모는 창고 확장 프로젝트를 언급하지 않는다."
+            },
+            {
+                "question": "When answering customers’ questions, staff should _______ to the online help guide first.",
+                "options": [
+                    "refer",
+                    "reduce",
+                    "reverse",
+                    "rescue"
+                ],
+                "answer": "refer",
+                "translation": "고객 질문에 답할 때 직원들은 먼저 온라인 도움말 가이드를 참조해야 한다."
+            }
+        ]
+    },
+    {
+        "id": 118,
+        "expression": "pay for",
+        "meaning": "비용을 지불하다",
+        "options": [
+            "pay",
+            "pass",
+            "pack",
+            "plan"
+        ],
+        "question": "The company will _______ for your taxi fare if the meeting ends after 10:00 p.m.",
+        "answer": "pay",
+        "translation": "회의가 오후 10시 이후에 끝나면 회사가 택시 요금을 지불할 것이다.",
+        "quizzes": [
+            {
+                "question": "The company will _______ for your taxi fare if the meeting ends after 10:00 p.m.",
+                "options": [
+                    "pay",
+                    "pass",
+                    "pack",
+                    "plan"
+                ],
+                "answer": "pay",
+                "translation": "회의가 오후 10시 이후에 끝나면 회사가 택시 요금을 지불할 것이다."
+            },
+            {
+                "question": "Customers can _______ for their subscriptions by credit card or bank transfer.",
+                "options": [
+                    "pay",
+                    "point",
+                    "print",
+                    "push"
+                ],
+                "answer": "pay",
+                "translation": "고객은 신용카드나 은행 송금으로 구독료를 지불할 수 있다."
+            },
+            {
+                "question": "Who will _______ for the replacement parts if the warranty has expired?",
+                "options": [
+                    "pay",
+                    "pull",
+                    "pour",
+                    "pose"
+                ],
+                "answer": "pay",
+                "translation": "보증 기간이 만료되었다면 누가 교체 부품 비용을 지불하나요?"
+            }
+        ]
+    },
+    {
+        "id": 119,
+        "expression": "lead to",
+        "meaning": "~로 이어지다; 초래하다",
+        "options": [
+            "lead",
+            "lift",
+            "leave",
+            "lend"
+        ],
+        "question": "Poor packaging can _______ to product damage during transit.",
+        "answer": "lead",
+        "translation": "포장이 불량하면 운송 중 제품 손상으로 이어질 수 있다.",
+        "quizzes": [
+            {
+                "question": "Poor packaging can _______ to product damage during transit.",
+                "options": [
+                    "lead",
+                    "lift",
+                    "leave",
+                    "lend"
+                ],
+                "answer": "lead",
+                "translation": "포장이 불량하면 운송 중 제품 손상으로 이어질 수 있다."
+            },
+            {
+                "question": "Even a small data-entry error may _______ to delays in processing customer orders.",
+                "options": [
+                    "lead",
+                    "label",
+                    "list",
+                    "launch"
+                ],
+                "answer": "lead",
+                "translation": "사소한 데이터 입력 오류도 고객 주문 처리 지연으로 이어질 수 있다."
+            },
+            {
+                "question": "A shortage of raw materials could _______ to higher production costs.",
+                "options": [
+                    "lead",
+                    "lock",
+                    "locate",
+                    "learn"
+                ],
+                "answer": "lead",
+                "translation": "원자재 부족은 더 높은 생산 비용으로 이어질 수 있다."
+            }
+        ]
+    },
+    {
+        "id": 120,
+        "expression": "point out",
+        "meaning": "지적하다; 알려 주다",
+        "options": [
+            "point",
+            "pull",
+            "put",
+            "press"
+        ],
+        "question": "The auditor was quick to _______ out several inconsistencies in the report.",
+        "answer": "point",
+        "translation": "감사 담당자는 보고서의 몇 가지 불일치를 재빨리 지적했다.",
+        "quizzes": [
+            {
+                "question": "The auditor was quick to _______ out several inconsistencies in the report.",
+                "options": [
+                    "point",
+                    "pull",
+                    "put",
+                    "press"
+                ],
+                "answer": "point",
+                "translation": "감사 담당자는 보고서의 몇 가지 불일치를 재빨리 지적했다."
+            },
+            {
+                "question": "Please _______ out the updated deadline to anyone who has not seen the notice.",
+                "options": [
+                    "point",
+                    "pass",
+                    "post",
+                    "park"
+                ],
+                "answer": "point",
+                "translation": "공지사항을 못 본 사람들에게 수정된 마감일을 알려 주세요."
+            },
+            {
+                "question": "Ms. Green pointed _______ that the invoice total did not include the service fee.",
+                "options": [
+                    "out",
+                    "off",
+                    "up",
+                    "over"
+                ],
+                "answer": "out",
+                "translation": "Green 씨는 청구서 총액에 서비스 수수료가 포함되어 있지 않다고 지적했다."
+            }
+        ]
+    }
+
+];

--- a/card/toeic_reserve_data.js
+++ b/card/toeic_reserve_data.js
@@ -427,4 +427,515 @@ Keihin Industrial Group`
       }
     ]
   }
+,
+{
+  "id": 59,
+  "type": "part7",
+  "title": "59강 (Part 7) — Part 7 Multiple Passages (Set 14)",
+  "questions": [
+    {
+      "id": "59-1",
+      "question": "According to the Web page, who may apply for a monthly parking permit?",
+      "options": [
+        "Any employee with a company ID",
+        "Full-time employees who work onsite at least three days per week",
+        "Employees who arrive before 8:00 a.m. each day",
+        "Only employees in Procurement or Facilities"
+      ],
+      "answer": "Full-time employees who work onsite at least three days per week"
+    },
+    {
+      "id": "59-2",
+      "question": "According to the assignment notice, why was Lena Cho assigned to the Overflow Lot for October?",
+      "options": [
+        "She requested the least expensive option",
+        "North Lot permits were reserved for visitors",
+        "East Garage will undergo resurfacing work",
+        "Her application was submitted after the deadline"
+      ],
+      "answer": "East Garage will undergo resurfacing work"
+    },
+    {
+      "id": "59-3",
+      "question": "Why did Lena Cho write to Facilities Support?",
+      "options": [
+        "To cancel her October permit entirely",
+        "To ask about a different arrangement because she works early shifts",
+        "To report that the shuttle stop has been moved",
+        "To request a refund for September parking charges"
+      ],
+      "answer": "To ask about a different arrangement because she works early shifts"
+    },
+    {
+      "id": "59-4",
+      "question": "What is indicated about the Overflow Lot?",
+      "options": [
+        "It is closer to the building than the North Lot",
+        "It can be used at any time with a company ID",
+        "It is served by a shuttle from Stop 2",
+        "It is covered and costs $95 per month"
+      ],
+      "answer": "It is served by a shuttle from Stop 2"
+    },
+    {
+      "id": "59-5",
+      "question": "In the e-mail, the word \"reassigned\" is closest in meaning to",
+      "options": [
+        "moved to a different option",
+        "charged a new fee",
+        "checked in manually",
+        "listed in advance"
+      ],
+      "answer": "moved to a different option"
+    }
+  ],
+  "passage": `Document 1: Web Page
+
+PARKLANE CENTER
+Employee Parking Permit Program — October 2027
+
+Permit Options
+East Garage (covered): $95/month
+North Lot (outdoor): $60/month, approximately a five-minute walk to the main lobby
+Overflow Lot (outdoor): $35/month, available after 8:30 a.m. only. Complimentary Route B shuttle departs from Stop 2 every 12 minutes.
+
+Eligibility
+Full-time employees scheduled onsite at least three days each workweek may apply for a monthly permit.
+
+Application Deadline
+September 20 for October permits
+
+Pickup
+Approved permits may be picked up beginning September 25 at the Security Desk. A photo ID is required.
+
+Notes
+Assignments are based on availability and may be adjusted during maintenance periods.
+
+Document 2: Assignment Notice
+
+PARKLANE CENTER — October Parking Assignment
+Employee: Lena Cho
+Department: Procurement
+Permit type requested: East Garage
+Status: Approved
+Assigned location: Overflow Lot
+Pickup available: September 25, 9:00 a.m.–5:00 p.m. at the Security Desk
+
+Important: Because resurfacing work will take place in East Garage throughout October, employees who requested covered parking have been temporarily assigned to alternate areas. Please display the permit at all times while parked on site.
+
+Document 3: E-mail
+
+Subject: October parking assignment
+From: Lena Cho <lcho@parklane.example>
+To: Facilities Support <facilities@parklane.example>
+Date: September 23, 2027
+
+Hello,
+
+I received my October permit notice and saw that I was assigned to the Overflow Lot. On Mondays and Wednesdays, I arrive before 7:15 a.m. to receive vendor sample deliveries for Procurement. Since the Overflow Lot cannot be used until 8:30 a.m. and the shuttle does not begin running until 8:20, would it be possible to be reassigned to the North Lot or to receive temporary access closer to the building on those early-shift days?
+
+Also, I will be out of town on September 25. May I pick up the permit on September 26 instead?
+
+Thank you,
+Lena Cho`
+},
+{
+  "id": 60,
+  "type": "part7",
+  "title": "60강 (Part 7) — Part 7 Multiple Passages (Set 15)",
+  "questions": [
+    {
+      "id": "60-1",
+      "question": "According to the Web page, what is required for same-day pickup?",
+      "options": [
+        "A request entered by 11:30 a.m. on a business day",
+        "A Premium account and prepaid label",
+        "At least three packages to the same destination",
+        "A phone confirmation from customer service"
+      ],
+      "answer": "A request entered by 11:30 a.m. on a business day"
+    },
+    {
+      "id": "60-2",
+      "question": "According to the pickup confirmation, what must be given to the driver?",
+      "options": [
+        "A packing list and proof of insurance",
+        "Three signed commercial invoices",
+        "A blank return label",
+        "Two photo IDs"
+      ],
+      "answer": "Three signed commercial invoices"
+    },
+    {
+      "id": "60-3",
+      "question": "Why did Nari Kim write to Ben Walsh?",
+      "options": [
+        "To ask him to prepare the shipment materials before the courier arrives",
+        "To tell him the pickup had been postponed until the next day",
+        "To confirm that the label printer has been repaired",
+        "To ask him to change the destination address"
+      ],
+      "answer": "To ask him to prepare the shipment materials before the courier arrives"
+    },
+    {
+      "id": "60-4",
+      "question": "What is suggested about BrightArc Interiors?",
+      "options": [
+        "It requested paperless customs processing",
+        "It has a Premium account with SwiftLane Courier",
+        "It will provide its own shipping label",
+        "It scheduled the pickup after the cutoff time"
+      ],
+      "answer": "It will provide its own shipping label"
+    },
+    {
+      "id": "60-5",
+      "question": "In Document 2, the word \"window\" is closest in meaning to",
+      "options": [
+        "container",
+        "time period",
+        "office counter",
+        "glass opening"
+      ],
+      "answer": "time period"
+    }
+  ],
+  "passage": `Document 1: Web Page
+
+SWIFTLANE COURIER
+Business Pickup Services
+
+Same-day pickup is available Monday through Friday for requests entered by 11:30 a.m.
+
+All pickups are scheduled in two-hour windows.
+
+International shipments require three copies of a signed commercial invoice unless the Paperless Customs option is selected.
+
+Label printing at pickup is available only for Premium account holders.
+
+If the pickup address is changed after confirmation, an $8 service fee applies.
+
+Temperature-sensitive items are not accepted through standard pickup.
+
+Document 2: Pickup Confirmation
+
+SWIFTLANE COURIER — Pickup Confirmation
+Shipment No.: SW-77421
+Account: BrightArc Interiors
+Pickup date: Thursday, November 4, 2027
+Pickup window: 2:00–4:00 p.m.
+Service: International Express
+Destination: Auckland, New Zealand
+Packages: 1 carton / 4.2 kg
+Label status: Customer printed
+Paperless customs option: No
+Driver instructions: Collect 3 signed commercial invoices at pickup
+
+Document 3: E-mail
+
+Subject: This afternoon’s courier pickup
+From: Nari Kim <nkim@brightarc.example>
+To: Ben Walsh <bwalsh@brightarc.example>
+Date: November 4, 2027
+
+Hi Ben,
+
+Could you leave the finish-sample box at reception by 1:45 this afternoon? I scheduled the Auckland shipment for the 2:00–4:00 p.m. pickup window.
+
+I attached the shipping label because our SwiftLane account does not include driver label printing. Also, since I did not select the paperless customs option, please place the three signed commercial invoices in the clear pouch on the carton before the driver arrives.
+
+If the courier comes while I’m still in the client call, reception can release the package using shipment number SW-77421.
+
+Thanks,
+Nari`
+},
+{
+  "id": 61,
+  "type": "part6",
+  "title": "61강 (Part 6) — 복리후생 등록 마감 안내 이메일 (지문 1개 + 4문항)",
+  "questions": [
+    {
+      "id": "61-1",
+      "question": "Select the best answer for blank (1).",
+      "options": [
+        "change",
+        "changes",
+        "changed",
+        "changing"
+      ],
+      "answer": "change"
+    },
+    {
+      "id": "61-2",
+      "question": "Select the best answer for blank (2).",
+      "options": [
+        "unless",
+        "so that",
+        "although",
+        "whereas"
+      ],
+      "answer": "so that"
+    },
+    {
+      "id": "61-3",
+      "question": "Select the best answer for blank (3).",
+      "options": [
+        "event",
+        "events",
+        "eventual",
+        "even"
+      ],
+      "answer": "event"
+    },
+    {
+      "id": "61-4",
+      "question": "Sentence Insertion \n \nIn which of the positions marked [1], [2], [3], and [4] does the following sentence best belong? \n \nSentence: Paper enrollment forms will not be accepted this year.",
+      "options": [
+        "[1]",
+        "[2]",
+        "[3]",
+        "[4]"
+      ],
+      "answer": "[1]"
+    }
+  ],
+  "passage": `Directions: Read the text below and choose the best answer for each blank.
+
+Subject: Reminder: Benefits Enrollment Deadline
+
+Dear Employees,
+
+Annual open enrollment for medical and dental coverage will close at 5:00 p.m. on Friday, November 13. All benefit selections must be submitted through the HR portal by that time. [1]
+
+If you wish to add or remove dependents, please upload the required supporting documents, such as birth certificates or proof of residence, before completing your selections. Elections submitted without proper documentation may be delayed or returned for correction. [2]
+
+Even if you plan to keep your current coverage, you should still review the plan summaries carefully, as several monthly premium rates will (1) _______ effective January 1. [3]
+
+If you are unable to access the portal, contact Human Resources as soon as possible (2) _______ we can help you complete the process before the deadline. [4] Employees who miss the enrollment period may be able to make changes later only after a qualifying (3) _______.`
+},
+{
+  "id": 62,
+  "type": "part6",
+  "title": "62강 (Part 6) — 재고 실사 일정 및 작업 지시 메모 (지문 1개 + 4문항)",
+  "questions": [
+    {
+      "id": "62-1",
+      "question": "Select the best answer for blank (1).",
+      "options": [
+        "operate",
+        "operation",
+        "operator",
+        "operating"
+      ],
+      "answer": "operate"
+    },
+    {
+      "id": "62-2",
+      "question": "Select the best answer for blank (2).",
+      "options": [
+        "at",
+        "by",
+        "for",
+        "until"
+      ],
+      "answer": "by"
+    },
+    {
+      "id": "62-3",
+      "question": "Select the best answer for blank (3).",
+      "options": [
+        "prepare",
+        "prepared",
+        "preparation",
+        "preparations"
+      ],
+      "answer": "preparations"
+    },
+    {
+      "id": "62-4",
+      "question": "Sentence Insertion \n \nIn which of the positions marked [1], [2], [3], and [4] does the following sentence best belong? \n \nSentence: Scanners that are not working properly should be exchanged at the equipment desk before counting begins.",
+      "options": [
+        "[1]",
+        "[2]",
+        "[3]",
+        "[4]"
+      ],
+      "answer": "[2]"
+    }
+  ],
+  "passage": `Directions: Read the text below and choose the best answer for each blank.
+
+Subject: Instructions for Saturday Inventory Count
+
+Dear Warehouse Team,
+
+The quarterly inventory count for Building C will take place on Saturday, December 5, from 7:00 a.m. to 1:00 p.m. During that time, no outgoing shipments will be processed from the facility. [1]
+
+Team supervisors will distribute zone assignments on Thursday afternoon. Please review your section before arriving, and report any missing shelf labels to Operations by Friday at noon. [2]
+
+To reduce errors, each item must be scanned twice, and any quantity differences should be recorded on the variance sheet immediately. Temporary staff will assist with pallet movement, but only certified forklift operators may (1) _______ equipment in the loading area. [3]
+
+After the count is complete, supervisors will compare the results with the inventory system and submit a summary (2) _______ 3:00 p.m. Monday. [4] Employees scheduled to work that day will receive overtime pay according to company policy. If you need special protective gear, contact the Safety Office so the necessary (3) _______ can be made in advance.`
+},
+{
+  "id": 63,
+  "type": "part5",
+  "title": "63강 (Part 5) — 시간/조건 부사절의 시제 (3문항)",
+  "questions": [
+    {
+      "id": "63-1",
+      "question": "By the time the inspectors arrive, the maintenance team ______ the safety barriers around the work area.",
+      "options": [
+        "will install",
+        "installed",
+        "has installed",
+        "will have installed"
+      ],
+      "answer": "will have installed"
+    },
+    {
+      "id": "63-2",
+      "question": "Please keep the samples refrigerated until the courier ______ them up this afternoon.",
+      "options": [
+        "picks",
+        "will pick",
+        "picked",
+        "is picking"
+      ],
+      "answer": "picks"
+    },
+    {
+      "id": "63-3",
+      "question": "Once the budget revision ______ by the director, Finance will issue the updated figures to all departments.",
+      "options": [
+        "is approved",
+        "approved",
+        "approves",
+        "will approve"
+      ],
+      "answer": "is approved"
+    }
+  ]
+},
+{
+  "id": 64,
+  "type": "part5",
+  "title": "64강 (Part 5) — 동사 문형/동사 패턴 (3문항)",
+  "questions": [
+    {
+      "id": "64-1",
+      "question": "The new expense portal allows employees ______ receipts directly from their phones.",
+      "options": [
+        "to upload",
+        "uploading",
+        "upload",
+        "uploaded"
+      ],
+      "answer": "to upload"
+    },
+    {
+      "id": "64-2",
+      "question": "Our legal team advised the supplier ______ the wording in Section 4 before signing the contract.",
+      "options": [
+        "revise",
+        "to revise",
+        "revising",
+        "revised"
+      ],
+      "answer": "to revise"
+    },
+    {
+      "id": "64-3",
+      "question": "The delay prevented the technicians from ______ the network test before noon.",
+      "options": [
+        "completing",
+        "complete",
+        "completed",
+        "to complete"
+      ],
+      "answer": "completing"
+    }
+  ]
+},
+{
+  "id": 65,
+  "type": "part5",
+  "title": "65강 (Part 5) — 출장/배송/예약 실무 어휘 (3문항)",
+  "questions": [
+    {
+      "id": "65-1",
+      "question": "The hotel agreed to waive the late check-out ______ because the flight had been canceled.",
+      "options": [
+        "fee",
+        "fare",
+        "price",
+        "salary"
+      ],
+      "answer": "fee"
+    },
+    {
+      "id": "65-2",
+      "question": "Customers can track the status of each ______ by entering the reference number online.",
+      "options": [
+        "shipment",
+        "payroll",
+        "brochure",
+        "warranty"
+      ],
+      "answer": "shipment"
+    },
+    {
+      "id": "65-3",
+      "question": "Please review the attached ______ for tomorrow’s client visit and notify me of any scheduling conflicts.",
+      "options": [
+        "itinerary",
+        "contract",
+        "résumé",
+        "inventory"
+      ],
+      "answer": "itinerary"
+    }
+  ]
+},
+{
+  "id": 66,
+  "type": "part5",
+  "title": "66강 (Part 5) — 실무 콜로케이션/복합명사 (3문항)",
+  "questions": [
+    {
+      "id": "66-1",
+      "question": "All visitors must check in at the security ______ before entering the laboratory wing.",
+      "options": [
+        "desk",
+        "label",
+        "batch",
+        "item"
+      ],
+      "answer": "desk"
+    },
+    {
+      "id": "66-2",
+      "question": "The marketing team asked for advance ______ before any changes were made to the promotional schedule.",
+      "options": [
+        "notice",
+        "notify",
+        "notification",
+        "notifying"
+      ],
+      "answer": "notice"
+    },
+    {
+      "id": "66-3",
+      "question": "The replacement parts are still pending manager ______, so the repair cannot begin yet.",
+      "options": [
+        "approval",
+        "approve",
+        "approved",
+        "approving"
+      ],
+      "answer": "approval"
+    }
+  ]
+}
+
 ];


### PR DESCRIPTION
Added 20 new collocation items (IDs 101-120) into a new `card/collocation_reserve_data.js` file to prepare for future migration. Also appended 8 new TOEIC practice sets (IDs 59-66) to the existing `card/toeic_reserve_data.js`.

---
*PR created automatically by Jules for task [15239460927146539758](https://jules.google.com/task/15239460927146539758) started by @romarin0325-cell*