### PR TITLE
Fix missing Chaos Blessing info modal

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -2884,7 +2884,9 @@
                 });
                 msg += `<br><b>(현재 총 활성화된 축복: ${this.state.chaosBuffs.length}개)</b>`;
 
-                this.openInfoModal("축복 성공", msg);
+                setTimeout(() => {
+                    this.openInfoModal("축복 성공", msg);
+                }, 1200);
             },
 
             reshuffleChaosPool() {

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1180,7 +1180,9 @@
             msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}%, 치명타/회피율 증가<br>`;
         });
         msg += `<br><b>(현재 총 활성화된 축복: ${this.state.chaosBuffs.length}개)</b><br>(전투 시작 시 해당 카드의 체력이 모두 회복됩니다.)`;
-        this.openInfoModal("축복 성공", msg);
+        setTimeout(() => {
+            this.openInfoModal("축복 성공", msg);
+        }, 1200);
     },
 
     // --- Gacha & Deck UI ---


### PR DESCRIPTION
Fixes an issue where the Chaos Blessing and Great Sage Blessing result popups were not appearing because they were being immediately overridden by the closing animation of the quiz modal.

---
*PR created automatically by Jules for task [17490722371025969708](https://jules.google.com/task/17490722371025969708) started by @romarin0325-cell*