### PR TITLE
Fix duplicate battle resolution and stage skipping bug

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -238,6 +238,7 @@ const BattleRuntime = {
         rpg.battle.turn = 1;
         rpg.battle.currentPlayerIdx = 0;
         rpg.battle.isNewTurn = true;
+        rpg.battle.isFinished = false;
 
         while (
             rpg.battle.currentPlayerIdx < GAME_CONSTANTS.DECK_SIZE &&
@@ -666,6 +667,9 @@ const BattleRuntime = {
     },
 
     executeSkill(rpg, source, target, skill, isDelayed = false) {
+        if (rpg.battle && rpg.battle.isFinished) return;
+        if (!target || target.hp <= 0 || !source || source.isDead) return;
+
         if (!isDelayed && !skill.isDelayed) {
             if (rpg.hasArtifact('blue_moon') && Math.random() < 0.3) {
                 rpg.log('[아티팩트] 블루문: 마나 소비 없이 스킬 사용!');

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1466,6 +1466,9 @@
 
 
     winBattle() {
+        if (this.battle && this.battle.isFinished) return;
+        if (this.battle) this.battle.isFinished = true;
+
         let transMsg = this.cleanupTranscendenceCards();
         let deadMsg = this.handlePermadeath(this.battle.players);
         if (transMsg) deadMsg += transMsg;
@@ -1674,6 +1677,9 @@
 
 
     loseBattle() {
+        if (this.battle && this.battle.isFinished) return;
+        if (this.battle) this.battle.isFinished = true;
+
         let transMsg = this.cleanupTranscendenceCards();
         // No saveRecord here (User request: only on New Game)
 


### PR DESCRIPTION
This commit fixes a bug where rapidly clicking skill buttons or specific card loop combos (e.g. Time Mage + Phantom) caused the battle to end multiple times, inadvertently skipping the next stage (by incrementing `enemyScale` twice). A simple boolean lock, `isFinished`, has been added to block additional calls or skills once the battle state has resolved.

---
*PR created automatically by Jules for task [1676960438503790964](https://jules.google.com/task/1676960438503790964) started by @romarin0325-cell*