### PR TITLE
card: adjust puzzle challenge rewards and balance

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -85,8 +85,17 @@ const GameAPI = {
         let targetInfo = "";
         if (type === 'collocation') {
             targetInfo = `Target Expression: '${targetData.expression}' (Meaning: ${targetData.meaning})`;
-            if (targetData.options && targetData.options.length > 0) {
-                targetInfo += `\nOptions: [${targetData.options.join(', ')}]`;
+            if (targetData.question) {
+                targetInfo += `\nQuiz Prompt: '${targetData.question}'`;
+            }
+            if (targetData.answer) {
+                targetInfo += `\nCorrect Option: '${targetData.answer}'`;
+            }
+            const collocationOptions = Array.isArray(targetData.options)
+                ? targetData.options
+                : (targetData.selectedQuiz && Array.isArray(targetData.selectedQuiz.options) ? targetData.selectedQuiz.options : []);
+            if (collocationOptions.length > 0) {
+                targetInfo += `\nOptions: [${collocationOptions.join(', ')}]`;
             }
             targetInfo += `\n\n**[숙어 연상법 규칙]**`;
             targetInfo += `\n- 왜 이 단어들의 조합이 이 의미가 되는지 의미적 연결을 설명하십시오. (예: 'conduct a survey' → conduct는 '이끌다/수행하다'의 뉘앙스 → 설문조사를 '주도해서 진행'하는 이미지)`;

--- a/card/data.js
+++ b/card/data.js
@@ -353,7 +353,7 @@ const CARDS = [
     {
         id: 'silent_librarian', name: '침묵의사서', grade: 'rare', element: 'water', role: 'debuffer',
         stats: { hp: 330, atk: 70, matk: 95, def: 55, mdef: 75 },
-        trait: { type: 'death_dmg_mag', val: 2.0, desc: '사망시 적에게 200% 마법대미지' },
+        trait: { type: 'death_dmg_mag', val: 6.0, desc: '사망시 적에게 600% 마법대미지' },
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
             { name: '사일런트', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] },

--- a/card/index.html
+++ b/card/index.html
@@ -1364,7 +1364,7 @@
             <button class="menu-btn" onclick="RPG.activateChaos('great_sage')"
                 style="border-color:#00e676; color:#00e676;">
                 대현자의 축복<br>
-                <span style="font-size:0.75rem; font-weight:normal; color:#b9f6ca;">문법 퀴즈 성공 시 12명에게 축복 + 티켓 1장</span>
+                <span id="great-sage-desc" style="font-size:0.75rem; font-weight:normal; color:#b9f6ca;">문법 퀴즈 성공 시 12명에게 축복 + 티켓 1장</span>
             </button>
             <button class="menu-btn" onclick="RPG.checkActiveChaosBlessings()"
                 style="border-color:#29b6f6; color:#29b6f6;">
@@ -1854,6 +1854,17 @@
                 };
             },
 
+            resolveCollocationTutoringQuiz(data) {
+                if (data && data.selectedQuiz) return data.selectedQuiz;
+                if (!data) return null;
+
+                const quizList = (Array.isArray(data.quizzes) && data.quizzes.length > 0)
+                    ? data.quizzes
+                    : [{ question: data.question, options: data.options, answer: data.answer, translation: data.translation }];
+                if (quizList.length === 0) return null;
+                return quizList[Math.floor(Math.random() * quizList.length)];
+            },
+
             /**
              * Build config for a tutoring review quiz (vocab or collocation).
              * @param {Object}   item           - { data, type: 'vocab'|'collocation' }
@@ -1865,8 +1876,12 @@
                 const data = item.data;
 
                 if (item.type === 'collocation') {
-                    let quizList = data.quizzes || [{ question: data.question, options: data.options, answer: data.answer, translation: data.translation }];
-                    let q = quizList[Math.floor(Math.random() * quizList.length)];
+                    const q = this.resolveCollocationTutoringQuiz(data) || {
+                        question: data.question,
+                        options: data.options || [],
+                        answer: data.answer,
+                        translation: data.translation
+                    };
 
                     return {
                         question: q.question,
@@ -2604,7 +2619,7 @@
                     { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
                     { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
                     { id: 'suffering', name: '고난의 여정', desc: '초기 10장, 클리어 보상 없음, 축복 카드 +2장.\n(성공조건: 24 스테이지)' },
-                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 획득하여 진행합니다. 사용한 카드는 소멸하고 대폭 강화된 적이 출현합니다.\n(성공조건: 12 스테이지)' },
+                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 확보해 진행. 사용한 카드는 소멸, 강화된 적 출현.\n(성공조건: 12 스테이지)' },
                     { id: 'archive', name: '아카이브', desc: '매 스테이지 종료 후 문법 퀴즈. 정답률 80% 이상 필요.\n(성공조건: 18 스테이지)' },
                     { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
@@ -2797,8 +2812,14 @@
                 // Show artifact check button only in artifact mode
                 const artBtn = document.getElementById('btn-artifact-check');
                 const modal = document.getElementById('modal-chaos');
+                const sageDesc = document.getElementById('great-sage-desc');
                 if (artBtn) {
                     artBtn.style.display = (this.state.mode === 'artifact') ? 'block' : 'none';
+                }
+                if (sageDesc) {
+                    sageDesc.innerText = this.state.mode === 'puzzle'
+                        ? '문법 퀴즈 성공 시 12명에게 축복'
+                        : '문법 퀴즈 성공 시 12명에게 축복 + 티켓 1장';
                 }
 
                 if (this.state.mode === 'artifact') {
@@ -2867,8 +2888,11 @@
                 // Update UI immediately
                 document.getElementById('sage-uses').innerText = this.state.greatSageBlessingUses;
 
-                this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.SAGE_BLESSING;
-                if (document.getElementById('ui-tickets')) document.getElementById('ui-tickets').innerText = this.state.tickets;
+                const grantsTicket = this.state.mode !== 'puzzle';
+                if (grantsTicket) {
+                    this.state.tickets += GAME_CONSTANTS.BONUS_REWARDS.SAGE_BLESSING;
+                    if (document.getElementById('ui-tickets')) document.getElementById('ui-tickets').innerText = this.state.tickets;
+                }
 
                 // Apply to 12 random cards
                 let pool = GameUtils.buildCardPool(this.global, {
@@ -2897,7 +2921,11 @@
                 this.state.activeSageBlessing = newBuffs;
                 this.updateMergedBlessings();
 
-                let msg = "<b>대현자의 축복 성공!</b><br>12명의 동료에게 축복이 내려졌습니다.<br>드로우 티켓 1장 획득!<br><br><b>[새로 적용된 축복]</b><br>";
+                let msg = "<b>대현자의 축복 성공!</b><br>12명의 동료에게 축복이 내려졌습니다.<br>";
+                if (grantsTicket) {
+                    msg += "드로우 티켓 1장 획득!<br>";
+                }
+                msg += "<br><b>[새로 적용된 축복]</b><br>";
                 newBuffs.forEach(b => {
                     msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}%, 치명타/회피율 증가<br>`;
                 });
@@ -4277,7 +4305,21 @@
                     return this.startTutoringSession(); // Retry
                 }
 
-                this.currentTutoringItem = { data: targetData, type: isCollocation ? 'collocation' : 'vocab' };
+                let tutoringData = targetData;
+                if (isCollocation) {
+                    const selectedQuiz = QuizEngine.resolveCollocationTutoringQuiz(targetData);
+                    const selectedOptions = selectedQuiz && Array.isArray(selectedQuiz.options) ? [...selectedQuiz.options] : [];
+                    tutoringData = {
+                        ...targetData,
+                        question: selectedQuiz ? selectedQuiz.question : targetData.question,
+                        options: selectedOptions,
+                        answer: selectedQuiz ? selectedQuiz.answer : targetData.answer,
+                        translation: selectedQuiz ? selectedQuiz.translation : targetData.translation,
+                        selectedQuiz: selectedQuiz ? { ...selectedQuiz, options: selectedOptions } : null
+                    };
+                }
+
+                this.currentTutoringItem = { data: tutoringData, type: isCollocation ? 'collocation' : 'vocab' };
 
                 // UI Loading
                 this.isApiLoading = true;
@@ -4287,7 +4329,7 @@
                 try {
                     const text = await GameAPI.getTutoringContent(
                         key,
-                        targetData,
+                        tutoringData,
                         isCollocation ? 'collocation' : 'vocab',
                         { model: LumiQuestionRuntime.selectedModel }
                     );
@@ -4351,8 +4393,9 @@
                     this.toMenu();
 
                     // Rumi Surprise Gift Logic
+                    const allowTicketGift = this.state.mode !== 'puzzle';
                     this.state.rumiGiftCount = this.state.rumiGiftCount || 0;
-                    if (this.state.rumiGiftCount < 3 && Math.random() < 0.3) {
+                    if (allowTicketGift && this.state.rumiGiftCount < 3 && Math.random() < 0.3) {
                         this.state.rumiGiftCount++;
                         this.state.tickets = (this.state.tickets || 0) + 1;
                         if (document.getElementById('ui-tickets')) document.getElementById('ui-tickets').innerText = this.state.tickets;

--- a/card/logic.js
+++ b/card/logic.js
@@ -1729,8 +1729,13 @@ const Logic = {
         if (forceCritChance && Math.random() * 100 < forceCritChance.val) isCrit = true;
 
         let critDmg = GAME_CONSTANTS.BASE_CRIT_MULT;
-        if (source.proto && sourceFieldBuffs.some(b => b.name === 'sun_bless')) critDmg += GAME_CONSTANTS.SUN_BLESS_CRIT_BONUS;
-        if (source.proto && sourceFieldBuffs.some(b => b.name === 'reaper_realm')) critDmg += 0.4;
+        const critBuffMult = (mode === 'flood' && source.proto) ? 2.0 : 1.0;
+        if (source.proto && sourceFieldBuffs.some(b => b.name === 'sun_bless')) {
+            critDmg += GAME_CONSTANTS.SUN_BLESS_CRIT_BONUS * critBuffMult;
+        }
+        if (source.proto && sourceFieldBuffs.some(b => b.name === 'reaper_realm')) {
+            critDmg += 0.4 * critBuffMult;
+        }
 
         let val = (skill.type === 'phy') ? srcStats.atk : srcStats.matk;
 

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -791,7 +791,7 @@
 
 
     needsChallengeSafety() {
-        return this.state.gameType === 'challenge' && this.getUnlockedBonusCardCount() < 5;
+        return this.state.gameType === 'challenge' && this.getUnlockedBonusCardCount() <= 10;
     },
 
 
@@ -799,11 +799,12 @@
         if (!this.needsChallengeSafety()) return;
 
         if (mode === 'puzzle') {
+            this.state.tickets += 3;
             return;
         }
 
         if (mode === 'chaos' || mode === 'draft') {
-            this.state.tickets = Math.max(this.state.tickets, 5);
+            this.state.tickets += 5;
             return;
         }
 
@@ -1425,9 +1426,14 @@
             ? GAME_CONSTANTS.MODE_REWARDS[this.state.mode]
             : GAME_CONSTANTS.MODE_REWARDS.default;
 
-        const hasLooterReward = this.battle.players.some(
-            p => p && p.proto && p.proto.trait && p.proto.trait.type === 'looter'
+        const hasLuther = this.battle.players.some(
+            p => p && (p.id === 'doom_luther' || (p.proto && p.proto.role === 'luther'))
         );
+        const hasLooterReward = mode === 'puzzle'
+            ? hasLuther
+            : this.battle.players.some(
+                p => p && p.proto && p.proto.trait && p.proto.trait.type === 'looter'
+            );
         if (hasLooterReward) {
             reward += GAME_CONSTANTS.BONUS_REWARDS.LOOTER;
         }


### PR DESCRIPTION
## Summary
- expand beginner safety to runs with 10 or fewer unlocked bonus cards, add the missing extra 5 tickets in draft/chaos, and grant 3 starting tickets in puzzle challenge runs
- update puzzle-mode ticket sources so only Luther grants looter tickets, remove puzzle-mode ticket payouts from Great Sage Blessing and tutoring gifts, and align the related puzzle UI copy
- rebalance Silent Librarian self-destruct to 600%, make flood mode double field-buff critical damage bonuses, and keep collocation tutoring API options aligned with the actual quiz variant

## Testing
- 
pm run verify

## Notes
- UI copy and reward-flow changes were covered by smoke verification, but I did not do a separate manual browser pass for the updated puzzle/tutoring modal text.