### PR TITLE
style: update fortune cookie button styling

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -938,7 +938,7 @@
             <div class="title-screen-actions">
                 <button id="btn-start-new" class="menu-btn" onclick="RPG.startGame('new')" disabled>새로하기</button>
                 <button id="btn-start-load" class="menu-btn" onclick="RPG.startGame('load')" disabled>이어하기</button>
-                <button id="btn-fortune-cookie" class="menu-btn" style="border-color: #ffd700; color: #ffd700;" disabled>🥠 포춘쿠키</button>
+                <button id="btn-fortune-cookie" class="menu-btn" disabled>포춘쿠키</button>
                 <button id="btn-title-question" class="menu-btn" onclick="RPG.openLumiQuestion()"
                     disabled>질문하기</button>
                 <button id="btn-title-mission" class="menu-btn" onclick="RPG.openMissionHub()"


### PR DESCRIPTION
Updated the "Fortune Cookie" button on the main Card RPG screen to match the styling of other buttons by removing its inline styles and emoji.

---
*PR created automatically by Jules for task [1761109395055964332](https://jules.google.com/task/1761109395055964332) started by @romarin0325-cell*