### PR TITLE
fix(card): restore deterministic mobile boot order

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1528,60 +1528,77 @@
 
     <script>
         window._scriptLoadErrors = [];
-        // Sequential script loader — loads one file at a time for mobile file:// reliability
+        window._scriptRuntimeErrors = [];
+        window._bootRuntimeTrackingEnabled = true;
+
+        function getBootScriptName(filename) {
+            if (!filename) return '';
+            var normalized = String(filename).split('?')[0].replace(/\\/g, '/');
+            return normalized.slice(normalized.lastIndexOf('/') + 1);
+        }
+
+        window.addEventListener('error', function (event) {
+            if (!window._bootRuntimeTrackingEnabled) return;
+            var scriptName = getBootScriptName(event && event.filename);
+            if (!scriptName) return;
+
+            var knownScripts = ['rpg_config.js', 'rpg_flow_modules.js'];
+            if (window.RPGConfig && Array.isArray(window.RPGConfig.BOOT_MODULES)) {
+                window.RPGConfig.BOOT_MODULES.forEach(function (moduleInfo) {
+                    if (moduleInfo && moduleInfo.src) knownScripts.push(moduleInfo.src);
+                });
+            }
+            if (knownScripts.indexOf(scriptName) === -1) return;
+
+            var message = scriptName + ': ' + (event.message || 'Unknown error');
+            if (window._scriptRuntimeErrors.indexOf(message) === -1) {
+                window._scriptRuntimeErrors.push(message);
+            }
+        }, true);
+    </script>
+    <script src="rpg_config.js" charset="utf-8" onerror="window._scriptLoadErrors.push('rpg_config.js')"></script>
+    <script src="rpg_flow_modules.js" charset="utf-8" onerror="window._scriptLoadErrors.push('rpg_flow_modules.js')"></script>
+    <script>
+        // Sequential script loader for mobile file:// reliability
         (function () {
-            var bootstrapScripts = [
-                { src: 'rpg_config.js', label: 'RPG Config' }
-            ];
-            var bootModulesLoaded = false;
+            var scripts = (window.RPGConfig && Array.isArray(window.RPGConfig.BOOT_MODULES))
+                ? window.RPGConfig.BOOT_MODULES
+                : [];
             var idx = 0;
 
-            function getScripts() {
-                if (bootModulesLoaded && typeof RPGConfig !== 'undefined' && Array.isArray(RPGConfig.BOOT_MODULES)) {
-                    return bootstrapScripts.concat(RPGConfig.BOOT_MODULES);
-                }
-                return bootstrapScripts;
-            }
-
             function loadNext() {
-                var scripts = getScripts();
                 if (idx >= scripts.length) return;
                 var info = scripts[idx];
                 var el = document.createElement('script');
                 el.src = info.src;
+                el.charset = 'utf-8';
+                el.async = false;
 
                 el.onload = function () {
-                    if (info.src === 'rpg_config.js') {
-                        bootModulesLoaded = true;
-                    }
                     idx++;
                     updateProgress();
-                    // 🚀 핵심 수정: 모바일 기기의 파일 I/O 및 메모리 정리를 위해 100ms 대기 후 다음 파일 로드
                     setTimeout(loadNext, 100);
                 };
 
                 el.onerror = function () {
                     window._scriptLoadErrors.push(info.src);
-                    if (info.src === 'rpg_config.js') {
-                        bootModulesLoaded = true;
-                    }
                     idx++;
                     updateProgress();
-                    // 에러 발생 시에도 기기가 쉴 수 있게 대기 시간 부여
                     setTimeout(loadNext, 100);
                 };
 
-                // head보다는 body에 추가하는 것이 모바일 웹뷰 메모리 처리에 더 안정적입니다.
                 document.body.appendChild(el);
             }
 
             function updateProgress() {
+                if ((window._scriptLoadErrors && window._scriptLoadErrors.length > 0)
+                    || (window._scriptRuntimeErrors && window._scriptRuntimeErrors.length > 0)) {
+                    return;
+                }
                 var el = document.getElementById('title-loading');
-                var scripts = getScripts();
-                if (el) el.innerText = '⏳ 데이터 로딩 중 (' + idx + '/' + scripts.length + ')... 잠시만 기다려주세요.';
+                if (el) el.innerText = '\u23f3 \ub370\uc774\ud130 \ub85c\ub529 \uc911 (' + idx + '/' + scripts.length + ')... \uc7a0\uc2dc\ub9cc \uae30\ub2e4\ub824\uc8fc\uc138\uc694.';
             }
 
-            // 첫 스크립트 로드 시작 전에도 DOM이 안정화될 시간을 약간 줍니다.
             setTimeout(loadNext, 50);
         })();
     </script>
