### PR TITLE
feat: 토끼 시즌 변주 12종 추가 (발렌타인/할로윈/수영복/크리스마스)

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -909,6 +909,27 @@ const BattleRuntime = {
             rpg.log("[특성] 세이렌의 노래! 트윙클파티 추가!");
             BattleRuntime.applyFieldBuff(rpg, 'twinkle_party');
         }
+
+        // 토끼 발렌타인 시너지: 스킬 사용시 발렌타인 필드버프 발동
+        if (rpg.battle.activeTraits.includes('syn_rabbit_valentine_snow') && skill.name === '소다키스') {
+            rpg.log('[특성] 눈토끼(발렌타인): 발렌타인 발동!');
+            BattleRuntime.applyFieldBuff(rpg, 'valentine');
+        }
+        if (rpg.battle.activeTraits.includes('syn_rabbit_valentine_night') && skill.name === '딥키스') {
+            rpg.log('[특성] 밤토끼(발렌타인): 발렌타인 발동!');
+            BattleRuntime.applyFieldBuff(rpg, 'valentine');
+        }
+        if (rpg.battle.activeTraits.includes('syn_rabbit_valentine_silver') && skill.name === '화이트키스') {
+            rpg.log('[특성] 은토끼(발렌타인): 발렌타인 발동!');
+            BattleRuntime.applyFieldBuff(rpg, 'valentine');
+        }
+
+        // 크리스마스 은토끼: 특성 발동시 울트라기프트에 성역+달의축복 추가
+        if (rpg.battle.activeTraits.includes('christmas_rabbit_trio_gift') && skill.name === '울트라기프트') {
+            rpg.log('[특성] 은토끼(크리스마스): 성역과 달의축복 추가 발동!');
+            BattleRuntime.applyFieldBuff(rpg, 'sanctuary');
+            BattleRuntime.applyFieldBuff(rpg, 'moon_bless');
+        }
     },
 
     expireFieldBuffs(rpg, turn) {

--- a/card/data.js
+++ b/card/data.js
@@ -1093,7 +1093,20 @@ const SPECIAL_CARD_VARIANTS = [
     { id: 'rumi_halloween', name: '루미(할로윈)', baseCardId: 'rumi', specialSeason: 'halloween' },
     { id: 'luna_christmas', name: '루나(크리스마스)', baseCardId: 'luna', specialSeason: 'christmas' },
     { id: 'jasmine_christmas', name: '자스민(크리스마스)', baseCardId: 'jasmine', specialSeason: 'christmas' },
-    { id: 'rumi_christmas', name: '루미(크리스마스)', baseCardId: 'rumi', specialSeason: 'christmas' }
+    { id: 'rumi_christmas', name: '루미(크리스마스)', baseCardId: 'rumi', specialSeason: 'christmas' },
+    // --- 토끼 시즌 변주 ---
+    { id: 'snow_rabbit_valentine', name: '눈토끼(발렌타인)', baseCardId: 'snow_rabbit', specialSeason: 'valentine' },
+    { id: 'night_rabbit_valentine', name: '밤토끼(발렌타인)', baseCardId: 'night_rabbit', specialSeason: 'valentine' },
+    { id: 'silver_rabbit_valentine', name: '은토끼(발렌타인)', baseCardId: 'silver_rabbit', specialSeason: 'valentine' },
+    { id: 'snow_rabbit_halloween', name: '눈토끼(할로윈)', baseCardId: 'snow_rabbit', specialSeason: 'halloween' },
+    { id: 'night_rabbit_halloween', name: '밤토끼(할로윈)', baseCardId: 'night_rabbit', specialSeason: 'halloween' },
+    { id: 'silver_rabbit_halloween', name: '은토끼(할로윈)', baseCardId: 'silver_rabbit', specialSeason: 'halloween' },
+    { id: 'snow_rabbit_swimsuit', name: '눈토끼(수영복)', baseCardId: 'snow_rabbit', specialSeason: 'beach' },
+    { id: 'night_rabbit_swimsuit', name: '밤토끼(수영복)', baseCardId: 'night_rabbit', specialSeason: 'beach' },
+    { id: 'silver_rabbit_swimsuit', name: '은토끼(수영복)', baseCardId: 'silver_rabbit', specialSeason: 'beach' },
+    { id: 'snow_rabbit_christmas', name: '눈토끼(크리스마스)', baseCardId: 'snow_rabbit', specialSeason: 'christmas' },
+    { id: 'night_rabbit_christmas', name: '밤토끼(크리스마스)', baseCardId: 'night_rabbit', specialSeason: 'christmas' },
+    { id: 'silver_rabbit_christmas', name: '은토끼(크리스마스)', baseCardId: 'silver_rabbit', specialSeason: 'christmas' }
 ];
 
 function cloneData(value) {
@@ -1274,6 +1287,103 @@ const SPECIAL_CARD_OVERRIDES = {
                     { type: 'consume_debuff_all', debuff: 'divine', multPerStack: 1.5 }
                 ]
             }
+        ]
+    }),
+    // --- 토끼 발렌타인 변주 (페어 조건부 발렌타인 필드버프, 스탯 그대로) ---
+    'snow_rabbit_valentine': card => ({
+        ...card,
+        trait: { type: 'syn_rabbit_valentine_snow', desc: '밤토끼 혹은 은토끼가 덱에 있을 경우 소다키스 사용시 발렌타인 발동' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '소다키스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율', effects: [] },
+            cloneSkillByName(card, '실버스톰')
+        ]
+    }),
+    'night_rabbit_valentine': card => ({
+        ...card,
+        trait: { type: 'syn_rabbit_valentine_night', desc: '눈토끼 혹은 은토끼가 덱에 있을 경우 딥키스 사용시 발렌타인 발동' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '딥키스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율', effects: [] },
+            cloneSkillByName(card, '문라이트')
+        ]
+    }),
+    'silver_rabbit_valentine': card => ({
+        ...card,
+        trait: { type: 'syn_rabbit_valentine_silver', desc: '눈토끼 혹은 밤토끼가 덱에 있을 경우 화이트키스 사용시 발렌타인 발동' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '화이트키스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율', effects: [] },
+            cloneSkillByName(card, '헤븐리루어')
+        ]
+    }),
+    // --- 토끼 할로윈 변주 (선봉 배치시 페어 토끼 강화, 스킬/스탯 그대로) ---
+    'snow_rabbit_halloween': card => ({
+        ...card,
+        trait: { type: 'halloween_rabbit_peer_boost', peerIds: ['night_rabbit', 'silver_rabbit'], stat: ['matk', 'mdef'], val: 50, desc: '선봉 배치시 덱의 밤토끼/은토끼 마공·마방 50% 증가' }
+    }),
+    'night_rabbit_halloween': card => ({
+        ...card,
+        trait: { type: 'halloween_rabbit_peer_boost', peerIds: ['snow_rabbit', 'silver_rabbit'], stat: ['atk', 'def'], val: 50, desc: '선봉 배치시 덱의 눈토끼/은토끼 물공·물방 50% 증가' }
+    }),
+    'silver_rabbit_halloween': card => ({
+        ...card,
+        trait: { type: 'halloween_rabbit_peer_boost', peerIds: ['snow_rabbit', 'night_rabbit'], stat: ['atk', 'matk'], val: 50, desc: '선봉 배치시 덱의 눈토끼/밤토끼 물공·마공 50% 증가' }
+    }),
+    // --- 토끼 수영복 변주 (강력한 디버프, 배리어 유지) ---
+    'snow_rabbit_swimsuit': card => ({
+        ...card,
+        trait: { type: 'syn_night_rabbit', val: 50, desc: '밤토끼 혹은 은토끼가 덱에 있을시 마공 마방 50% 증가' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '콜드스플래시', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
+            { name: '서머판타지', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 유혹 부여', effects: [{ type: 'debuff', id: 'temptation' }] }
+        ]
+    }),
+    'night_rabbit_swimsuit': card => ({
+        ...card,
+        trait: { type: 'syn_snow_rabbit', val: 50, desc: '눈토끼 혹은 은토끼가 덱에 있을시 물공 물방 50% 증가' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '미드나잇다이빙', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '물리 2.5배율, 암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] },
+            { name: '루나세레나데', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 유혹 부여', effects: [{ type: 'debuff', id: 'temptation' }] }
+        ]
+    }),
+    'silver_rabbit_swimsuit': card => ({
+        ...card,
+        trait: { type: 'syn_silver_rabbit', val: 50, desc: '눈토끼 혹은 밤토끼가 덱에 있을시 물공 마공 50% 증가' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '실버서핑', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '물리 2.5배율, 침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] },
+            { name: '선샤인로맨스', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 유혹 부여', effects: [{ type: 'debuff', id: 'temptation' }] }
+        ]
+    }),
+    // --- 토끼 크리스마스 변주 (3장 조합 궁극 시너지) ---
+    'snow_rabbit_christmas': card => ({
+        ...card,
+        trait: { type: 'christmas_rabbit_trio', requiredPeers: ['night_rabbit', 'silver_rabbit'], stat: ['atk', 'matk', 'def', 'mdef'], val: 50, desc: '밤토끼와 은토끼가 모두 덱에 있으면 물공/마공/물방/마방 50% 증가' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '울트라판타지', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 특성 발동시 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'synergy_active', trait: 'christmas_rabbit_trio', mult: 2.0 }] },
+            cloneSkillByName(card, '실버스톰')
+        ]
+    }),
+    'night_rabbit_christmas': card => ({
+        ...card,
+        trait: { type: 'christmas_rabbit_trio_crit', requiredPeers: ['snow_rabbit', 'silver_rabbit'], val: 20, desc: '눈토끼와 은토끼가 모두 덱에 있으면 덱 전체 치명타 20% 증가' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '울트라바이올렛', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 특성 발동시 약화·침묵·저주 부여', effects: [{ type: 'conditional_debuff_on_synergy', trait: 'christmas_rabbit_trio_crit', debuffs: ['weak', 'silence', 'curse'] }] },
+            cloneSkillByName(card, '문라이트')
+        ]
+    }),
+    'silver_rabbit_christmas': card => ({
+        ...card,
+        trait: { type: 'christmas_rabbit_trio_gift', requiredPeers: ['snow_rabbit', 'night_rabbit'], desc: '눈토끼와 밤토끼가 모두 덱에 있으면 울트라기프트 사용시 성역+달의축복 추가 발동' },
+        skills: [
+            cloneSkillByName(card, '배리어'),
+            { name: '울트라기프트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 필드버프 스타파우더 부여', effects: [{ type: 'field_buff', id: 'star_powder' }] },
+            cloneSkillByName(card, '헤븐리루어')
         ]
     })
 };

