### PR TITLE
refactor: 하드코딩된 상수 분리 및 모듈 주석 정리 (P2)

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -1,3 +1,11 @@
+/**
+ * @file api.js
+ * @module AI_API
+ * @description
+ * Handles all AI interactions (Lumi persona).
+ * Manages prompt construction, API requests (Google Gemini Core/Flash),
+ * content generation, and fallback logic for educational/tutoring scenarios.
+ */
 const LUMI_PERSONA = `# Role: 대현자 루미 (Grand Sage Rumi)
 
 ## 1. 정체성 (Identity)
@@ -79,7 +87,8 @@ const GameAPI = {
         const modelConfig = getLumiModelConfig(options.model);
         // 1. 30% 확률 (30스테이지 이상 시 50%) (The 'Accidental' Event)
         const enableEvent = RPG.global.tutoringEventEnabled !== false;
-        const prob = (RPG.state.enemyScale >= 30) ? 0.5 : 0.3;
+        const config = GAME_CONSTANTS.TUTORING_EVENT;
+        const prob = (RPG.state.enemyScale >= config.STAGE_THRESHOLD) ? config.PROB_HIGH : config.PROB_BASE;
         const isMisunderstandingMode = enableEvent && Math.random() < prob;
 
         let targetInfo = "";

--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -1,7 +1,9 @@
 /**
- * battle_runtime.js — Non-visual battle runtime for Card RPG.
- *
- * Keeps battle state transitions and skill/effect resolution outside index.html
+ * @file battle_runtime.js
+ * @module BattleRuntime
+ * @description
+ * Contains the non-visual battle state machine and turn execution logic.
+ * Keeps battle state transitions and skill/effect resolution separate from UI code
  * while preserving the existing RPG method names and DOM entrypoints.
  */
 
@@ -98,11 +100,11 @@ function buildBattleEnemy(rpg) {
         ? ENDLESS_ENEMY_ROTATION.length
         : ENEMIES.length;
     const cycle = Math.floor(rpg.state.enemyScale / cycleLength);
-    let scale = 1.0 + (cycle * 0.2);
+    let scale = 1.0 + (cycle * GAME_CONSTANTS.ENEMY_SCALING.CYCLE_BONUS);
     if (rpg.state.mode === 'puzzle') {
         scale += (GAME_CONSTANTS.PUZZLE && GAME_CONSTANTS.PUZZLE.ENEMY_SCALE_BONUS) || 0.2;
     } else if ((rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') && ['artifact', 'flood', 'curse'].includes(rpg.state.mode)) {
-        scale = scale * 1.1;
+        scale = scale * GAME_CONSTANTS.ENEMY_SCALING.HARD_MODE_MULT;
     }
     const suppressBossRewards = rpg.state.mode === 'puzzle';
     const enemy = {

--- a/card/data.js
+++ b/card/data.js
@@ -1,9 +1,17 @@
-// Role guide:
-// dealer: pure damage finisher focused on closing fights.
-// balancer: mixed offense/utility that covers multiple situations.
-// buffer: field buff or protection specialist that raises party stability.
-// debuffer: pressure card that stacks status effects or disruption.
-// looter / luther: reward-oriented finisher that helps card acquisition flow.
+/**
+ * @file data.js
+ * @module GameData
+ * @description
+ * Contains static data definitions for cards, enemies, synergy types, and artifacts.
+ * Acts as the read-only dictionary for game content.
+ * 
+ * Role guide:
+ * - dealer: pure damage finisher focused on closing fights.
+ * - balancer: mixed offense/utility that covers multiple situations.
+ * - buffer: field buff or protection specialist that raises party stability.
+ * - debuffer: pressure card that stacks status effects or disruption.
+ * - looter / luther: reward-oriented finisher that helps card acquisition flow.
+ */
 const CARDS = [
     // --- Legend ---
     {

--- a/card/logic.js
+++ b/card/logic.js
@@ -1,13 +1,13 @@
-﻿/**
- * game.js — Game utilities, storage layer, and constants for Card RPG.
- *
+/**
+ * @file logic.js
+ * @module GameLogic
+ * @description
+ * Game utilities, central damage calculation, storage layer, and constants for Card RPG.
  * Provides:
- *   - Storage: Centralized localStorage abstraction with safe JSON parsing
- *   - GAME_CONSTANTS: Named constants replacing magic numbers
- *   - GACHA_RATES: Gacha probability tables per mode
- *   - GameUtils.buildCardPool(): Unified card pool builder (replaces 6 duplicated patterns)
- *   - GameUtils.resolveGachaGrade(): Grade determination from GACHA_RATES table
- *   - GameUtils.getCardById()/getAllCards()/buildDeckContext(): Shared card lookup and Joker-aware deck helpers
+ * - Storage: Centralized localStorage abstraction with safe JSON parsing
+ * - GAME_CONSTANTS: Named constants replacing magic numbers
+ * - Logic: Core calculation engine (Damage, Stats, Death/OnHit traits, SideEffects)
+ * - GameUtils: Deck helpers, pool selection, gacha tables
  */
 
 // ─── Storage Layer ────────────────────────────────────────────────────────────
@@ -160,6 +160,35 @@ window.GAME_CONSTANTS = {
         BONUS_BLESSING_USES: 5,
         ENEMY_SCALE_BONUS: 0.2
     },
+    
+    // Core combat stat constants
+    BASE_CRIT: 10,
+    BASE_EVA_BONUS: 5,
+    BLESSING_CRIT: 10,
+    BLESSING_EVA: 5,
+    
+    // Debuff stat reductions
+    DEBUFF_REDUCTIONS: {
+        ATK: 0.2,      // weak
+        MATK: 0.2,     // silence
+        MDEF: 0.2,     // curse, temptation
+        DEF_BASE: 0.2, // darkness or corrosion
+        DEF_FULL: 0.4  // darkness AND corrosion
+    },
+    
+    // Artifact specific bonus values
+    ARTIFACT_BONUSES: {
+        DARK_DIVINE_GRAY_CRIT: 20,
+        DARK_DIVINE_GRAY_EVA: 10,
+        DARK_VEIL_CRIT: 10,
+        DARK_VEIL_EVA: 10
+    },
+
+    ENEMY_SCALING: {
+        CYCLE_BONUS: 0.2,    // added to scale per cycle
+        HARD_MODE_MULT: 1.1  // multiplied to scale for hard modes
+    },
+
     INITIAL_TICKETS: {
         default: 20,
         suffering: 10,
@@ -180,6 +209,12 @@ window.GAME_CONSTANTS = {
     SAGE_BLESSING_PICK_COUNT: 12,
     DEFAULT_BLESSING_USES: 3,
     MAX_BONUS_POOL_PRESETS: 3,
+
+    TUTORING_EVENT: {
+        PROB_BASE: 0.3,
+        PROB_HIGH: 0.5,
+        STAGE_THRESHOLD: 30
+    },
 
     /** Stack cap configuration for stackable buffs/debuffs */
     STACK_CAP: {
@@ -203,6 +238,8 @@ window.GAME_CONSTANTS = {
     DRAFT: {
         INITIAL_REROLLS: 3
     },
+
+    DREAM_CORRIDOR_MAX_LIVES: 3,
 
     LOADING: {
         MAX_ATTEMPTS: 200,
@@ -1559,14 +1596,14 @@ const Logic = {
             matk: char.matk,
             def: char.def,
             mdef: char.mdef,
-            crit: (char.baseCrit || 10),
-            evasion: (char.baseEva || 0) + 5
+            crit: (char.baseCrit || GAME_CONSTANTS.BASE_CRIT),
+            evasion: (char.baseEva || 0) + GAME_CONSTANTS.BASE_EVA_BONUS
         };
 
         // Blessings
         if (char.blessing) {
-            stats.crit += 10;
-            stats.evasion += 5;
+            stats.crit += GAME_CONSTANTS.BLESSING_CRIT;
+            stats.evasion += GAME_CONSTANTS.BLESSING_EVA;
         }
 
         // Check if character is Player (has proto)
@@ -1583,8 +1620,8 @@ const Logic = {
                 stats.crit += trait.val || 0;
             }
             if (trait.type === 'luna_jasmine_trait' && effectiveFieldBuffs.some(b => b.name === 'goddess_descent')) {
-                stats.evasion += 25;
-                stats.crit += 25;
+                stats.evasion += (trait.val || 25);
+                stats.crit += (trait.val || 25);
             }
         }
 
@@ -1662,15 +1699,15 @@ const Logic = {
         // Char Buffs/Debuffs
         let debuffMult = (mode === 'curse') ? 2.0 : 1.0;
 
-        if (char.buffs['weak']) m.atk -= (0.2 * debuffMult);
-        if (char.buffs['silence']) m.matk -= (0.2 * debuffMult);
+        if (char.buffs['weak']) m.atk -= (GAME_CONSTANTS.DEBUFF_REDUCTIONS.ATK * debuffMult);
+        if (char.buffs['silence']) m.matk -= (GAME_CONSTANTS.DEBUFF_REDUCTIONS.MATK * debuffMult);
         if (char.buffs['evasion']) stats.evasion += 50;
-        if (char.buffs['curse']) m.mdef -= (0.2 * debuffMult);
-        if (char.buffs['temptation']) m.mdef -= (0.2 * debuffMult);
+        if (char.buffs['curse']) m.mdef -= (GAME_CONSTANTS.DEBUFF_REDUCTIONS.MDEF * debuffMult);
+        if (char.buffs['temptation']) m.mdef -= (GAME_CONSTANTS.DEBUFF_REDUCTIONS.MDEF * debuffMult);
 
         let defRed = 0.0;
-        if (char.buffs['darkness'] && char.buffs['corrosion']) defRed = 0.4;
-        else if (char.buffs['darkness'] || char.buffs['corrosion']) defRed = 0.2;
+        if (char.buffs['darkness'] && char.buffs['corrosion']) defRed = GAME_CONSTANTS.DEBUFF_REDUCTIONS.DEF_FULL;
+        else if (char.buffs['darkness'] || char.buffs['corrosion']) defRed = GAME_CONSTANTS.DEBUFF_REDUCTIONS.DEF_BASE;
         // Artifact: assassin_nail — double darkness def reduction
         if (artifacts.includes('assassin_nail') && (char.buffs['darkness'] || char.buffs['corrosion'])) {
             defRed *= 2.0;
@@ -1679,7 +1716,7 @@ const Logic = {
 
         // Artifact: shadow_ball — darkness also reduces mdef
         if (artifacts.includes('shadow_ball') && char.buffs['darkness']) {
-            let mdefRed = 0.2;
+            let mdefRed = GAME_CONSTANTS.DEBUFF_REDUCTIONS.MDEF;
             if (artifacts.includes('assassin_nail')) mdefRed *= 2.0;
             m.mdef -= (mdefRed * debuffMult);
         }
@@ -1687,11 +1724,11 @@ const Logic = {
         // Artifact: veil_of_darkness / divine_gray — dark element crit/eva boost
         if (isPlayer && GameUtils.cardMatchesElement(char.proto, 'dark')) {
             if (artifacts.includes('divine_gray')) {
-                stats.crit += 20;
-                stats.evasion += 10;
+                stats.crit += GAME_CONSTANTS.ARTIFACT_BONUSES.DARK_DIVINE_GRAY_CRIT;
+                stats.evasion += GAME_CONSTANTS.ARTIFACT_BONUSES.DARK_DIVINE_GRAY_EVA;
             } else if (artifacts.includes('veil_of_darkness')) {
-                stats.crit += 10;
-                stats.evasion += 10;
+                stats.crit += GAME_CONSTANTS.ARTIFACT_BONUSES.DARK_VEIL_CRIT;
+                stats.evasion += GAME_CONSTANTS.ARTIFACT_BONUSES.DARK_VEIL_EVA;
             }
         }
 
@@ -2093,10 +2130,10 @@ const Logic = {
     calculateInitialStats: function (playerProto, deck, allCards, idx) {
         // Base stats copy
         let p = {
-            maxHp: playerProto.stats.hp, hp: playerProto.stats.hp, mp: 100,
+            maxHp: playerProto.stats.hp, hp: playerProto.stats.hp, mp: GAME_CONSTANTS.MAX_MP || 100,
             atk: playerProto.stats.atk, matk: playerProto.stats.matk,
             def: playerProto.stats.def, mdef: playerProto.stats.mdef,
-            baseCrit: 10, baseEva: 0
+            baseCrit: GAME_CONSTANTS.BASE_CRIT, baseEva: 0
         };
 
         const deckCtx = GameUtils.buildDeckContext(deck, allCards);

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1,3 +1,14 @@
+/**
+ * @file rpg_features.js
+ * @module RPGFeatures
+ * @description
+ * Contains the core UI and logic for all RPG out-of-battle features.
+ * Responsibilities include:
+ * - Managing specific game modes (Endless, Chaos, Draft, Dream Corridor)
+ * - Handling events, shops, gacha, and inventory/deck management UI
+ * - Mission progression and rewards processing
+ * - Central state loop (menu navigation)
+ */
 (function () {
     const SPECIAL_CARD_GROUPS = [
         { baseId: 'jasmine', label: '자스민' },
@@ -1317,7 +1328,7 @@
             return this.showAlert("이미 덱이 완성되어 있습니다. 전투에 진입하세요.");
         }
 
-        if (!this.state.draft) this.state.draft = { active: true, round: 0, rerolls: 3, currentOptions: [] };
+        if (!this.state.draft) this.state.draft = { active: true, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] };
 
         // Find first empty slot
         this.state.draft.round = this.state.deck.indexOf(null);
@@ -1552,7 +1563,8 @@
 
         const fail = (label) => {
             // 현재 목숨 확인 (기본값 3)
-            const current = (this.state.dreamCorridorLives !== undefined) ? this.state.dreamCorridorLives : 3;
+            const maxLives = GAME_CONSTANTS.DREAM_CORRIDOR_MAX_LIVES;
+            const current = (this.state.dreamCorridorLives !== undefined) ? this.state.dreamCorridorLives : maxLives;
             const remaining = current - 1;
             this.state.dreamCorridorLives = remaining;
 
@@ -1561,15 +1573,15 @@
 
             if (remaining <= 0) {
                 // 목숨 소진 → 런 실패
-                this.failDreamCorridorRun(`${label}에서 오답이 발생해 꿈의회랑이 종료되었습니다.<br>(오답 3회 소진)`);
+                this.failDreamCorridorRun(`${label}에서 오답이 발생해 꿈의회랑이 종료되었습니다.<br>(오답 ${maxLives}회 소진)`);
             } else {
                 // 목숨 차감 후 계속 진행 안내
-                const hearts = '❤️'.repeat(remaining) + '🖤'.repeat(3 - remaining);
+                const hearts = '❤️'.repeat(remaining) + '🖤'.repeat(maxLives - remaining);
                 this.openInfoModal(
                     '꿈의회랑 ─ 오답',
                     `${label}에서 오답이 발생했습니다.<br><br>` +
                     `남은 기회: ${hearts}<br><br>` +
-                    `(3회 오답 시 이 런은 실패 처리됩니다.)`,
+                    `(${maxLives}회 오답 시 이 런은 실패 처리됩니다.)`,
                     () => this.toMenu()
                 );
             }


### PR DESCRIPTION
- [#1-4] 기본 치명타(10), 추가 회피(5) -> GAME_CONSTANTS.BASE_CRIT, BASE_EVA_BONUS 추출
- [#1-5] 축복 보너스 -> GAME_CONSTANTS.BLESSING_CRIT, BLESSING_EVA 추출
- [#1-6] 자스민 특성 수치 -> trait.val(기본 25)을 사용하도록 수정
- [#1-7] 디버프 방어력 감소치(0.2, 0.4) -> GAME_CONSTANTS.DEBUFF_REDUCTIONS 테이블화
- [#1-8] 어둠 아티팩트 보너스 -> GAME_CONSTANTS.ARTIFACT_BONUSES 구조체화
- [#1-9] 초기스탯 calculateInitialStats 하드코딩 상수 연동
- [#1-11] draft rerolls(3) -> GAME_CONSTANTS.DRAFT.INITIAL_REROLLS
- [#1-12] 꿈의회랑 목숨(3) -> GAME_CONSTANTS.DREAM_CORRIDOR_MAX_LIVES
- [#1-13, #1-14] 적 스케일링 공식 상수 배율 분리 (ENEMY_SCALING)
- [#1-15] 루미 튜터링 이벤트 확률 상수화 (TUTORING_EVENT)
- [문서화] api.js, data.js, logic.js, battle_runtime.js, rpg_features.js 최상단 JSDoc 모듈 주석 작성