### PR TITLE
챌린지 퍼즐 모드 추가

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -95,9 +95,12 @@ function buildBattleEnemy(rpg) {
         : ENEMIES.length;
     const cycle = Math.floor(rpg.state.enemyScale / cycleLength);
     let scale = 1.0 + (cycle * 0.2);
-    if ((rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') && ['artifact', 'flood', 'curse'].includes(rpg.state.mode)) {
+    if (rpg.state.mode === 'puzzle') {
+        scale += (GAME_CONSTANTS.PUZZLE && GAME_CONSTANTS.PUZZLE.ENEMY_SCALE_BONUS) || 0.2;
+    } else if ((rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') && ['artifact', 'flood', 'curse'].includes(rpg.state.mode)) {
         scale = scale * 1.1;
     }
+    const suppressBossRewards = rpg.state.mode === 'puzzle';
     const enemy = {
         id: baseEnemy.id,
         name: baseEnemy.name,
@@ -118,8 +121,8 @@ function buildBattleEnemy(rpg) {
         lastHitType: null,
         isHiddenBoss: !!baseEnemy.hiddenBossFor,
         isSpecialBoss: !!baseEnemy.isSpecialBoss,
-        bonusRewardTickets: baseEnemy.hiddenBossFor && !baseEnemy.noBonusRewards ? 3 : 0,
-        bonusTranscendenceReward: baseEnemy.noBonusRewards ? null : (baseEnemy.bonusTranscendenceReward || null)
+        bonusRewardTickets: !suppressBossRewards && baseEnemy.hiddenBossFor && !baseEnemy.noBonusRewards ? 3 : 0,
+        bonusTranscendenceReward: suppressBossRewards || baseEnemy.noBonusRewards ? null : (baseEnemy.bonusTranscendenceReward || null)
     };
 
     if (baseEnemy.id === 'creator_god') {
@@ -193,6 +196,15 @@ function buildBattlePlayer(rpg, cardId, idx, allCards) {
 
 const BattleRuntime = {
     startBattleInit(rpg) {
+        if (rpg.state.mode === 'puzzle') {
+            if (!rpg.state.puzzlePiecesClaimed) {
+                return rpg.showAlert("퍼즐 모드는 먼저 퍼즐조각획득을 완료해야 합니다.");
+            }
+            if (rpg.state.deck.some(cardId => cardId === null)) {
+                return rpg.showAlert("퍼즐 모드는 덱 3장을 모두 채워야 전투에 입장할 수 있습니다.");
+            }
+        }
+
         if (rpg.state.deck.every(cardId => cardId === null)) {
             return rpg.showAlert("덱을 완성해주세요.");
         }

--- a/card/index.html
+++ b/card/index.html
@@ -955,8 +955,8 @@
                         style="width:100%; height:100%; object-fit:contain;"></div>
             </div>
             <div id="menu-gacha-area" style="display:flex; gap:5px; margin-bottom:10px;">
-                <button class="menu-btn" onclick="RPG.openGacha()" style="flex:1;">일반 뽑기 (1장)</button>
-                <button class="menu-btn" onclick="RPG.openChallengeGacha()"
+                <button id="btn-normal-gacha" class="menu-btn" onclick="RPG.openGacha()" style="flex:1;">일반 뽑기 (1장)</button>
+                <button id="btn-challenge-gacha" class="menu-btn" onclick="RPG.openChallengeGacha()"
                     style="flex:1; border-color:#e040fb; color:#e040fb;">도전 뽑기</button>
             </div>
             <div id="menu-draft-area" style="display:none; margin-bottom:10px;">
@@ -1952,7 +1952,8 @@
                 activeSpecialCardSelections: {},
                 quiz_stats: { correct: 0, total: 0 },
                 pendingEnemyId: null,
-                pendingEnemyStage: null
+                pendingEnemyStage: null,
+                puzzlePiecesClaimed: false
             },
 
             // Battle State (Transient)
@@ -2607,7 +2608,7 @@
                     { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
                     { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
                     { id: 'suffering', name: '고난의 여정', desc: '초기 10장, 클리어 보상 없음, 축복 카드 +2장.\n(성공조건: 24 스테이지)' },
-                    { id: 'overdrive', name: '오버드라이브', desc: '초기 10장, 클리어 보상 +1장, 축복 카드 +1장.\n(성공조건: 30 스테이지)' },
+                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 획득하여 진행합니다. 사용한 카드는 소멸하고 대폭 강화된 적이 출현합니다.\n(성공조건: 12 스테이지)' },
                     { id: 'archive', name: '아카이브', desc: '매 스테이지 종료 후 문법 퀴즈. 정답률 80% 이상 필요.\n(성공조건: 18 스테이지)' },
                     { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
@@ -2691,6 +2692,17 @@
                 const gachaArea = document.getElementById('menu-gacha-area');
                 const draftArea = document.getElementById('menu-draft-area');
                 const chaosArea = document.getElementById('menu-chaos-area');
+                const normalGachaBtn = document.getElementById('btn-normal-gacha');
+                const challengeGachaBtn = document.getElementById('btn-challenge-gacha');
+
+                if (normalGachaBtn) {
+                    normalGachaBtn.innerText = '일반 뽑기 (1장)';
+                    normalGachaBtn.onclick = () => this.openGacha();
+                }
+                if (challengeGachaBtn) {
+                    challengeGachaBtn.innerText = '도전 뽑기';
+                    challengeGachaBtn.onclick = () => this.openChallengeGacha();
+                }
 
                 // Hide all first
                 gachaArea.style.display = 'none';
@@ -2702,6 +2714,13 @@
                 }
                 else if (this.state.mode === 'chaos') {
                     if (chaosArea) chaosArea.style.display = 'block';
+                }
+                else if (this.state.mode === 'puzzle') {
+                    if (normalGachaBtn) {
+                        normalGachaBtn.innerText = '퍼즐조각획득';
+                        normalGachaBtn.onclick = () => this.openPuzzlePieces();
+                    }
+                    gachaArea.style.display = 'flex';
                 }
                 else {
                     gachaArea.style.display = 'flex';
@@ -2940,7 +2959,97 @@
                 );
             },
 
+            openPuzzlePieces() {
+                if (this.state.mode !== 'puzzle') return this.openGacha();
+                if (this.state.puzzlePiecesClaimed) {
+                    return this.showAlert("이미 퍼즐조각을 획득했습니다. 현재 카드풀로 스테이지를 진행해주세요.");
+                }
+                this.startPuzzlePieceQuiz();
+            },
+
+            startPuzzlePieceQuiz() {
+                const puzzleConfig = GAME_CONSTANTS.PUZZLE || {};
+                const total = puzzleConfig.QUIZ_COUNT || 10;
+                let answered = 0;
+                let correct = 0;
+
+                const askNext = () => {
+                    if (answered >= total) {
+                        this.grantPuzzlePieceCards(correct, total);
+                        return;
+                    }
+
+                    const config = QuizEngine.buildVocabQuiz((success) => {
+                        answered++;
+                        if (success) correct++;
+                        askNext();
+                    });
+                    if (!config) return this.showAlert("단어 퀴즈 데이터가 없습니다.");
+
+                    config.question = `[퍼즐조각 ${answered + 1}/${total}] ${config.question}`;
+                    config.correctDelay = 500;
+                    config.wrongDelay = 700;
+                    QuizEngine.show(config);
+                };
+
+                askNext();
+            },
+
+            drawPuzzlePieceCards(useChallengeRates) {
+                const puzzleConfig = GAME_CONSTANTS.PUZZLE || {};
+                const count = puzzleConfig.PIECE_COUNT || 36;
+                const pool = GameUtils.buildCardPool(this.global, {
+                    activeBonusPoolIds: this.state.activeBonusPoolIds,
+                    specialCardSelections: this.state.activeSpecialCardSelections
+                });
+                if (pool.length === 0) return [];
+
+                const picks = [];
+                for (let i = 0; i < count; i++) {
+                    const grade = GameUtils.resolveGachaGrade('puzzle', useChallengeRates);
+                    let gradePool = pool.filter(card => card.grade === grade);
+                    if (gradePool.length === 0) gradePool = pool.filter(card => card.grade === 'normal');
+                    if (gradePool.length === 0) gradePool = pool;
+                    const pick = gradePool[Math.floor(Math.random() * gradePool.length)];
+                    picks.push(pick.id);
+                }
+                return picks;
+            },
+
+            grantPuzzlePieceCards(correct, total) {
+                const puzzleConfig = GAME_CONSTANTS.PUZZLE || {};
+                const threshold = puzzleConfig.CHALLENGE_RATE_THRESHOLD || 0.7;
+                const rate = total > 0 ? correct / total : 0;
+                const useChallengeRates = rate >= threshold;
+                const picks = this.drawPuzzlePieceCards(useChallengeRates);
+                if (picks.length === 0) return this.showAlert("획득 가능한 카드풀이 없습니다.");
+
+                this.state.puzzlePiecesClaimed = true;
+                this.state.chaosPool = [...picks];
+                this.state.inventory = [...picks];
+                this.state.deck = [null, null, null];
+                this.saveGame(false);
+
+                const summary = { normal: 0, rare: 0, epic: 0, legend: 0 };
+                picks.forEach(id => {
+                    const card = this.getCardData(id);
+                    if (card && summary[card.grade] !== undefined) summary[card.grade]++;
+                });
+
+                const rateText = (rate * 100).toFixed(0);
+                const rateName = useChallengeRates ? '도전뽑기 확률' : '일반뽑기 확률';
+                this.openInfoModal(
+                    "퍼즐조각획득",
+                    `단어 퀴즈 결과: ${correct}/${total} (${rateText}%)<br>` +
+                    `${rateName}로 카드 36장을 획득했습니다.<br><br>` +
+                    `NORMAL ${summary.normal} / RARE ${summary.rare} / EPIC ${summary.epic} / LEGEND ${summary.legend}<br><br>` +
+                    `덱 3장을 모두 채워 전투에 입장하세요.`,
+                    () => this.toMenu()
+                );
+            },
+
             openGacha() {
+                if (this.state.mode === 'puzzle') return this.openPuzzlePieces();
                 if (this.state.tickets < GAME_CONSTANTS.COSTS.GACHA_SINGLE) return this.showAlert("티켓이 부족합니다.");
                 this.state.tickets -= GAME_CONSTANTS.COSTS.GACHA_SINGLE;
                 this.runGacha(false);
@@ -3192,7 +3301,13 @@
                     else { el.innerText = `${role} (비어있음)`; el.classList.remove('filled'); }
                 });
             },
-            confirmDeck() { if (this.state.deck.every(x => x === null)) return this.showAlert("최소 1장의 카드는 선택해야 합니다."); this.toMenu(); },
+            confirmDeck() {
+                if (this.state.mode === 'puzzle' && this.state.deck.some(x => x === null)) {
+                    return this.showAlert("퍼즐 모드는 덱 3장을 모두 채워야 합니다.");
+                }
+                if (this.state.deck.every(x => x === null)) return this.showAlert("최소 1장의 카드는 선택해야 합니다.");
+                this.toMenu();
+            },
 
             // --- Battle Logic Start ---
 
@@ -3450,7 +3565,26 @@
 
                 this.openInfoModal("전투 결과", msg, () => {
                     if (this.state.mode !== 'archive') {
-                        if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+                        if (this.state.mode === 'puzzle') {
+                            this.showConfirm("추가 퀴즈에 도전하시겠습니까?\n(성공 시 다음 전투 혼돈의 축복 5회)",
+                                () => {
+                                    this.startQuiz((success) => {
+                                        if (success) {
+                                            const bonusUses = (GAME_CONSTANTS.PUZZLE && GAME_CONSTANTS.PUZZLE.BONUS_BLESSING_USES) || 5;
+                                            this.state.chaosBlessingUses = bonusUses;
+                                            this.showAlert(`정답! 다음 전투의 혼돈의 축복이 ${bonusUses}회로 증가합니다.`);
+                                        } else {
+                                            this.showAlert("오답입니다... 추가 효과는 없습니다.");
+                                        }
+                                        this.toMenu();
+                                    });
+                                },
+                                () => {
+                                    this.toMenu();
+                                }
+                            );
+                        }
+                        else if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
                             this.showConfirm("추가 보상을 위한 콜로케이션 퀴즈에 도전하시겠습니까?\n(성공 시 드로우권 1장 획득)",
                                 () => {
                                     this.startCollocationQuiz((success) => {
@@ -3513,9 +3647,17 @@
 
                                     this.startGrammarQuiz(q,
                                         () => { // Success
-                                            this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.CREATOR_GOD_QUIZ;
-                                            document.getElementById('ui-tickets').innerText = this.state.tickets;
-                                            this.showAlert("정답! 드로우권 3장을 추가로 획득했습니다.");
+                                            if (this.state.mode === 'puzzle') {
+                                                const currentUses = Number.isFinite(this.state.greatSageBlessingUses)
+                                                    ? this.state.greatSageBlessingUses
+                                                    : GAME_CONSTANTS.DEFAULT_BLESSING_USES;
+                                                this.state.greatSageBlessingUses = currentUses + 1;
+                                                this.showAlert("정답! 대현자의 축복 상한이 1회 증가했습니다.");
+                                            } else {
+                                                this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.CREATOR_GOD_QUIZ;
+                                                document.getElementById('ui-tickets').innerText = this.state.tickets;
+                                                this.showAlert("정답! 드로우권 3장을 추가로 획득했습니다.");
+                                            }
                                             this.toMenu();
                                         },
                                         () => { // Fail

--- a/card/logic.js
+++ b/card/logic.js
@@ -85,10 +85,18 @@ window.GAME_CONSTANTS = {
     BASE_CRIT_MULT: 1.5,
     SUN_BLESS_CRIT_BONUS: 0.6,
     CHAOS_POOL_SIZE: 15,
+    PUZZLE: {
+        PIECE_COUNT: 36,
+        QUIZ_COUNT: 10,
+        CHALLENGE_RATE_THRESHOLD: 0.7,
+        BONUS_BLESSING_USES: 5,
+        ENEMY_SCALE_BONUS: 0.2
+    },
     INITIAL_TICKETS: {
         default: 20,
         suffering: 10,
         overdrive: 10,
+        puzzle: 0,
         restriction: 10,
         balance: 10,
         archive: 10,
@@ -130,6 +138,7 @@ window.GAME_CONSTANTS = {
         balance: 18,
         archive: 18,
         overdrive: 30,
+        puzzle: 12,
         curse: 24,
         flood: 24,
         chaos: 24,
@@ -140,7 +149,8 @@ window.GAME_CONSTANTS = {
     MODE_REWARDS: {
         default: 1,
         suffering: 0,
-        chaos: 0
+        chaos: 0,
+        puzzle: 0
     },
 
     BONUS_REWARDS: {

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -646,7 +646,9 @@
         ) {
             enemyId = this.getCurrentSpecialSeason().bossId;
         }
-        if (this.state.gameType === 'endless' && stageNumber > 30 && hiddenBossMap[baseId] && Math.random() < 0.3) {
+        if (this.state.mode === 'puzzle' && stageNumber > rotation.length && hiddenBossMap[baseId]) {
+            enemyId = hiddenBossMap[baseId];
+        } else if (this.state.gameType === 'endless' && stageNumber > 30 && hiddenBossMap[baseId] && Math.random() < 0.3) {
             enemyId = hiddenBossMap[baseId];
         }
 
@@ -713,6 +715,10 @@
 
     applyBeginnerChallengeSafety(mode) {
         if (!this.needsChallengeSafety()) return;
+
+        if (mode === 'puzzle') {
+            return;
+        }
 
         if (mode === 'chaos' || mode === 'draft') {
             this.state.tickets = Math.max(this.state.tickets, 5);
@@ -956,6 +962,7 @@
                 if (!this.state.artifacts) this.state.artifacts = [];
                 if (this.state.pendingEnemyId === undefined) this.state.pendingEnemyId = null;
                 if (this.state.pendingEnemyStage === undefined) this.state.pendingEnemyStage = null;
+                if (this.state.puzzlePiecesClaimed === undefined) this.state.puzzlePiecesClaimed = false;
                 this.state.activeBonusPoolIds = this.normalizeActiveBonusPoolIds(this.state.activeBonusPoolIds);
                 this.state.activeSpecialCardSelections = this.normalizeSpecialCardSelections(this.state.activeSpecialCardSelections || this.global.activeSpecialCardSelections);
                 if (this.state.mode === 'dream_corridor' && this.state.dreamCorridorLives === undefined) this.state.dreamCorridorLives = 3;
@@ -1002,6 +1009,7 @@
             artifacts: [],
             pendingEnemyId: null,
             pendingEnemyStage: null,
+            puzzlePiecesClaimed: false,
             // [목적] 카오스/드래프트 모드에서 해당 런에서만 유효한 이벤트 카드 목록을 초기화
             activeEventCards: []
         };
@@ -1302,13 +1310,16 @@
     handlePermadeath(players) {
         let deadNames = [];
         players.forEach(p => {
-            if (p && p.isDead) {
+            if (p && (p.isDead || this.state.mode === 'puzzle')) {
                 let idx = this.state.inventory.indexOf(p.id);
                 if (idx > -1) this.state.inventory.splice(idx, 1);
                 if (p.pos !== undefined) this.state.deck[p.pos] = null;
                 deadNames.push(p.name);
             }
         });
+        if (deadNames.length > 0 && this.state.mode === 'puzzle') {
+            return `사용 카드 소멸: ${deadNames.join(', ')}<br>(전투에 사용한 카드가 모두 소멸했습니다)`;
+        }
         if (deadNames.length > 0) return `전사자 발생: ${deadNames.join(', ')}<br>(카드가 소멸했습니다)`;
         return "";
     },
@@ -1325,13 +1336,17 @@
             ? GAME_CONSTANTS.MODE_REWARDS[this.state.mode]
             : GAME_CONSTANTS.MODE_REWARDS.default;
 
-        if (this.battle.players.some(p => p && p.proto.trait.type === 'looter')) {
+        const hasLuther = this.battle.players.some(p => p && (p.id === 'doom_luther' || (p.proto && p.proto.role === 'luther')));
+        const hasLooterReward = mode === 'puzzle'
+            ? hasLuther
+            : this.battle.players.some(p => p && p.proto.trait.type === 'looter');
+        if (hasLooterReward) {
             reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
         }
         if (this.state.mode === 'overdrive') {
             reward += GAME_CONSTANTS.BONUS_REWARDS.OVERDRIVE;
         }
-        if (this.battle.enemy && this.battle.enemy.bonusRewardTickets) {
+        if (mode !== 'puzzle' && this.battle.enemy && this.battle.enemy.bonusRewardTickets) {
             reward += this.battle.enemy.bonusRewardTickets;
         }
 

--- a/card_remaster/battle_runtime.js
+++ b/card_remaster/battle_runtime.js
@@ -91,9 +91,12 @@ function buildBattleEnemy(rpg) {
         : ENEMIES.length;
     const cycle = Math.floor(rpg.state.enemyScale / cycleLength);
     let scale = 1.0 + (cycle * 0.2);
-    if ((rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') && ['artifact', 'flood', 'curse'].includes(rpg.state.mode)) {
+    if (rpg.state.mode === 'puzzle') {
+        scale += (GAME_CONSTANTS.PUZZLE && GAME_CONSTANTS.PUZZLE.ENEMY_SCALE_BONUS) || 0.2;
+    } else if ((rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') && ['artifact', 'flood', 'curse'].includes(rpg.state.mode)) {
         scale = scale * 1.1;
     }
+    const suppressBossRewards = rpg.state.mode === 'puzzle';
     const enemy = {
         id: baseEnemy.id,
         name: baseEnemy.name,
@@ -113,8 +116,8 @@ function buildBattleEnemy(rpg) {
         tookDamageThisTurn: false,
         lastHitType: null,
         isHiddenBoss: !!baseEnemy.hiddenBossFor,
-        bonusRewardTickets: baseEnemy.hiddenBossFor ? 3 : 0,
-        bonusTranscendenceReward: baseEnemy.bonusTranscendenceReward || null
+        bonusRewardTickets: !suppressBossRewards && baseEnemy.hiddenBossFor ? 3 : 0,
+        bonusTranscendenceReward: suppressBossRewards ? null : (baseEnemy.bonusTranscendenceReward || null)
     };
 
     if (baseEnemy.id === 'creator_god') {
@@ -188,6 +191,15 @@ function buildBattlePlayer(rpg, cardId, idx, allCards) {
 
 const BattleRuntime = {
     startBattleInit(rpg) {
+        if (rpg.state.mode === 'puzzle') {
+            if (!rpg.state.puzzlePiecesClaimed) {
+                return rpg.showAlert("퍼즐 모드는 먼저 퍼즐조각획득을 완료해야 합니다.");
+            }
+            if (rpg.state.deck.some(cardId => cardId === null)) {
+                return rpg.showAlert("퍼즐 모드는 덱 3장을 모두 채워야 전투에 입장할 수 있습니다.");
+            }
+        }
+
         if (rpg.state.deck.every(cardId => cardId === null)) {
             return rpg.showAlert("덱을 완성해주세요.");
         }

--- a/card_remaster/data.js
+++ b/card_remaster/data.js
@@ -1127,6 +1127,23 @@ const BONUS_TRANSCENDENCE_CARDS = [
 
 ENEMIES.push(
     {
+        id: 'flora', name: '꽃의 여신 플로라', element: 'nature',
+        stats: { hp: 700, atk: 70, matk: 70, def: 70, mdef: 70 },
+        skills: [
+            { name: '제네시스블룸', type: 'sup', rate: 0.0, val: 0, desc: '대미지 반감, 자신에게 걸린 모든 디버프를 해제', effects: [{ type: 'buff', id: 'guard', duration: 1 }, { type: 'clear_self_debuffs' }] },
+            { name: '블러썸템페스트', type: 'mag', rate: 0.3, val: 2.0, desc: '마법공격 2배율', effects: [] }
+        ]
+    },
+    {
+        id: 'gray', name: '사신 그레이', element: 'dark',
+        stats: { hp: 800, atk: 90, matk: 90, def: 60, mdef: 60 },
+        skills: [
+            { name: '영혼절단', type: 'mag', rate: 0.0, val: 2.0, desc: '2~4배율 랜덤 마법공격', effects: [{ type: 'random_mult', min: 2.0, max: 4.0 }] },
+            { name: '차원절단', type: 'phy', rate: 0.0, val: 2.0, desc: '2~4배율 랜덤 물리공격', effects: [{ type: 'random_mult', min: 2.0, max: 4.0 }] },
+            { name: '디멘션제로', type: 'phy', rate: 0.0, val: 4.0, desc: '물리공격 4배율', effects: [] }
+        ]
+    },
+    {
         id: 'thor', name: '뇌신 토르', element: 'light', hiddenBossFor: 'iris_curse', bonusTranscendenceReward: 'trans_thor',
         stats: { hp: 900, atk: 100, matk: 50, def: 100, mdef: 50 },
         skills: [

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -2067,8 +2067,8 @@
                 <section class="menu-section glass-panel">
                     <div class="menu-section__title">Draw / Draft Flow</div>
                     <div id="menu-gacha-area" class="button-pair">
-                        <button class="menu-btn" onclick="RPG.openGacha()" style="flex:1;">Normal Draw</button>
-                        <button class="menu-btn accent-violet" onclick="RPG.openChallengeGacha()" style="flex:1;">Challenge Draw</button>
+                        <button id="btn-normal-gacha" class="menu-btn" onclick="RPG.openGacha()" style="flex:1;">Normal Draw</button>
+                        <button id="btn-challenge-gacha" class="menu-btn accent-violet" onclick="RPG.openChallengeGacha()" style="flex:1;">Challenge Draw</button>
                     </div>
                     <div id="menu-draft-area" class="solo-action" style="display:none;">
                         <button class="menu-btn accent-green" onclick="RPG.startDraft()">Start Draft</button>
@@ -3247,7 +3247,8 @@
                 activeBonusPoolIds: [],
                 quiz_stats: { correct: 0, total: 0 },
                 pendingEnemyId: null,
-                pendingEnemyStage: null
+                pendingEnemyStage: null,
+                puzzlePiecesClaimed: false
             },
 
             // Battle State (Transient)
@@ -3734,9 +3735,16 @@
                     pharaoh: 'poseidon',
                     demon_god: 'ares'
                 };
+                const puzzleHiddenBossMap = {
+                    artificial_demon_god: 'flora',
+                    iris_love: 'gray',
+                    ...hiddenBossMap
+                };
 
                 let enemyId = baseId;
-                if (this.state.gameType === 'endless' && stageNumber > 30 && hiddenBossMap[baseId] && Math.random() < 0.3) {
+                if (this.state.mode === 'puzzle' && stageNumber > rotation.length && puzzleHiddenBossMap[baseId]) {
+                    enemyId = puzzleHiddenBossMap[baseId];
+                } else if (this.state.gameType === 'endless' && stageNumber > 30 && hiddenBossMap[baseId] && Math.random() < 0.3) {
                     enemyId = hiddenBossMap[baseId];
                 }
 
@@ -3796,6 +3804,10 @@
 
             applyBeginnerChallengeSafety(mode) {
                 if (!this.needsChallengeSafety()) return;
+
+                if (mode === 'puzzle') {
+                    return;
+                }
 
                 if (mode === 'chaos' || mode === 'draft') {
                     this.state.tickets = Math.max(this.state.tickets, 5);
@@ -4270,6 +4282,7 @@
                         if (!this.state.artifacts) this.state.artifacts = [];
                         if (this.state.pendingEnemyId === undefined) this.state.pendingEnemyId = null;
                         if (this.state.pendingEnemyStage === undefined) this.state.pendingEnemyStage = null;
+                        if (this.state.puzzlePiecesClaimed === undefined) this.state.puzzlePiecesClaimed = false;
                         this.state.activeBonusPoolIds = this.normalizeActiveBonusPoolIds(this.state.activeBonusPoolIds);
                         this.loadStudyProgress();
 
@@ -4317,7 +4330,7 @@
                     { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
                     { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
                     { id: 'suffering', name: '고난의 여정', desc: '초기 10장, 클리어 보상 없음, 축복 카드 +2장.\n(성공조건: 24 스테이지)' },
-                    { id: 'overdrive', name: '오버드라이브', desc: '초기 10장, 클리어 보상 +1장, 축복 카드 +1장.\n(성공조건: 30 스테이지)' },
+                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 획득하여 진행합니다. 사용한 카드는 소멸하고 대폭 강화된 적이 출현합니다.\n(성공조건: 12 스테이지)' },
                     { id: 'archive', name: '아카이브', desc: '매 스테이지 종료 후 문법 퀴즈. 정답률 80% 이상 필요.\n(성공조건: 18 스테이지)' },
                     { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
@@ -4415,6 +4428,7 @@
                     artifacts: [],
                     pendingEnemyId: null,
                     pendingEnemyStage: null,
+                    puzzlePiecesClaimed: false,
                     // [목적] 카오스/드래프트 모드에서 해당 런에서만 유효한 이벤트 카드 목록을 초기화
                     activeEventCards: []
                 };
@@ -4512,6 +4526,17 @@
                 const gachaArea = document.getElementById('menu-gacha-area');
                 const draftArea = document.getElementById('menu-draft-area');
                 const chaosArea = document.getElementById('menu-chaos-area');
+                const normalGachaBtn = document.getElementById('btn-normal-gacha');
+                const challengeGachaBtn = document.getElementById('btn-challenge-gacha');
+
+                if (normalGachaBtn) {
+                    normalGachaBtn.innerText = 'Normal Draw';
+                    normalGachaBtn.onclick = () => this.openGacha();
+                }
+                if (challengeGachaBtn) {
+                    challengeGachaBtn.innerText = 'Challenge Draw';
+                    challengeGachaBtn.onclick = () => this.openChallengeGacha();
+                }
 
                 // Hide all first
                 gachaArea.style.display = 'none';
@@ -4523,6 +4548,13 @@
                 }
                 else if (this.state.mode === 'chaos') {
                     if (chaosArea) chaosArea.style.display = 'block';
+                }
+                else if (this.state.mode === 'puzzle') {
+                    if (normalGachaBtn) {
+                        normalGachaBtn.innerText = 'Puzzle Pieces';
+                        normalGachaBtn.onclick = () => this.openPuzzlePieces();
+                    }
+                    gachaArea.style.display = 'flex';
                 }
                 else {
                     gachaArea.style.display = 'flex';
@@ -4865,7 +4897,96 @@
                 );
             },
 
+            openPuzzlePieces() {
+                if (this.state.mode !== 'puzzle') return this.openGacha();
+                if (this.state.puzzlePiecesClaimed) {
+                    return this.showAlert("이미 퍼즐조각을 획득했습니다. 현재 카드풀로 스테이지를 진행해주세요.");
+                }
+                this.startPuzzlePieceQuiz();
+            },
+
+            startPuzzlePieceQuiz() {
+                const puzzleConfig = GAME_CONSTANTS.PUZZLE || {};
+                const total = puzzleConfig.QUIZ_COUNT || 10;
+                let answered = 0;
+                let correct = 0;
+
+                const askNext = () => {
+                    if (answered >= total) {
+                        this.grantPuzzlePieceCards(correct, total);
+                        return;
+                    }
+
+                    const config = QuizEngine.buildVocabQuiz((success) => {
+                        answered++;
+                        if (success) correct++;
+                        askNext();
+                    });
+                    if (!config) return this.showAlert("단어 퀴즈 데이터가 없습니다.");
+
+                    config.question = `[퍼즐조각 ${answered + 1}/${total}] ${config.question}`;
+                    config.correctDelay = 500;
+                    config.wrongDelay = 700;
+                    QuizEngine.show(config);
+                };
+
+                askNext();
+            },
+
+            drawPuzzlePieceCards(useChallengeRates) {
+                const puzzleConfig = GAME_CONSTANTS.PUZZLE || {};
+                const count = puzzleConfig.PIECE_COUNT || 36;
+                const pool = GameUtils.buildCardPool(this.global, {
+                    activeBonusPoolIds: this.state.activeBonusPoolIds
+                });
+                if (pool.length === 0) return [];
+
+                const picks = [];
+                for (let i = 0; i < count; i++) {
+                    const grade = GameUtils.resolveGachaGrade('puzzle', useChallengeRates);
+                    let gradePool = pool.filter(card => card.grade === grade);
+                    if (gradePool.length === 0) gradePool = pool.filter(card => card.grade === 'normal');
+                    if (gradePool.length === 0) gradePool = pool;
+                    const pick = gradePool[Math.floor(Math.random() * gradePool.length)];
+                    picks.push(pick.id);
+                }
+                return picks;
+            },
+
+            grantPuzzlePieceCards(correct, total) {
+                const puzzleConfig = GAME_CONSTANTS.PUZZLE || {};
+                const threshold = puzzleConfig.CHALLENGE_RATE_THRESHOLD || 0.7;
+                const rate = total > 0 ? correct / total : 0;
+                const useChallengeRates = rate >= threshold;
+                const picks = this.drawPuzzlePieceCards(useChallengeRates);
+                if (picks.length === 0) return this.showAlert("획득 가능한 카드풀이 없습니다.");
+
+                this.state.puzzlePiecesClaimed = true;
+                this.state.chaosPool = [...picks];
+                this.state.inventory = [...picks];
+                this.state.deck = [null, null, null];
+                this.saveGame(false);
+
+                const summary = { normal: 0, rare: 0, epic: 0, legend: 0 };
+                picks.forEach(id => {
+                    const card = this.getCardData(id);
+                    if (card && summary[card.grade] !== undefined) summary[card.grade]++;
+                });
+
+                const rateText = (rate * 100).toFixed(0);
+                const rateName = useChallengeRates ? '도전뽑기 확률' : '일반뽑기 확률';
+                this.openInfoModal(
+                    "퍼즐조각획득",
+                    `단어 퀴즈 결과: ${correct}/${total} (${rateText}%)<br>` +
+                    `${rateName}로 카드 36장을 획득했습니다.<br><br>` +
+                    `NORMAL ${summary.normal} / RARE ${summary.rare} / EPIC ${summary.epic} / LEGEND ${summary.legend}<br><br>` +
+                    `덱 3장을 모두 채워 전투에 입장하세요.`,
+                    () => this.toMenu()
+                );
+            },
+
             openGacha() {
+                if (this.state.mode === 'puzzle') return this.openPuzzlePieces();
                 if (this.state.tickets < GAME_CONSTANTS.COSTS.GACHA_SINGLE) return this.showAlert("티켓이 부족합니다.");
                 this.state.tickets -= GAME_CONSTANTS.COSTS.GACHA_SINGLE;
                 this.runGacha(false);
@@ -5152,7 +5273,13 @@
                     }
                 });
             },
-            confirmDeck() { if (this.state.deck.every(x => x === null)) return this.showAlert("최소 1장의 카드는 선택해야 합니다."); this.toMenu(); },
+            confirmDeck() {
+                if (this.state.mode === 'puzzle' && this.state.deck.some(x => x === null)) {
+                    return this.showAlert("퍼즐 모드는 덱 3장을 모두 채워야 합니다.");
+                }
+                if (this.state.deck.every(x => x === null)) return this.showAlert("최소 1장의 카드는 선택해야 합니다.");
+                this.toMenu();
+            },
 
             // --- Battle Logic Start ---
 
@@ -5434,13 +5561,16 @@
             handlePermadeath(players) {
                 let deadNames = [];
                 players.forEach(p => {
-                    if (p && p.isDead) {
+                    if (p && (p.isDead || this.state.mode === 'puzzle')) {
                         let idx = this.state.inventory.indexOf(p.id);
                         if (idx > -1) this.state.inventory.splice(idx, 1);
                         if (p.pos !== undefined) this.state.deck[p.pos] = null;
                         deadNames.push(p.name);
                     }
                 });
+                if (deadNames.length > 0 && this.state.mode === 'puzzle') {
+                    return `사용 카드 소멸: ${deadNames.join(', ')}<br>(전투에 사용한 카드가 모두 소멸했습니다)`;
+                }
                 if (deadNames.length > 0) return `전사자 발생: ${deadNames.join(', ')}<br>(카드가 소멸했습니다)`;
                 return "";
             },
@@ -5453,13 +5583,18 @@
                     ? GAME_CONSTANTS.MODE_REWARDS[this.state.mode]
                     : GAME_CONSTANTS.MODE_REWARDS.default;
 
-                if (this.battle.players.some(p => p && p.proto.trait.type === 'looter')) {
+                const mode = this.state.mode;
+                const hasLuther = this.battle.players.some(p => p && (p.id === 'doom_luther' || (p.proto && p.proto.role === 'luther')));
+                const hasLooterReward = mode === 'puzzle'
+                    ? hasLuther
+                    : this.battle.players.some(p => p && p.proto.trait.type === 'looter');
+                if (hasLooterReward) {
                     reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
                 }
                 if (this.state.mode === 'overdrive') {
                     reward += GAME_CONSTANTS.BONUS_REWARDS.OVERDRIVE;
                 }
-                if (this.battle.enemy && this.battle.enemy.bonusRewardTickets) {
+                if (mode !== 'puzzle' && this.battle.enemy && this.battle.enemy.bonusRewardTickets) {
                     reward += this.battle.enemy.bonusRewardTickets;
                 }
 
@@ -5480,7 +5615,6 @@
                 this.log(`승리 보상: 뽑기권 ${reward}장 획득.`);
 
                 // Victory Condition Check
-                const mode = this.state.mode;
                 const stage = this.state.enemyScale; // current stage (already incremented)
                 const clearStage = GameUtils.getClearStage(mode, this.state.gameType);
                 const gameClear = stage >= clearStage;
@@ -5673,7 +5807,26 @@
 
                 this.openInfoModal("전투 결과", msg, () => {
                     if (this.state.mode !== 'archive') {
-                        if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+                        if (this.state.mode === 'puzzle') {
+                            this.showConfirm("추가 퀴즈에 도전하시겠습니까?\n(성공 시 다음 전투 혼돈의 축복 5회)",
+                                () => {
+                                    this.startQuiz((success) => {
+                                        if (success) {
+                                            const bonusUses = (GAME_CONSTANTS.PUZZLE && GAME_CONSTANTS.PUZZLE.BONUS_BLESSING_USES) || 5;
+                                            this.state.chaosBlessingUses = bonusUses;
+                                            this.showAlert(`정답! 다음 전투의 혼돈의 축복이 ${bonusUses}회로 증가합니다.`);
+                                        } else {
+                                            this.showAlert("오답입니다... 추가 효과는 없습니다.");
+                                        }
+                                        this.toMenu();
+                                    });
+                                },
+                                () => {
+                                    this.toMenu();
+                                }
+                            );
+                        }
+                        else if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
                             this.showConfirm("추가 보상을 위한 콜로케이션 퀴즈에 도전하시겠습니까?\n(성공 시 드로우권 1장 획득)",
                                 () => {
                                     this.startCollocationQuiz((success) => {
@@ -5736,9 +5889,17 @@
 
                                     this.startGrammarQuiz(q,
                                         () => { // Success
-                                            this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.CREATOR_GOD_QUIZ;
-                                            document.getElementById('ui-tickets').innerText = this.state.tickets;
-                                            this.showAlert("정답! 드로우권 3장을 추가로 획득했습니다.");
+                                            if (this.state.mode === 'puzzle') {
+                                                const currentUses = Number.isFinite(this.state.greatSageBlessingUses)
+                                                    ? this.state.greatSageBlessingUses
+                                                    : GAME_CONSTANTS.DEFAULT_BLESSING_USES;
+                                                this.state.greatSageBlessingUses = currentUses + 1;
+                                                this.showAlert("정답! 대현자의 축복 상한이 1회 증가했습니다.");
+                                            } else {
+                                                this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.CREATOR_GOD_QUIZ;
+                                                document.getElementById('ui-tickets').innerText = this.state.tickets;
+                                                this.showAlert("정답! 드로우권 3장을 추가로 획득했습니다.");
+                                            }
                                             this.toMenu();
                                         },
                                         () => { // Fail

--- a/card_remaster/logic.js
+++ b/card_remaster/logic.js
@@ -85,10 +85,18 @@ const GAME_CONSTANTS = {
     BASE_CRIT_MULT: 1.5,
     SUN_BLESS_CRIT_BONUS: 0.6,
     CHAOS_POOL_SIZE: 15,
+    PUZZLE: {
+        PIECE_COUNT: 36,
+        QUIZ_COUNT: 10,
+        CHALLENGE_RATE_THRESHOLD: 0.7,
+        BONUS_BLESSING_USES: 5,
+        ENEMY_SCALE_BONUS: 0.2
+    },
     INITIAL_TICKETS: {
         default: 20,
         suffering: 10,
         overdrive: 10,
+        puzzle: 0,
         restriction: 10,
         balance: 10,
         archive: 10,
@@ -130,6 +138,7 @@ const GAME_CONSTANTS = {
         balance: 18,
         archive: 18,
         overdrive: 30,
+        puzzle: 12,
         curse: 24,
         flood: 24,
         chaos: 24,
@@ -140,7 +149,8 @@ const GAME_CONSTANTS = {
     MODE_REWARDS: {
         default: 1,
         suffering: 0,
-        chaos: 0
+        chaos: 0,
+        puzzle: 0
     },
 
     BONUS_REWARDS: {
@@ -1837,6 +1847,17 @@ const Logic = {
         else if (enemy.id === 'demon_god') {
             if (turn === 7 || turn === 14) skill = enemy.skills.find(s => s.name === '제노사이드');
             else if (r < 0.2) skill = enemy.skills.find(s => s.name === '다크니스');
+        }
+        else if (enemy.id === 'flora') {
+            if (turn === 5 || turn === 10) skill = enemy.skills.find(s => s.name === '제네시스블룸');
+            else if (r < 0.3) skill = enemy.skills.find(s => s.name === '블러썸템페스트');
+        }
+        else if (enemy.id === 'gray') {
+            if (turn === 14) skill = enemy.skills.find(s => s.name === '디멘션제로');
+            else if (turn % 4 === 0) {
+                const skillName = Math.random() < 0.5 ? '영혼절단' : '차원절단';
+                skill = enemy.skills.find(s => s.name === skillName);
+            }
         }
         else if (enemy.id === 'thor') {
             if (turn === 10) skill = enemy.skills.find(s => s.name === '썬더러쉬');


### PR DESCRIPTION
## 요약
- 챌린지 모드 선택에서 오버드라이브 대신 퍼즐 모드를 추가했습니다.
- 퍼즐조각획득 10문항 퀴즈와 정답률 기반 36장 카드풀 지급을 구현했습니다.
- 퍼즐 전투의 3장 덱 필수, 사용 카드 소멸, 20% 강화 및 2싸이클 난입 보스 규칙을 추가했습니다.
- 퍼즐 모드의 티켓 보상 예외, 전투 후 퀴즈 축복 5회 보너스, 창조신 문법 퀴즈 대현자 축복 상한 증가를 반영했습니다.

## 검증
- npm run verify
- Playwright로 퍼즐 버튼 전환, 퍼즐조각 지급 36장, 전투 진입 차단/진입, 20% 강화, 2싸이클 보스 순서를 확인했습니다.