### PR TITLE
fix: 코드 리뷰 지적 2건 수정 (P3)

### DIFF
--- a/card/logic.js
+++ b/card/logic.js
@@ -2185,6 +2185,11 @@ const Logic = {
             }
         }
 
+        // Legacy positional trait — pos_rear_atk (rear = idx 2)
+        if (t.type === 'pos_rear_atk' && idx === 2) {
+            p.atk = Math.floor(p.atk * (1 + (t.val || 0) / 100));
+        }
+
         if (t.type === 'rabbit_synergy_boost') {
             const count = deckCtx.countMatchingIds(['night_rabbit', 'snow_rabbit', 'silver_rabbit', 'trans_yeon_rabbit']);
             if (count > 0) {
@@ -2366,7 +2371,7 @@ const Logic = {
      */
     _applyDeathDamage: function (result, victim, killer, skillPartial, fieldBuffs, logFn, deck, turn, artifacts, logPrefix) {
         const skill = { ...skillPartial, effects: skillPartial.effects || [] };
-        const dmgResult = this.calculateDamage(victim, killer, skill, fieldBuffs, [], logFn, null, deck, turn);
+        const dmgResult = this.calculateDamage(victim, killer, skill, fieldBuffs, [], logFn, null, deck, turn, artifacts);
         if (artifacts.includes('companion')) {
             dmgResult.dmg *= 2;
             logFn(`[아티팩트] 길동무: ${skill.name} 대미지 2배!`);


### PR DESCRIPTION
- [지적1] _applyDeathDamage → calculateDamage 호출 시 artifacts 인자 누락 수정 사망 반격 대미지 계산에서 demon_iris, lucky_vicky, death_roulette 등 아티팩트 효과가 반영되지 않던 버그 수정

- [지적2] 레거시 pos_rear_atk trait 핸들러 복원 데이터(웨어베어)에 pos_rear_atk 트레이트가 존재하나 calculateInitialStats에서 pos_stat_boost만 처리하고 있어 대장 배치 시 공격력 30% 증가가 적용되지 않던 문제 수정