### PR TITLE
feat: use specific wrong collocation details for API tutoring context

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -106,9 +106,16 @@ const GameAPI = {
             if (collocationOptions.length > 0) {
                 targetInfo += `\nOptions: [${collocationOptions.join(', ')}]`;
             }
+            if (targetData.wrongSelected) {
+                targetInfo += `\nUser's Incorrect Choice: '${targetData.wrongSelected}'`;
+            }
             targetInfo += `\n\n**[숙어 연상법 규칙]**`;
             targetInfo += `\n- 왜 이 단어들의 조합이 이 의미가 되는지 의미적 연결을 설명하십시오. (예: 'conduct a survey' → conduct는 '이끌다/수행하다'의 뉘앙스 → 설문조사를 '주도해서 진행'하는 이미지)`;
-            targetInfo += `\n- 틀린 보기 단어와 비교하여, 왜 정답 단어만 이 명사와 어울리는지 직관적으로 설명하십시오.`;
+            if (targetData.wrongSelected) {
+                targetInfo += `\n- 틀린 보기 단어와 비교하여, 왜 정답 단어만 이 명사와 어울리는지 직관적으로 설명하십시오. (특히 형아가 고른 오답 '${targetData.wrongSelected}'이 왜 어색한지 반드시 짚어주십시오.)`;
+            } else {
+                targetInfo += `\n- 틀린 보기 단어와 비교하여, 왜 정답 단어만 이 명사와 어울리는지 직관적으로 설명하십시오.`;
+            }
             targetInfo += `\n- 딱딱한 사전적 설명보다, '이 조합을 들으면 떠오르는 장면'을 묘사하여 기억에 남기십시오.`;
         } else {
             targetInfo = `Target Word: '${targetData.word}' (Meaning: ${targetData.meaning})`;

--- a/card/index.html
+++ b/card/index.html
@@ -1823,8 +1823,20 @@
                     options: [...q.options],
                     answer: q.answer,
                     onCorrect: () => callback(true),
-                    onWrong: () => {
+                    onWrong: (chosenText) => {
                         if (!RPG.state.wrongCollocations) RPG.state.wrongCollocations = [];
+                        if (!RPG.state.wrongCollocationDetails) RPG.state.wrongCollocationDetails = {};
+
+                        RPG.state.wrongCollocationDetails[q.parentId] = {
+                            question: q.question,
+                            options: q.options,
+                            answer: q.answer,
+                            translation: q.translation,
+                            wrongSelected: chosenText,
+                            timestamp: Date.now()
+                        };
+                        Storage.save(Storage.keys.COLLOCATION_DETAILS, RPG.state.wrongCollocationDetails);
+
                         if (!RPG.state.wrongCollocations.includes(q.parentId)) {
                             RPG.state.wrongCollocations.push(q.parentId);
                             Storage.save(Storage.keys.COLLOCATION, RPG.state.wrongCollocations);
@@ -4307,6 +4319,10 @@
                     if (isCollocation) {
                         this.state.wrongCollocations = this.state.wrongCollocations.filter(id => id !== targetId);
                         Storage.save(Storage.keys.COLLOCATION, this.state.wrongCollocations);
+                        if (this.state.wrongCollocationDetails && this.state.wrongCollocationDetails[targetId]) {
+                            delete this.state.wrongCollocationDetails[targetId];
+                            Storage.save(Storage.keys.COLLOCATION_DETAILS, this.state.wrongCollocationDetails);
+                        }
                     } else {
                         this.state.wrongWords = this.state.wrongWords.filter(w => w !== targetId);
                         Storage.save(Storage.keys.VOCAB, this.state.wrongWords);
@@ -4316,7 +4332,12 @@
 
                 let tutoringData = targetData;
                 if (isCollocation) {
-                    const selectedQuiz = QuizEngine.resolveCollocationTutoringQuiz(targetData);
+                    let selectedQuiz = null;
+                    if (this.state.wrongCollocationDetails && this.state.wrongCollocationDetails[targetData.id]) {
+                        selectedQuiz = this.state.wrongCollocationDetails[targetData.id];
+                    } else {
+                        selectedQuiz = QuizEngine.resolveCollocationTutoringQuiz(targetData);
+                    }
                     const selectedOptions = selectedQuiz && Array.isArray(selectedQuiz.options) ? [...selectedQuiz.options] : [];
                     tutoringData = {
                         ...targetData,
@@ -4324,6 +4345,7 @@
                         options: selectedOptions,
                         answer: selectedQuiz ? selectedQuiz.answer : targetData.answer,
                         translation: selectedQuiz ? selectedQuiz.translation : targetData.translation,
+                        wrongSelected: selectedQuiz ? selectedQuiz.wrongSelected : null,
                         selectedQuiz: selectedQuiz ? { ...selectedQuiz, options: selectedOptions } : null
                     };
                 }
@@ -4394,6 +4416,10 @@
                     if (item.type === 'collocation') {
                         this.state.wrongCollocations = this.state.wrongCollocations.filter(id => id !== data.id);
                         Storage.save(Storage.keys.COLLOCATION, this.state.wrongCollocations);
+                        if (this.state.wrongCollocationDetails && this.state.wrongCollocationDetails[data.id]) {
+                            delete this.state.wrongCollocationDetails[data.id];
+                            Storage.save(Storage.keys.COLLOCATION_DETAILS, this.state.wrongCollocationDetails);
+                        }
                     } else {
                         this.state.wrongWords = this.state.wrongWords.filter(w => w !== data.word);
                         Storage.save(Storage.keys.VOCAB, this.state.wrongWords);

--- a/card/logic.js
+++ b/card/logic.js
@@ -18,6 +18,7 @@ const Storage = {
         GLOBAL: 'cardRpgGlobal',
         VOCAB: 'cardRpgVocab',
         COLLOCATION: 'cardRpgCollocation',
+        COLLOCATION_DETAILS: 'cardRpgCollocationDetails',
         API_KEY: 'cardRpgApiKey',
         RECORDS: 'cardRpgRecords'
     },

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -55,6 +55,9 @@
 
         const col = Storage.load(Storage.keys.COLLOCATION);
         if (col) this.state.wrongCollocations = col;
+
+        const colDetails = Storage.load(Storage.keys.COLLOCATION_DETAILS);
+        if (colDetails) this.state.wrongCollocationDetails = colDetails;
     },
 
 
@@ -62,6 +65,9 @@
         Storage.save(Storage.keys.VOCAB, this.state.wrongWords || []);
         if (this.state.wrongCollocations) {
             Storage.save(Storage.keys.COLLOCATION, this.state.wrongCollocations);
+        }
+        if (this.state.wrongCollocationDetails) {
+            Storage.save(Storage.keys.COLLOCATION_DETAILS, this.state.wrongCollocationDetails);
         }
     },
 


### PR DESCRIPTION
데이터 저장 방식 최적화 (logic.js, rpg_features.js): 기존의 배열 구조(wrongCollocations)를 전혀 건드리지 않아서 세이브 파일 오염 확률을 원천 차단했습니다! 대신에 COLLOCATION_DETAILS라는 별도 키를 마련해서 세부 오답 데이터를 저장하고 관리하도록 했습니다.
세부 오답 기록 로직 추가 (index.html): 형아가 퀴즈에서 오답을 선택하면, 실제 문제의 내용과 형아가 고른 보기(chosenText)를 함께 저장하고, 퀴즈를 마치거나 정리할 때 해당 찌꺼기 데이터가 알아서 지워지도록 했습니다.
루미 맞춤 프롬프트 주입 (api.js): 루미에게 정보를 넘길 때, wrongSelected 항목을 포함시켰습니다. 이제 프롬프트는 "형아가 고른 오답이 왜 정답에 비해 문맥상/의미상 어색한지 반드시 짚어주십시오"라고 명확히 지시합니다.