### PR TITLE
Fix looter bonus reward trigger in puzzle mode

### DIFF
--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1336,10 +1336,9 @@
             ? GAME_CONSTANTS.MODE_REWARDS[this.state.mode]
             : GAME_CONSTANTS.MODE_REWARDS.default;
 
-        const hasLuther = this.battle.players.some(p => p && (p.id === 'doom_luther' || (p.proto && p.proto.role === 'luther')));
-        const hasLooterReward = mode === 'puzzle'
-            ? hasLuther
-            : this.battle.players.some(p => p && p.proto.trait.type === 'looter');
+        const hasLooterReward = this.battle.players.some(
+            p => p && p.proto && p.proto.trait && p.proto.trait.type === 'looter'
+        );
         if (hasLooterReward) {
             reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
         }

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -5584,10 +5584,9 @@
                     : GAME_CONSTANTS.MODE_REWARDS.default;
 
                 const mode = this.state.mode;
-                const hasLuther = this.battle.players.some(p => p && (p.id === 'doom_luther' || (p.proto && p.proto.role === 'luther')));
-                const hasLooterReward = mode === 'puzzle'
-                    ? hasLuther
-                    : this.battle.players.some(p => p && p.proto.trait.type === 'looter');
+                const hasLooterReward = this.battle.players.some(
+                    p => p && p.proto && p.proto.trait && p.proto.trait.type === 'looter'
+                );
                 if (hasLooterReward) {
                     reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
                 }


### PR DESCRIPTION
### Motivation
- Puzzle-mode victories were not granting the extra draw reward consistently when a looter card was in the deck because the reward detection used a Luther/id special-case instead of a trait check.
- The intent is to unify the detection to the card `looter` trait so any card with that trait (including Luther variants) grants the extra reward.

### Description
- Replaced the previous puzzle-only `hasLuther` special-case with a unified trait-based check that looks for `p.proto.trait.type === 'looter'` in `winBattle()`.
- Applied the same fix in both runtime implementations by updating `card/rpg_features.js` and `card_remaster/index.html` to use the trait-based detection.
- This ensures `GAME_CONSTANTS.BONUS_REWARDS.LOOTER` is awarded whenever any player card has the `looter` trait.

### Testing
- Ran `npm run verify` which runs lint and smoke tests, and it completed successfully.
- Lint checks (`node --check ...`) passed with no syntax errors.
- Smoke checks (`scripts/verify_card_smoke.js`, `scripts/verify_card_remaster_smoke.js`, `scripts/verify_idle_hero_smoke.js`) all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88e4103c8832291fb56eb3dc69780)