### PR TITLE
Fix Christmas Rabbit trait ID to trigger synergy correctly

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -925,7 +925,7 @@ const BattleRuntime = {
         }
 
         // 크리스마스 은토끼: 특성 발동시 울트라기프트에 성역+달의축복 추가
-        if (rpg.battle.activeTraits.includes('christmas_rabbit_trio_gift') && skill.name === '울트라기프트') {
+        if (rpg.battle.activeTraits.includes('syn_christmas_rabbit_trio_gift') && skill.name === '울트라기프트') {
             rpg.log('[특성] 은토끼(크리스마스): 성역과 달의축복 추가 발동!');
             BattleRuntime.applyFieldBuff(rpg, 'sanctuary');
             BattleRuntime.applyFieldBuff(rpg, 'moon_bless');

--- a/card/data.js
+++ b/card/data.js
@@ -1379,7 +1379,7 @@ const SPECIAL_CARD_OVERRIDES = {
     }),
     'silver_rabbit_christmas': card => ({
         ...card,
-        trait: { type: 'christmas_rabbit_trio_gift', requiredPeers: ['snow_rabbit', 'night_rabbit'], desc: '눈토끼와 밤토끼가 모두 덱에 있으면 울트라기프트 사용시 성역+달의축복 추가 발동' },
+        trait: { type: 'syn_christmas_rabbit_trio_gift', requiredPeers: ['snow_rabbit', 'night_rabbit'], desc: '눈토끼와 밤토끼가 모두 덱에 있으면 울트라기프트 사용시 성역+달의축복 추가 발동' },
         skills: [
             cloneSkillByName(card, '배리어'),
             { name: '울트라기프트', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 필드버프 스타파우더 부여', effects: [{ type: 'field_buff', id: 'star_powder' }] },

--- a/card/logic.js
+++ b/card/logic.js
@@ -2193,7 +2193,7 @@ const Logic = {
         'syn_rabbit_valentine_night':  { cond: d => d.hasAnyCard(['snow_rabbit', 'silver_rabbit']),  apply: () => {} },
         'syn_rabbit_valentine_silver': { cond: d => d.hasAnyCard(['snow_rabbit', 'night_rabbit']),   apply: () => {} },
         // 토끼 크리스마스 은토끼 시너지 (울트라기프트 추가 필드버프 트리거용)
-        'christmas_rabbit_trio_gift':  { cond: d => d.hasCard('snow_rabbit') && d.hasCard('night_rabbit'), apply: () => {} }
+        'syn_christmas_rabbit_trio_gift':  { cond: d => d.hasCard('snow_rabbit') && d.hasCard('night_rabbit'), apply: () => {} }
     },
 
     calculateInitialStats: function (playerProto, deck, allCards, idx) {


### PR DESCRIPTION
Updated the trait ID for the Silver Rabbit (Christmas) card from `christmas_rabbit_trio_gift` to `syn_christmas_rabbit_trio_gift` in `card/data.js`, `card/logic.js`, and `card/battle_runtime.js` so that the game logic engine evaluates and triggers the synergy buff correctly.

---
*PR created automatically by Jules for task [5199164132516052248](https://jules.google.com/task/5199164132516052248) started by @romarin0325-cell*