### PR TITLE
fix: luna_jasmine_trait 치명타/회피 25%→2% 급감 버그 수정 및 collocation fallback…

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1860,7 +1860,7 @@
 
                 const quizList = (Array.isArray(data.quizzes) && data.quizzes.length > 0)
                     ? data.quizzes
-                    : [{ question: data.question, options: data.options, answer: data.answer, translation: data.translation }];
+                    : [{ question: data.question, options: data.options || [], answer: data.answer, translation: data.translation }];
                 if (quizList.length === 0) return null;
                 return quizList[Math.floor(Math.random() * quizList.length)];
             },

--- a/card/logic.js
+++ b/card/logic.js
@@ -1620,8 +1620,8 @@ const Logic = {
                 stats.crit += trait.val || 0;
             }
             if (trait.type === 'luna_jasmine_trait' && effectiveFieldBuffs.some(b => b.name === 'goddess_descent')) {
-                stats.evasion += (trait.val || 25);
-                stats.crit += (trait.val || 25);
+                stats.evasion += 25;
+                stats.crit += 25;
             }
         }
 


### PR DESCRIPTION
… 보강 (P4)

- [BUG-1] luna_jasmine_trait 회피/크리 보너스 복원 P2에서 25 → (trait.val || 25)로 변경했으나 trait.val=2.0(디바인 배율용)이므로 여신강림 회피/크리가 25% → 2%로 급감. 원래 하드코딩 25로 복원.

- [BUG-2] resolveCollocationTutoringQuiz fallback에 options || [] 추가 data.options가 undefined일 때 [...q.options]에서 TypeError 발생 방지.

- [검증-기각] _applyDeathDamage의 mode=null / activeTraits=[] 전달 건 리팩토링 전 원본 코드도 동일한 호출 패턴이므로 기존 동작. 변경 시 curse 모드 등에서 사망 반격 밸런스가 파괴되어 수정 불가.