--- a/card/logic.js
+++ b/card/logic.js
@@ -1600,6 +1600,13 @@ const SideEffects = {
             ctx.applyFieldBuff(pick);
             ctx.logFn(`코스믹 하모니: [${getBuffName(pick)}] 생성!`);
         },
+        'conditional_debuff_on_synergy': (ctx, eff) => {
+            if (!ctx.activeTraits || !ctx.activeTraits.includes(eff.trait)) return;
+            (eff.debuffs || []).forEach(id => {
+                ctx.target.buffs[id] = 1;
+                ctx.logFn(`[특성] ${getBuffName(id)} 부여!`);
+            });
+        },
         'dream_form_execute': (ctx, eff) => {
             if (ctx.battle.fieldBuffs.length > 0) {
                 let logMsg = [];
@@ -2180,7 +2187,13 @@ const Logic = {
         'syn_water_light_midnight_twinkle':{ cond: d => d.hasElement('water') && d.hasElement('light'), apply: () => {} },
         'syn_light_3_party_def_mdef':      { cond: d => d.countElement('light') >= 3,             apply: () => {} },
         'syn_nature_3_party_def_mdef':     { cond: d => d.countElement('nature') >= 3,            apply: () => {} },
-        'syn_dark_full_party_crit':        { cond: d => d.countElement('dark') >= 3,              apply: (p, t) => { p.baseCrit += t.val; } }
+        'syn_dark_full_party_crit':        { cond: d => d.countElement('dark') >= 3,              apply: (p, t) => { p.baseCrit += t.val; } },
+        // 토끼 발렌타인 시너지 (발동 시 효과 없음, activeTraits 등록용)
+        'syn_rabbit_valentine_snow':   { cond: d => d.hasAnyCard(['night_rabbit', 'silver_rabbit']), apply: () => {} },
+        'syn_rabbit_valentine_night':  { cond: d => d.hasAnyCard(['snow_rabbit', 'silver_rabbit']),  apply: () => {} },
+        'syn_rabbit_valentine_silver': { cond: d => d.hasAnyCard(['snow_rabbit', 'night_rabbit']),   apply: () => {} },
+        // 토끼 크리스마스 은토끼 시너지 (울트라기프트 추가 필드버프 트리거용)
+        'christmas_rabbit_trio_gift':  { cond: d => d.hasCard('snow_rabbit') && d.hasCard('night_rabbit'), apply: () => {} }
     },
 
     calculateInitialStats: function (playerProto, deck, allCards, idx) {
@@ -2311,7 +2324,32 @@ const Logic = {
             }
         }
 
+        // 크리스마스 토끼 3장 조합 시너지
+        if (t.type === 'christmas_rabbit_trio' && t.requiredPeers) {
+            if (t.requiredPeers.every(id => deckCtx.hasCard(id))) {
+                active = true;
+                const stats = Array.isArray(t.stat) ? t.stat : [t.stat];
+                const boost = 1 + (t.val || 0) / 100;
+                stats.forEach(s => {
+                    if (s === 'atk') p.atk *= boost;
+                    if (s === 'matk') p.matk *= boost;
+                    if (s === 'def') p.def *= boost;
+                    if (s === 'mdef') p.mdef *= boost;
+                });
+                p.atk = Math.floor(p.atk); p.matk = Math.floor(p.matk);
+                p.def = Math.floor(p.def); p.mdef = Math.floor(p.mdef);
+            }
+        }
+
+        // 크리스마스 밤토끼: 3장 조합시 파티 전체 치명타 증가
+        if (t.type === 'christmas_rabbit_trio_crit' && t.requiredPeers) {
+            if (t.requiredPeers.every(id => deckCtx.hasCard(id))) {
+                active = true;
+            }
+        }
+
         // Party-wide Stat Boost Traits (Event)
+        const peerBoosts = {}; // { [playerIdx]: { atk, matk, def, mdef } }
         const partyBoost = { atk: 0, matk: 0, def: 0, mdef: 0, crit: 0 };
         activeCards.forEach((c, cardIdx) => {
             const tr = c.trait;
@@ -2343,6 +2381,25 @@ const Logic = {
                 partyBoost.def -= (tr.defDown || 50);
                 partyBoost.mdef -= (tr.defDown || 50);
             }
+            // 크리스마스 밤토끼: 3장 조합시 파티 전체 치명타 증가
+            else if (tr && tr.type === 'christmas_rabbit_trio_crit' && tr.requiredPeers) {
+                if (tr.requiredPeers.every(id => deckCtx.hasCard(id))) {
+                    partyBoost.crit += (tr.val || 0);
+                }
+            }
+            // 할로윈 토끼: 선봉(idx 0)일 때 특정 페어 토끼 스탯 증가
+            else if (tr && tr.type === 'halloween_rabbit_peer_boost' && cardIdx === 0) {
+                const peerIds = tr.peerIds || [];
+                const boostStats = Array.isArray(tr.stat) ? tr.stat : [tr.stat];
+                const boostVal = tr.val || 0;
+                activeCards.forEach((tc, ti) => {
+                    if (ti === cardIdx || !tc) return;
+                    if (GameUtils.cardMatchesAnyId(tc, peerIds)) {
+                        if (!peerBoosts[ti]) peerBoosts[ti] = { atk: 0, matk: 0, def: 0, mdef: 0 };
+                        boostStats.forEach(s => { if (peerBoosts[ti][s] !== undefined) peerBoosts[ti][s] += boostVal; });
+                    }
+                });
+            }
         });
 
         if (partyBoost.atk) p.atk = Math.floor(p.atk * (1 + partyBoost.atk / 100));
@@ -2350,6 +2407,23 @@ const Logic = {
         if (partyBoost.def) p.def = Math.floor(p.def * (1 + partyBoost.def / 100));
         if (partyBoost.mdef) p.mdef = Math.floor(p.mdef * (1 + partyBoost.mdef / 100));
         if (partyBoost.crit) p.baseCrit += partyBoost.crit;
+
+        // 할로윈 토끼 peer boost 적용
+        const myPeerBoost = peerBoosts[idx];
+        if (myPeerBoost) {
+            if (myPeerBoost.atk) p.atk = Math.floor(p.atk * (1 + myPeerBoost.atk / 100));
+            if (myPeerBoost.matk) p.matk = Math.floor(p.matk * (1 + myPeerBoost.matk / 100));
+            if (myPeerBoost.def) p.def = Math.floor(p.def * (1 + myPeerBoost.def / 100));
+            if (myPeerBoost.mdef) p.mdef = Math.floor(p.mdef * (1 + myPeerBoost.mdef / 100));
+        }
+
+        // 할로윈 토끼 특성 활성화 표시 (선봉이고 페어가 존재할 때)
+        if (t.type === 'halloween_rabbit_peer_boost' && idx === 0) {
+            const peerIds = t.peerIds || [];
+            if (activeCards.some((c, ci) => ci !== 0 && GameUtils.cardMatchesAnyId(c, peerIds))) {
+                active = true;
+            }
+        }
 
         // 슈가파우더: 디저트킹덤 전체 치명타/회피율 증가
         const dessertKingdomIds = ['candy_boy', 'marshmallow', 'cotton_candy_sheep', 'cream_maid', 'pudding_princess', 'harmonius', 'sugar_powder'];

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -14,7 +14,10 @@
         { baseId: 'jasmine', label: '자스민' },
         { baseId: 'rumi', label: '루미' },
         { baseId: 'luna', label: '루나' },
-        { baseId: 'zeke', label: '지크' }
+        { baseId: 'zeke', label: '지크' },
+        { baseId: 'snow_rabbit', label: '눈토끼' },
+        { baseId: 'night_rabbit', label: '밤토끼' },
+        { baseId: 'silver_rabbit', label: '은토끼' }
     ];
 
     const SPECIAL_MISSION_SEASONS = {
@@ -23,28 +26,32 @@
             title: '스페셜미션(발렌타인)',
             bossId: 'flora_valentine',
             bossName: '플로라(발렌타인)',
-            rewardCardIds: ['luna_valentine', 'jasmine_valentine', 'rumi_valentine']
+            rewardCardIds: ['luna_valentine', 'jasmine_valentine', 'rumi_valentine',
+                            'snow_rabbit_valentine', 'night_rabbit_valentine', 'silver_rabbit_valentine']
         },
         beach: {
             id: 'beach',
             title: '스페셜미션(해변)',
             bossId: 'thor_swimsuit',
             bossName: '토르(수영복)',
-            rewardCardIds: ['jasmine_swimsuit', 'rumi_swimsuit', 'zeke_swimsuit']
+            rewardCardIds: ['jasmine_swimsuit', 'rumi_swimsuit', 'zeke_swimsuit',
+                            'snow_rabbit_swimsuit', 'night_rabbit_swimsuit', 'silver_rabbit_swimsuit']
         },
         halloween: {
             id: 'halloween',
             title: '스페셜미션(할로윈)',
             bossId: 'ares_halloween',
             bossName: '아레스(할로윈)',
-            rewardCardIds: ['luna_halloween', 'zeke_halloween', 'rumi_halloween']
+            rewardCardIds: ['luna_halloween', 'zeke_halloween', 'rumi_halloween',
+                            'snow_rabbit_halloween', 'night_rabbit_halloween', 'silver_rabbit_halloween']
         },
         christmas: {
             id: 'christmas',
             title: '스페셜미션(크리스마스)',
             bossId: 'astea_christmas',
             bossName: '아스테아(크리스마스)',
-            rewardCardIds: ['luna_christmas', 'jasmine_christmas', 'rumi_christmas']
+            rewardCardIds: ['luna_christmas', 'jasmine_christmas', 'rumi_christmas',
+                            'snow_rabbit_christmas', 'night_rabbit_christmas', 'silver_rabbit_christmas']
         }
     };
 
@@ -301,9 +308,21 @@
         const season = SPECIAL_MISSION_SEASONS[seasonId];
         if (!season) return [];
 
+        // 토끼 변주는 2027-01-01 이후에만 보상 풀에 포함
+        const RABBIT_RELEASE_DATE = '2027-01-01';
+        const today = new Date();
+        const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+        const rabbitVariantIds = new Set([
+            'snow_rabbit_valentine', 'night_rabbit_valentine', 'silver_rabbit_valentine',
+            'snow_rabbit_halloween', 'night_rabbit_halloween', 'silver_rabbit_halloween',
+            'snow_rabbit_swimsuit', 'night_rabbit_swimsuit', 'silver_rabbit_swimsuit',
+            'snow_rabbit_christmas', 'night_rabbit_christmas', 'silver_rabbit_christmas'
+        ]);
+
         const unlocked = new Set(this.global.unlocked_special_cards || []);
         return season.rewardCardIds
             .filter(id => !unlocked.has(id))
+            .filter(id => !rabbitVariantIds.has(id) || todayStr >= RABBIT_RELEASE_DATE)
             .map(id => this.getCardData(id))
             .filter(Boolean);
     },


