### PR TITLE
feat: 보너스 카드 10종 추가 + releaseDate 시간 게이팅 시스템

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -172,11 +172,16 @@ function buildBattlePlayer(rpg, cardId, idx, allCards) {
             mdef: player.mdef
         };
 
-        player.maxHp = Math.floor(player.maxHp * (1 + blessing.multiplier));
+        // 앤트로피: 혼돈의 축복 효과 2배
+        let blessingMult = blessing.multiplier;
+        const hasEntropy = rpg.state.deck && rpg.state.deck.includes('entropy');
+        if (hasEntropy) blessingMult *= 2;
+
+        player.maxHp = Math.floor(player.maxHp * (1 + blessingMult));
         player.hp = player.maxHp;
         player.blessing = blessing;
 
-        const mult = 1.0 + blessing.multiplier;
+        const mult = 1.0 + blessingMult;
         player.atk = Math.floor(player.atk * mult);
         player.matk = Math.floor(player.matk * mult);
         player.def = Math.floor(player.def * mult);

--- a/card/data.js
+++ b/card/data.js
@@ -304,7 +304,7 @@ const CARDS = [
         trait: { type: 'syn_nature_3_golem', val: 30, desc: '덱에 자연 3장 이상 시 공격력/방어력 30% 증가' },
         skills: [
             { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
-            { name: '차지어택', type: 'phy', tier: 2, cost: 20, val: 2.5, desc: '다음턴 휴식 (대지의축복 시 2배)', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] },
+            { name: '차지어택', type: 'phy', tier: 2, cost: 20, val: 3.0, desc: '다음턴 휴식 (대지의축복 시 2배)', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }, { type: 'dmg_boost', condition: 'field_buff', buff: 'earth_bless', mult: 2.0 }] },
             { name: '록스매시', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '약화 부여', effects: [{ type: 'debuff', id: 'weak' }] }
         ]
     },
@@ -971,6 +971,108 @@ const BONUS_CARD_EXPANSION = [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '흑조의속삭임', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '물리 2배율, 적에게 암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] },
             { name: '운명의무도', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 달의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.0 }] }
