### PR TITLE
Update Gemini 3.1 Flash Lite model name

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -69,7 +69,7 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
 const LUMI_MODEL_OPTIONS = Object.freeze([
     { id: 'gemini-2.5-pro', label: 'Pro', flashLike: false, allowSearch: true, useThinkingBudget: true },
     { id: 'gemini-3-flash-preview', label: 'Flash', flashLike: true, allowSearch: true },
-    { id: 'gemini-3.1-flash-lite-preview', label: 'Lite', flashLike: true, allowSearch: false }
+    { id: 'gemini-3.1-flash-lite', label: 'Lite', flashLike: true, allowSearch: false }
 ]);
 
 function getLumiModelConfig(modelId) {
@@ -312,7 +312,7 @@ function buildThinkingConfig(modelConfig, thinkingLevel = 'high') {
     }
 
     return {
-        thinkingLevel: normalizeThinkingLevel(modelConfig && modelConfig.id === 'gemini-3.1-flash-lite-preview' && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
+        thinkingLevel: normalizeThinkingLevel(modelConfig && modelConfig.id === 'gemini-3.1-flash-lite' && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
     };
 }
 
@@ -933,7 +933,7 @@ const LumiQuestionRuntime = {
                     ? getLumiOrbSystemInstruction(this.searchEnabled)
                     : session.systemInstruction,
                 enableSearch: this.searchEnabled && session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
-                thinkingLevel: session.mode === 'toeic-review' && modelConfig.id === 'gemini-3.1-flash-lite-preview' ? 'medium' : session.thinkingLevel,
+                thinkingLevel: session.mode === 'toeic-review' && modelConfig.id === 'gemini-3.1-flash-lite' ? 'medium' : session.thinkingLevel,
                 model: modelConfig.id,
                 signal: controller.signal,
                 timeoutMs: 120000
@@ -984,7 +984,7 @@ window.LumiQuestionRuntime = LumiQuestionRuntime;
 // --- Date System ---
 
 const DATE_PRIMARY_MODEL_ID = 'gemini-3-flash-preview';
-const DATE_FALLBACK_MODEL_ID = 'gemini-3.1-flash-lite-preview';
+const DATE_FALLBACK_MODEL_ID = 'gemini-3.1-flash-lite';
 
 const DATE_LUMI_PERSONA = `# Role: 대현자 루미 (Grand Sage Rumi)
 

--- a/card/index.html
+++ b/card/index.html
@@ -5100,7 +5100,7 @@
                 const contentBox = document.getElementById('date-content');
                 if (!contentBox || !dateParams) return;
 
-                const isFallback = modelId === 'gemini-3.1-flash-lite-preview';
+                const isFallback = modelId === 'gemini-3.1-flash-lite';
                 const modelNote = isFallback
                     ? `<br><span style="font-size:0.8rem; color:#81d4fa;">${LumiQuestionRuntime.getModelLabel(modelId)} 모델로 다시 시도 중...</span>`
                     : '';
@@ -5126,7 +5126,7 @@
                 const contentBox = document.getElementById('date-content');
                 if (!contentBox || !dateParams) return false;
 
-                const isFallback = modelId === 'gemini-3.1-flash-lite-preview';
+                const isFallback = modelId === 'gemini-3.1-flash-lite';
                 this.isApiLoading = true;
                 this.updateDateRetryButton({ visible: isFallback, disabled: true });
                 this.setDateLoadingState(dateParams, modelId);
@@ -5190,7 +5190,7 @@
                 const key = this.ensureApiKey('데이트를 다시 시도하려면');
                 if (!key) return this.showAlert("API 키가 없어 데이트를 다시 시도할 수 없습니다.");
 
-                await this.loadDateContent(key, dateParams, 'gemini-3.1-flash-lite-preview');
+                await this.loadDateContent(key, dateParams, 'gemini-3.1-flash-lite');
             },
 
             finishDate() {

--- a/card/index.txt
+++ b/card/index.txt
@@ -5100,7 +5100,7 @@
                 const contentBox = document.getElementById('date-content');
                 if (!contentBox || !dateParams) return;
 
-                const isFallback = modelId === 'gemini-3.1-flash-lite-preview';
+                const isFallback = modelId === 'gemini-3.1-flash-lite';
                 const modelNote = isFallback
                     ? `＜br＞＜span style="font-size:0.8rem; color:#81d4fa;"＞${LumiQuestionRuntime.getModelLabel(modelId)} 모델로 다시 시도 중...＜/span＞`
                     : '';
@@ -5126,7 +5126,7 @@
                 const contentBox = document.getElementById('date-content');
                 if (!contentBox || !dateParams) return false;
 
-                const isFallback = modelId === 'gemini-3.1-flash-lite-preview';
+                const isFallback = modelId === 'gemini-3.1-flash-lite';
                 this.isApiLoading = true;
                 this.updateDateRetryButton({ visible: isFallback, disabled: true });
                 this.setDateLoadingState(dateParams, modelId);
@@ -5190,7 +5190,7 @@
                 const key = this.ensureApiKey('데이트를 다시 시도하려면');
                 if (!key) return this.showAlert("API 키가 없어 데이트를 다시 시도할 수 없습니다.");
 
-                await this.loadDateContent(key, dateParams, 'gemini-3.1-flash-lite-preview');
+                await this.loadDateContent(key, dateParams, 'gemini-3.1-flash-lite');
             },
 
             finishDate() {


### PR DESCRIPTION
Replaces `gemini-3.1-flash-lite-preview` with `gemini-3.1-flash-lite` across the codebase (specifically in `card/api.js`, `card/index.html`, and `card/index.txt`) to switch from the preview endpoint to the stable endpoint as per the patch instructions.

---
*PR created automatically by Jules for task [4570722290806532658](https://jules.google.com/task/4570722290806532658) started by @romarin0325-cell*