@@ -2548,6 +2565,7 @@
             getMissingRequiredData() {
                 const requiredData = [
                     { name: 'RPGConfig', ref: typeof RPGConfig !== 'undefined' ? RPGConfig : null },
+                    { name: 'RPGFlowModules', ref: typeof RPGFlowModules !== 'undefined' ? RPGFlowModules : null },
                     { name: 'QuizEngine', ref: typeof QuizEngine !== 'undefined' ? QuizEngine : null }
                 ];
                 this.getBootModules().forEach(moduleInfo => {
@@ -2574,6 +2592,7 @@
                 const loading = document.getElementById('title-loading');
                 if (loading) {
                     if (enabled) {
+                        window._bootRuntimeTrackingEnabled = false;
                         loading.innerText = '⏳ 데이터 로딩 중... 잠시만 기다려주세요.';
                         loading.classList.add('hidden');
                     } else {
@@ -2600,6 +2619,14 @@
                         return;
                     }
 
+                    if (window._scriptRuntimeErrors && window._scriptRuntimeErrors.length > 0) {
+                        const loading = document.getElementById('title-loading');
+                        if (loading) {
+                            loading.innerHTML = `⚠️ 스크립트 실행 오류: ${window._scriptRuntimeErrors.join('<br>')}<br><span style="font-size:0.8rem; color:#aaa;">스크립트 파일은 읽혔지만 실행 중 오류가 발생했습니다.</span><br><button onclick="location.reload()" style="margin-top:8px; padding:8px 16px; border-radius:4px; border:1px solid #ff5252; background:#b71c1c; color:#fff; cursor:pointer; font-size:0.9rem;">새로고침</button>`;
+                        }
+                        return;
+                    }
+
                     const missing = this.getMissingRequiredData();
                     if (missing.length === 0) {
                         this.hydrateModules();
@@ -2613,7 +2640,9 @@
                         if (loading) {
                             const errorInfo = window._scriptLoadErrors && window._scriptLoadErrors.length > 0
                                 ? `<br>로드 실패 파일: ${window._scriptLoadErrors.join(', ')}` : '';
-                            loading.innerHTML = `⚠️ 로딩 시간 초과: ${missing.map(d => d.name).join(', ')}${errorInfo}<br><span style="font-size:0.8rem; color:#aaa;">모든 .js 파일이 index.html과 같은 폴더에 있는지 확인해주세요.</span><br><button onclick="location.reload()" style="margin-top:8px; padding:8px 16px; border-radius:4px; border:1px solid #ff5252; background:#b71c1c; color:#fff; cursor:pointer; font-size:0.9rem;">새로고침</button>`;
+                            const runtimeInfo = window._scriptRuntimeErrors && window._scriptRuntimeErrors.length > 0
+                                ? `<br>실행 오류: ${window._scriptRuntimeErrors.join('<br>')}` : '';
+                            loading.innerHTML = `⚠️ 로딩 시간 초과: ${missing.map(d => d.name).join(', ')}${errorInfo}${runtimeInfo}<br><span style="font-size:0.8rem; color:#aaa;">모든 .js 파일이 index.html과 같은 폴더에 있는지 확인해주세요.</span><br><button onclick="location.reload()" style="margin-top:8px; padding:8px 16px; border-radius:4px; border:1px solid #ff5252; background:#b71c1c; color:#fff; cursor:pointer; font-size:0.9rem;">새로고침</button>`;
                         }
                         return;
                     }

--- a/card/rpg_config.js
+++ b/card/rpg_config.js
@@ -222,11 +222,6 @@
             src: 'rpg_features.js',
             label: 'RPG Feature Modules',
             requiredGlobal: ['RPGFeatureModules']
-        },
-        {
-            src: 'rpg_flow_modules.js',
-            label: 'RPG Flow Modules',
-            requiredGlobal: ['RPGFlowModules']
         }
     ];
 

--- a/scripts/verify_card_smoke.js
+++ b/scripts/verify_card_smoke.js
@@ -17,8 +17,12 @@ function run() {
   mustContain(path.join(cardRoot, 'index.html'), [
     'id="modal-toeic-practice"',
     'id="toeic-review-hub"',
-    "{ src: 'rpg_config.js'",
+    'window._scriptRuntimeErrors = [];',
+    '<script src="rpg_config.js" charset="utf-8"',
+    '<script src="rpg_flow_modules.js" charset="utf-8"',
     'RPGConfig.BOOT_MODULES',
+    "window._scriptLoadErrors.push('rpg_flow_modules.js')",
+    "el.charset = 'utf-8';",
     '_featuresInstalled: false',
     'hydrateModules() {',
     'RPGFeatureModules.install(this);',
@@ -51,7 +55,8 @@ function run() {
     'MODE_META',
     'FIELD_BUFF_INFO',
     'TOEIC_TYPE_LABELS',
-    'BOOT_MODULES'
+    'BOOT_MODULES',
+    "src: 'rpg_features.js'"
   ]);
 
   mustContain(path.join(cardRoot, 'rpg_flow_modules.js'), [


### PR DESCRIPTION
## Summary
- load `rpg_config.js` and `rpg_flow_modules.js` as blocking UTF-8 script tags before the sequential mobile loader so boot-critical modules no longer depend on dynamic handoff timing
- use `RPGConfig.BOOT_MODULES` as the single source of truth for the remaining sequentially loaded files and remove `rpg_flow_modules.js` from that manifest
- record boot-time runtime errors separately from network/file load errors and stop progress text updates once an error is present, so failures are not hidden by later progress updates
- keep `RPGFlowModules` in the readiness check explicitly because it is now loaded outside `BOOT_MODULES`

## Root Cause
- PR #341 moved both `rpg_config.js` and `rpg_flow_modules.js` into the sequential loader path.
- That made the title boot depend on two extra dynamically appended script executions before readiness could complete.
- On some mobile `file://` environments, that handoff was unreliable: first `RPGConfig` could stay missing (`1/1`), and after a workaround `RPGFlowModules` could still be missing even though the progress counter reached the end.
- This patch removes those two boot-critical files from the dynamic handoff entirely instead of masking failures with a fallback.

## Testing
- `npm run verify`
- mobile Playwright smoke against `file:///.../card/index.html` confirmed the title screen reaches ready state with `missing=[]`
- forced missing `rpg_flow_modules.js` smoke confirmed the error message stays visible and is no longer overwritten by later progress updates

## Notes
- The review comment about `updateProgress()` overwriting an existing error state was valid; that guard is included here.
- The suggestion to derive the sequential script list from `RPGConfig.BOOT_MODULES` is also valid once `RPGConfig` is loaded through a normal blocking script tag, which this patch now does.
- This PR supersedes the earlier fallback-based approach.