+        ]
+    },
+
+    // ─── June 2026 Bonus Card Wave ──────────────────────────────────────────────
+    {
+        id: 'prism_twin', name: '프리즘트윈', grade: 'rare', element: 'light', role: 'balancer', unlockSource: 'bonus', releaseDate: '2026-06-01',
+        stats: { hp: 340, atk: 75, matk: 85, def: 60, mdef: 65 },
+        trait: { type: 'self_normal_atk_dmg_boost', val: 2.0, desc: '이 카드의 일반공격 대미지 2배' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '프리즘셔플', type: 'mag', tier: 2, cost: 20, val: 2.5, desc: '모든 필드버프를 랜덤 교체', effects: [{ type: 'roulette_field' }] },
+            { name: '일루미네이션', type: 'mag', tier: 3, cost: 30, val: 3.0, desc: '3턴 뒤 발동, 발동 시 랜덤 필드버프 부여', effects: [{ type: 'delayed_attack_random_field', turns: 3 }] }
+        ]
+    },
+    {
+        id: 'underdog', name: '언더독', grade: 'normal', element: 'nature', role: 'dealer', unlockSource: 'hidden', releaseDate: '2026-06-01',
+        stats: { hp: 310, atk: 80, matk: 70, def: 55, mdef: 60 },
+        trait: { type: 'cond_grade_count_leader_boost', gradeRequired: 'normal', countRequired: 3, pos: 2, stat: ['atk', 'matk'], val: 100, desc: '덱에 일반등급이 3장 이상이고 대장 배치 시 공격력/마법공격력 100% 증가' },
+        skills: [
+            { name: '퍼펙트머슬', type: 'sup', tier: 3, cost: 30, desc: '3턴간 받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 3 }] },
+            { name: '빅쇼', type: 'sup', tier: 2, cost: 20, desc: '필드버프 아레나 부여', effects: [{ type: 'field_buff', id: 'arena' }] },
+            { name: '기가크러셔', type: 'mag', tier: 3, cost: 30, val: 4.0, desc: '마법 4배율, 다음 턴 행동 불가', effects: [{ type: 'self_debuff', id: 'stun', duration: 1 }] }
+        ]
+    },
+    {
+        id: 'sugar_powder', name: '슈가파우더', grade: 'normal', element: 'light', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-06-01',
+        stats: { hp: 310, atk: 70, matk: 70, def: 50, mdef: 45 },
+        trait: { type: 'dessert_kingdom_crit_eva_boost', val: 20, desc: '디저트킹덤 카드 전체 치명타율/회피율 20% 증가' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '그랜드케이크', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '스타파우더 소모 시 대미지 3배', effects: [{ type: 'consume_field_buff_dmg', buff: 'star_powder', mult: 3.0 }] },
+            { name: '캔디메테오', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '트윙클파티 소모 시 대미지 3배', effects: [{ type: 'consume_field_buff_dmg', buff: 'twinkle_party', mult: 3.0 }] }
+        ]
+    },
+    {
+        id: 'skull_dragon', name: '스컬드래곤', grade: 'rare', element: 'dark', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-06-01',
+        stats: { hp: 355, atk: 110, matk: 70, def: 60, mdef: 55 },
+        trait: { type: 'leader_self_atk_party_def_down', atkBoost: 100, defDown: 50, desc: '대장 배치 시 자기 공격력 100% 증가, 덱 전체 방어력/마법방어력 50% 감소' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '드래곤크로', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] },
+            { name: '스컬브레스', type: 'mag', tier: 3, cost: 30, val: 5.0, desc: '현재 생명력 30% 감소', effects: [{ type: 'self_hp_cost_ratio', ratio: 0.3 }] }
+        ]
+    },
+    {
+        id: 'dragon_miko', name: '용혈의무녀', grade: 'epic', element: 'fire', role: 'balancer', unlockSource: 'bonus', releaseDate: '2026-06-01',
+        stats: { hp: 395, atk: 80, matk: 95, def: 65, mdef: 70 },
+        trait: { type: 'death_dmg_mag_stun_cond', val: 5.0, condition: 'deck_has_dragon', desc: '덱에 드래곤이 존재할 경우 사망 시 500% 마법대미지와 기절 부여' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '스파클', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '필드버프 트윙클파티 부여, 작열 부여', effects: [{ type: 'field_buff', id: 'twinkle_party' }, { type: 'debuff', id: 'burn', stack: 1 }] },
+            { name: '버닝스피릿', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
+        ]
+    },
+    {
+        id: 'perfect_aurora', name: '퍼펙트아우로라', grade: 'legend', element: 'water', role: 'debuffer', unlockSource: 'bonus', releaseDate: '2026-06-01',
+        stats: { hp: 500, atk: 90, matk: 130, def: 75, mdef: 85 },
+        trait: { type: 'field_buff_immune', desc: '이 카드는 필드버프를 받지 않는다' },
+        skills: [
+            { name: '진실의거울', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '물리 2배율, 상대의 물리공격 무효화', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '허실의거울', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 상대의 마법공격 무효화', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '퍼펙트플랜', type: 'mag', tier: 3, cost: 30, val: 4.0, desc: '3턴 뒤 발동, 발동 시 약화/부식/침묵/저주/기절 부여', effects: [{ type: 'delayed_attack_debuffs', turns: 3, debuffs: ['weak', 'corrosion', 'silence', 'curse', 'stun'] }] }
+        ]
+    },
+    {
+        id: 'flare_ribbon', name: '플레어리본', grade: 'normal', element: 'fire', role: 'buffer', unlockSource: 'hidden', releaseDate: '2026-06-01',
+        stats: { hp: 325, atk: 55, matk: 60, def: 55, mdef: 50 },
+        trait: { type: 'cond_same_grade_skill_buff', skillName: '리듬하이', buff: 'sun_bless', desc: '덱 전체가 같은 등급일 경우 리듬하이 발동 시 태양의축복 추가 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '리듬하이', type: 'sup', tier: 3, cost: 30, desc: '필드버프 트윙클파티 부여', effects: [{ type: 'field_buff', id: 'twinkle_party' }] },
+            { name: '스파클래쉬', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율', effects: [] }
+        ]
+    },
+    {
+        id: 'entropy', name: '앤트로피', grade: 'rare', element: 'nature', role: 'dealer', unlockSource: 'hidden', releaseDate: '2026-06-01',
+        stats: { hp: 340, atk: 105, matk: 105, def: 50, mdef: 50 },
+        trait: { type: 'chaos_blessing_double', desc: '혼돈의 축복 효과가 2배로 적용된다' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '노바레퀴엠', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '필드버프를 전부 제거하고 제거한 수 x2.0 만큼 위력 증가', effects: [{ type: 'consume_field_all', multPerStack: 2.0 }] },
+            { name: '화이트노이즈', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '적 디버프 1개당 배율 1.0 증가, 사용 후 적 디버프 해제', effects: [{ type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: 1.0 }, { type: 'clear_target_debuffs' }] }
+        ]
+    },
+    {
+        id: 'tinker_bell', name: '팅커벨', grade: 'rare', element: 'light', role: 'debuffer', unlockSource: 'bonus', releaseDate: '2026-06-01',
+        stats: { hp: 345, atk: 60, matk: 100, def: 55, mdef: 65 },
+        trait: { type: 'death_dmg_mag_stun_same_grade', val: 5.0, desc: '덱 전체가 같은 등급일 경우 사망 시 500% 마법대미지와 기절 부여' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '픽시더스트', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '디바인, 저주 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'curse' }] },
+            { name: '네버랜드', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '디바인, 침묵 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }, { type: 'debuff', id: 'silence' }] }
+        ]
+    },
+    {
+        id: 'gumiho', name: '구미호', grade: 'epic', element: 'dark', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-06-01',
+        stats: { hp: 390, atk: 70, matk: 105, def: 70, mdef: 70 },
+        trait: { type: 'cond_same_grade_matk_boost', val: 100, desc: '덱 전체가 같은 등급일 경우 마법공격력 100% 증가' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '여우불', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '암흑 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'darkness', mult: 2.0 }] },
+            { name: '요화천벌', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '작열/디바인 전부 소모, 소모한 스택당 1.0배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 1.0 }, { type: 'consume_debuff_all', debuff: 'divine', multPerStack: 1.0 }] }
         ]
     }
 

--- a/card/logic.js
+++ b/card/logic.js
@@ -2209,7 +2209,7 @@ const Logic = {
         }
 
         if (t.type === 'dessert_kingdom_synergy_boost') {
-            const count = Math.max(0, deckCtx.countMatchingIds(['candy_boy', 'marshmallow', 'cotton_candy_sheep', 'cream_maid', 'pudding_princess', 'harmonius']) - 1);
+            const count = Math.max(0, deckCtx.countMatchingIds(['candy_boy', 'marshmallow', 'cotton_candy_sheep', 'cream_maid', 'pudding_princess', 'harmonius', 'sugar_powder']) - 1);
             if (count > 0) {
                 const boost = count * (t.val / 100);
                 p.atk = Math.floor(p.atk * (1 + boost));
@@ -2255,7 +2255,7 @@ const Logic = {
         // Artifact: dragon_heart — dragon cards matk +100%
         const artifacts = (typeof RPG !== 'undefined' && RPG.state && RPG.state.artifacts) ? RPG.state.artifacts : [];
         if (artifacts.includes('dragon_heart')) {
-            const dragonIds = ['baby_dragon', 'red_dragon', 'gold_dragon', 'ancient_dragon'];
+            const dragonIds = ['baby_dragon', 'red_dragon', 'gold_dragon', 'ancient_dragon', 'skull_dragon'];
             if (GameUtils.cardMatchesAnyId(playerProto, dragonIds)) {
                 p.matk = Math.floor(p.matk * 2.0);
             }

--- a/card/logic.js
+++ b/card/logic.js
@@ -900,7 +900,9 @@ const DELAYED_SKILL_EFFECT_TYPES = [
     'delayed_turn_scale_attack',
     'delayed_attack_debuff_scale',
     'delayed_random_unique_field_buffs',
-    'phantom_nightmare'
+    'phantom_nightmare',
+    'delayed_attack_random_field',
+    'delayed_attack_debuffs'
 ];
 
 function findDelayedSkillEffect(skill) {
@@ -944,6 +946,30 @@ function buildResolvedDelayedSkill(skill, delayedEff, currentTurn) {
                     mult: delayedEff.darknessMult || 2.0,
                     customLog: '[악몽] 암흑 상태의 적에게 대미지 2배!'
                 }
+            ]
+        };
+    }
+
+    // delayed_attack_random_field — 일루미네이션 (프리즘트윈): resolve to attack + random field buff
+    if (delayedEff.type === 'delayed_attack_random_field') {
+        return {
+            ...skill,
+            isDelayed: true,
+            effects: [
+                ...(skill.effects || []).filter(effect => effect !== delayedEff),
+                { type: 'random_field_buff' }
+            ]
+        };
+    }
+
+    // delayed_attack_debuffs — 퍼펙트플랜 (퍼펙트아우로라): resolve to attack + multi debuffs
+    if (delayedEff.type === 'delayed_attack_debuffs') {
+        return {
+            ...skill,
+            isDelayed: true,
+            effects: [
+                ...(skill.effects || []).filter(effect => effect !== delayedEff),
+                ...delayedEff.debuffs.map(d => ({ type: 'debuff', id: d, stack: 1 }))
             ]
         };
     }
@@ -1260,6 +1286,22 @@ const SideEffects = {
                 options.expireLog = eff.expireLog || null;
             }
             ctx.applyFieldBuff(eff.id, options);
+
+            // 플레어리본: 같은 등급 덱일 때 특정 스킬 사용 시 추가 필드버프
+            const sourceTrait = ctx.source && ctx.source.proto && ctx.source.proto.trait;
+            if (sourceTrait && sourceTrait.type === 'cond_same_grade_skill_buff') {
+                if (ctx.skill && ctx.skill.name === sourceTrait.skillName) {
+                    const deckCards = (ctx.deck || []).filter(Boolean).map(cardId => {
+                        const allCards = [...CARDS, ...BONUS_CARDS];
+                        return allCards.find(c => c.id === cardId);
+                    }).filter(Boolean);
+                    const grades = deckCards.map(c => c.grade);
+                    if (grades.length > 0 && grades.every(g => g === grades[0])) {
+                        ctx.applyFieldBuff(sourceTrait.buff);
+                        ctx.logFn(`[특성] ${ctx.source.name}: 같은 등급 덱 조건 달성! [${getBuffName(sourceTrait.buff)}] 추가 부여!`);
+                    }
+                }
+            }
         },
         'heal_ratio': (ctx, eff) => {
             const ratio = eff.ratio || eff.val || 0;
@@ -1464,6 +1506,12 @@ const SideEffects = {
         },
         'delayed_attack_field': (ctx, eff) => {
             if (eff.field) ctx.applyFieldBuff(eff.field);
+        },
+        'delayed_attack_random_field': (ctx, eff) => {
+            // handled via buildResolvedDelayedSkill → random_field_buff
+        },
+        'delayed_attack_debuffs': (ctx, eff) => {
+            // handled via buildResolvedDelayedSkill → debuff effects
         },
         'delayed_turn_scale_attack': (ctx, eff) => {
             const resolvedSkill = buildResolvedDelayedSkill(ctx.skill, eff, ctx.battle.turn);
@@ -1868,6 +1916,12 @@ const Logic = {
                 mult *= source.normalAttackPartyMult;
                 logFn(`[특성] 일반공격 강화! x${source.normalAttackPartyMult.toFixed(1)}`);
             }
+            // 프리즘트윈: 이 카드의 일반공격 대미지 배수
+            if (source.proto && source.proto.trait && source.proto.trait.type === 'self_normal_atk_dmg_boost') {
+                const selfMult = source.proto.trait.val || 2.0;
+                mult *= selfMult;
+                logFn(`[특성] ${source.name}: 일반공격 대미지 x${selfMult.toFixed(1)}!`);
+            }
         }
 
         // Trait Multipliers
@@ -2170,6 +2224,11 @@ const Logic = {
             active = true;
         }
 
+        // 프리즘트윈/앤트로피: 패시브 특성 활성화 표시
+        if (t.type === 'self_normal_atk_dmg_boost' || t.type === 'chaos_blessing_double') {
+            active = true;
+        }
+
         // Positional Traits (Generalized)
         if (t.type === 'pos_stat_boost' && idx !== undefined) {
             if (t.pos === idx) {
@@ -2217,6 +2276,39 @@ const Logic = {
             }
         }
 
+        // 언더독: 덱에 일반등급 3장 이상 + 대장 배치 시 공격/마공 증가
+        if (t.type === 'cond_grade_count_leader_boost' && idx !== undefined) {
+            const gradeCount = deckCtx.cards.filter(c => c && c.grade === (t.gradeRequired || 'normal')).length;
+            if (gradeCount >= (t.countRequired || 3) && idx === (t.pos !== undefined ? t.pos : 2)) {
+                active = true;
+                const stats = Array.isArray(t.stat) ? t.stat : [t.stat];
+                const boost = 1 + (t.val || 0) / 100;
+                stats.forEach(s => {
+                    if (s === 'atk') p.atk = Math.floor(p.atk * boost);
+                    if (s === 'matk') p.matk = Math.floor(p.matk * boost);
+                    if (s === 'def') p.def = Math.floor(p.def * boost);
+                    if (s === 'mdef') p.mdef = Math.floor(p.mdef * boost);
+                });
+            }
+        }
+
+        // 구미호: 덱 전체가 같은 등급일 때 마공 증가
+        if (t.type === 'cond_same_grade_matk_boost') {
+            const grades = deckCtx.cards.map(c => c ? c.grade : null).filter(Boolean);
+            if (grades.length > 0 && grades.every(g => g === grades[0])) {
+                active = true;
+                p.matk = Math.floor(p.matk * (1 + (t.val || 0) / 100));
+            }
+        }
+
+        // 스컬드래곤: 대장 배치 시 자기 공격력 증가, 덱 전체 방어/마방 감소
+        if (t.type === 'leader_self_atk_party_def_down' && idx !== undefined) {
+            if (idx === 2) {
+                active = true;
+                p.atk = Math.floor(p.atk * (1 + (t.atkBoost || 100) / 100));
+            }
+        }
+
         // Party-wide Stat Boost Traits (Event)
         const partyBoost = { atk: 0, matk: 0, def: 0, mdef: 0, crit: 0 };
         activeCards.forEach((c, cardIdx) => {
@@ -2244,6 +2336,11 @@ const Logic = {
             else if (tr && tr.type === 'mid_party_mdef_boost' && cardIdx === 1) {
                 partyBoost.mdef += (tr.val || 0);
             }
+            // 스컬드래곤: 대장 배치 시 덱 전체 방어/마방 감소
+            else if (tr && tr.type === 'leader_self_atk_party_def_down' && cardIdx === 2) {
+                partyBoost.def -= (tr.defDown || 50);
+                partyBoost.mdef -= (tr.defDown || 50);
+            }
         });
 
         if (partyBoost.atk) p.atk = Math.floor(p.atk * (1 + partyBoost.atk / 100));
@@ -2251,6 +2348,15 @@ const Logic = {
         if (partyBoost.def) p.def = Math.floor(p.def * (1 + partyBoost.def / 100));
         if (partyBoost.mdef) p.mdef = Math.floor(p.mdef * (1 + partyBoost.mdef / 100));
         if (partyBoost.crit) p.baseCrit += partyBoost.crit;
+
+        // 슈가파우더: 디저트킹덤 전체 치명타/회피율 증가
+        const dessertKingdomIds = ['candy_boy', 'marshmallow', 'cotton_candy_sheep', 'cream_maid', 'pudding_princess', 'harmonius', 'sugar_powder'];
+        const dessertBoostTrait = activeCards.find(c => c.trait && c.trait.type === 'dessert_kingdom_crit_eva_boost');
+        if (dessertBoostTrait && dessertKingdomIds.includes(playerProto.id)) {
+            const boostVal = dessertBoostTrait.trait.val || 20;
+            p.baseCrit += boostVal;
+            p.baseEva += boostVal;
+        }
 
         // Artifact: dragon_heart — dragon cards matk +100%
         const artifacts = (typeof RPG !== 'undefined' && RPG.state && RPG.state.artifacts) ? RPG.state.artifacts : [];
@@ -2465,6 +2571,37 @@ const Logic = {
         else if (t.type === 'death_twinkle') {
             result.fieldBuffsToAdd.push('twinkle_party');
             logFn(`[특성] 헬하운드 사망! 트윙클 파티 발동!`);
+        }
+        // 용혈의무녀: 덱에 드래곤 있을 때 사망 시 마법대미지 + 기절
+        else if (t.type === 'death_dmg_mag_stun_cond') {
+            const dragonIds = ['baby_dragon', 'red_dragon', 'gold_dragon', 'ancient_dragon', 'skull_dragon', 'dragon_miko'];
+            const hasDragon = deck && deck.some(cardId => {
+                if (!cardId || cardId === victim.proto.id) return false;
+                return dragonIds.includes(cardId);
+            });
+            if (hasDragon) {
+                this._applyDeathDamage(result, victim, killer, { name: '용혈의 사망 반격', type: 'mag', val: t.val }, fieldBuffs, logFn, deck, turn, artifacts, '[특성] 용혈의무녀: 드래곤의 힘으로 사망 반격!');
+                if (killer) {
+                    result.killerDebuffs['stun'] = (result.killerDebuffs['stun'] || 0) + 1;
+                    logFn('[특성] 용혈의무녀: 적에게 기절 부여!');
+                }
+            }
+        }
+        // 팅커벨: 덱 전부 같은 등급일 때 사망 시 마법대미지 + 기절
+        else if (t.type === 'death_dmg_mag_stun_same_grade') {
+            const deckCards = (deck || []).filter(Boolean).map(cardId => {
+                const allCards = [...CARDS, ...BONUS_CARDS];
+                return allCards.find(c => c.id === cardId);
+            }).filter(Boolean);
+            const grades = deckCards.map(c => c.grade);
+            const allSameGrade = grades.length > 0 && grades.every(g => g === grades[0]);
+            if (allSameGrade) {
+                this._applyDeathDamage(result, victim, killer, { name: '요정의 사망 반격', type: 'mag', val: t.val }, fieldBuffs, logFn, deck, turn, artifacts, '[특성] 팅커벨: 같은 등급 덱의 힘으로 사망 반격!');
+                if (killer) {
+                    result.killerDebuffs['stun'] = (result.killerDebuffs['stun'] || 0) + 1;
+                    logFn('[특성] 팅커벨: 적에게 기절 부여!');
+                }
+            }
         }
 
         // ─── Artifact Death Effects ─────────────────────────────

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -448,11 +448,26 @@
     },
 
 
-    getStandardBonusCards() {
+    getAllStandardBonusCards() {
         if (typeof GameUtils !== 'undefined' && typeof GameUtils.getBonusCards === 'function') {
             return GameUtils.getBonusCards().filter(card => card.unlockSource !== 'hidden');
         }
         return BONUS_CARDS.filter(card => card.unlockSource !== 'hidden');
+    },
+
+
+    getReleasedStandardBonusCards() {
+        const today = new Date();
+        const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+        return this.getAllStandardBonusCards().filter(card => {
+            if (!card.releaseDate) return true;
+            return card.releaseDate <= todayStr;
+        });
+    },
+
+
+    getStandardBonusCards() {
+        return this.getReleasedStandardBonusCards();
     },
 
 


### PR DESCRIPTION
## 변경 요약

### 신규 보너스 카드 10종 (6월 1일 공개)

| 카드 | ID | 등급 | 속성 | 분류 |
|------|-----|------|------|------|
| 프리즘트윈 | prism_twin | 레어 | 빛 | 일반 보너스 |
| 언더독 | underdog | 일반 | 자연 | 히든보너스 |
| 슈가파우더 | sugar_powder | 일반 | 빛 | 일반 보너스 |
| 스컬드래곤 | skull_dragon | 레어 | 어둠 | 일반 보너스 |
| 용혈의무녀 | dragon_miko | 에픽 | 화염 | 일반 보너스 |
| 퍼펙트아우로라 | perfect_aurora | 전설 | 물 | 일반 보너스 |
| 플레어리본 | flare_ribbon | 일반 | 불 | 히든보너스 |
| 앤트로피 | entropy | 레어 | 자연 | 히든보너스 |
| 팅커벨 | tinker_bell | 레어 | 빛 | 일반 보너스 |
| 구미호 | gumiho | 에픽 | 어둠 | 일반 보너스 |

### releaseDate 시스템

- 보너스 카드에 `releaseDate` 필드 추가 (예: `2026-06-01`)
- `getAllStandardBonusCards()`: 모든 일반 보너스 카드 (미래 포함)
- `getReleasedStandardBonusCards()`: 현재 날짜 기준 공개된 카드만
- `getStandardBonusCards()`: released 카드만 반환 (하위 호환)
- 챌린지 클리어 보상, `checkAllBonusUnlocked()` 자동 적용

### 기타 변경
- 골렘 차지어택 배율 2.5 → 3.0 상향
- 디저트킹덤 ID 목록에 `sugar_powder` 추가
- 드래곤하트 ID 목록에 `skull_dragon` 추가

### 후속 PR 필요사항
새로운 trait type들의 전투 로직 구현 (별도 PR):
- 복합 사망 특성 (death_dmg_mag_stun_cond, death_dmg_mag_stun_same_grade)
- 같은 등급 조건 (cond_same_grade_matk_boost, cond_same_grade_skill_buff)
- 등급별 카운트 조건 (cond_grade_count_leader_boost)
- 혼돈의 축복 2배 (chaos_blessing_double)
- 디저트킹덤 치명타/회피율 증가 (dessert_kingdom_crit_eva_boost)
- 대장 배치 복합 특성 (leader_self_atk_party_def_down)
- 지연 공격 + 디버프 (delayed_attack_debuffs, delayed_attack_random_field)
- 개별 일반공격 강화 (self_normal_atk_dmg_boost)