### PR TITLE
Increase model token limits, scope flash-lite checks to specific model, and reduce Silent Librarian death damage

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -190,7 +190,7 @@ const GameAPI = {
                 contents: [{ parts: [{ text: fullPrompt }] }],
                 generationConfig: {
                     temperature: isMisunderstandingMode ? 0.65 : 0.4,
-                    maxOutputTokens: isMisunderstandingMode ? 8192 : 4096,
+                    maxOutputTokens: isMisunderstandingMode ? 12288 : 6144,
                     thinkingConfig: buildThinkingConfig(modelConfig, 'high')
                 },
                 safetySettings: [
@@ -297,7 +297,7 @@ function buildThinkingConfig(modelConfig, thinkingLevel = 'high') {
     }
 
     return {
-        thinkingLevel: normalizeThinkingLevel(modelConfig && modelConfig.flashLike && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
+        thinkingLevel: normalizeThinkingLevel(modelConfig && modelConfig.id === 'gemini-3.1-flash-lite-preview' && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
     };
 }
 
@@ -838,7 +838,7 @@ const LumiQuestionRuntime = {
         const result = await GameAPI.askLumiQuestion(apiKey, requestHistory, {
             systemInstruction: session.systemInstruction,
             enableSearch: session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
-            thinkingLevel: session.mode === 'toeic-review' && modelConfig.flashLike ? 'medium' : session.thinkingLevel,
+            thinkingLevel: session.mode === 'toeic-review' && modelConfig.id === 'gemini-3.1-flash-lite-preview' ? 'medium' : session.thinkingLevel,
             model: modelConfig.id
         });
 
@@ -977,7 +977,7 @@ const LumiQuestionRuntime = {
                     ? getLumiOrbSystemInstruction(this.searchEnabled)
                     : session.systemInstruction,
                 enableSearch: this.searchEnabled && session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
-                thinkingLevel: session.mode === 'toeic-review' && modelConfig.flashLike ? 'medium' : session.thinkingLevel,
+                thinkingLevel: session.mode === 'toeic-review' && modelConfig.id === 'gemini-3.1-flash-lite-preview' ? 'medium' : session.thinkingLevel,
                 model: modelConfig.id,
                 signal: controller.signal,
                 timeoutMs: 120000

--- a/card/data.js
+++ b/card/data.js
@@ -361,7 +361,7 @@ const CARDS = [
     {
         id: 'silent_librarian', name: '침묵의사서', grade: 'rare', element: 'water', role: 'debuffer',
         stats: { hp: 330, atk: 70, matk: 95, def: 55, mdef: 75 },
-        trait: { type: 'death_dmg_mag', val: 6.0, desc: '사망시 적에게 600% 마법대미지' },
+        trait: { type: 'death_dmg_mag', val: 3.0, desc: '사망시 적에게 300% 마법대미지' },
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
             { name: '사일런트', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] },


### PR DESCRIPTION
### Motivation
- Allow the language model to produce longer outputs in misunderstanding mode and normal mode by increasing token budgets.
- Make thinking-level adjustments deterministic by tying the flash-lite downgrade to the explicit `gemini-3.1-flash-lite-preview` model id instead of the generic `flashLike` flag.
- Balance gameplay by reducing an overly strong death-triggered magic damage on the `silent_librarian` card.

### Description
- Increased `maxOutputTokens` in the generation request from `8192` to `12288` for misunderstanding mode and from `4096` to `6144` otherwise.
- Updated `buildThinkingConfig` to check `modelConfig.id === 'gemini-3.1-flash-lite-preview'` when converting a `'high'` thinking level to `'medium'` instead of using `modelConfig.flashLike`.
- Replaced uses of `modelConfig.flashLike` with an explicit check for `modelConfig.id === 'gemini-3.1-flash-lite-preview'` when selecting `thinkingLevel` in `LumiQuestionRuntime` paths.
- Reduced the `silent_librarian` card trait `death_dmg_mag` value from `6.0` to `3.0` and updated the associated description from `600%` to `300%`.

### Testing
- Ran unit tests with `npm test` and all tests passed.
- Ran the linter with `npm run lint` and no lint errors were reported.
- Performed a build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2fff9874832284089cdcfe0a4394)