### PR DESCRIPTION
## 개요
눈토끼, 밤토끼, 은토끼의 4개 시즌 변주(발렌타인/할로윈/수영복/크리스마스) 총 12종을 스페셜 카드로 추가합니다.

## 변경 사항

### data.js
- SPECIAL_CARD_VARIANTS에 12종 메타데이터 등록
- SPECIAL_CARD_OVERRIDES에 각 카드별 스탯/스킬/특성 오버라이드
  - 발렌타인: 페어 조건부 발렌타인 필드버프 (2.5배율 마법스킬)
  - 할로윈: 선봉 배치시 페어 토끼 스탯 버프 (스킬 유지)
  - 수영복: 강력한 디버프 + 배리어 (범용 노멀)
  - 크리스마스: 3장 조합 궁극 시너지

### logic.js
- _SYNERGY_TABLE: 발렌타인/크리스마스 시너지 조건 등록
- calculateInitialStats: 할로윈 peer buff, 크리스마스 3장 올스탯/치명타 시너지
- SideEffects: conditional_debuff_on_synergy 신규 핸들러

### battle_runtime.js
- applySkillEffects: 발렌타인 3종 + 크리스마스 은토끼 필드버프 트리거

### rpg_features.js
- SPECIAL_CARD_GROUPS: 눈토끼/밤토끼/은토끼 그룹 추가
- SPECIAL_MISSION_SEASONS: 각 시즌 보상풀에 토끼 변주 ID 추가
- getRemainingSpecialRewardCards: 2027-01-01 날짜 게이트 필터

## 해금 조건
- 2027년 1월 1일 이전: 기존 스페셜 카드만 보상풀에 포함
- 2027년 1월 1일 이후: 토끼 변주가 보상풀에 추가되어 획득 가능