### PR TITLE
Card RPG 날짜 보너스 카드 및 Gemini 모델 업그레이드

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -66,11 +66,26 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
    - [Special Direction]이 없으면 이 항목을 생략하십시오.
 8. **강의 마무리 멘트**`;
 
+const GEMINI_FLASH_MODEL_ID = 'gemini-3.6-flash';
+const GEMINI_FLASH_LITE_MODEL_ID = 'gemini-3.5-flash-lite';
+const GEMINI_GENERATE_CONTENT_ROOT = 'https://generativelanguage.googleapis.com/v1beta/models';
+
 const LUMI_MODEL_OPTIONS = Object.freeze([
-    { id: 'gemini-2.5-pro', label: 'Pro', flashLike: false, allowSearch: true, useThinkingBudget: true },
-    { id: 'gemini-3-flash-preview', label: 'Flash', flashLike: true, allowSearch: true },
-    { id: 'gemini-3.1-flash-lite', label: 'Lite', flashLike: true, allowSearch: false }
+    { id: 'gemini-2.5-pro', label: 'Pro', flashLike: false, allowSearch: true, useThinkingBudget: true, allowSampling: true },
+    { id: GEMINI_FLASH_MODEL_ID, label: 'Flash', flashLike: true, allowSearch: true, allowSampling: false },
+    { id: GEMINI_FLASH_LITE_MODEL_ID, label: 'Lite', flashLike: true, allowSearch: false, allowSampling: false }
 ]);
+
+function getGeminiGenerateContentUrl(modelId) {
+    return `${GEMINI_GENERATE_CONTENT_ROOT}/${encodeURIComponent(modelId)}:generateContent`;
+}
+
+function getGeminiRequestHeaders(apiKey) {
+    return {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey
+    };
+}
 
 function getLumiModelConfig(modelId) {
     return LUMI_MODEL_OPTIONS.find(option => option.id === modelId) || LUMI_MODEL_OPTIONS[0];
@@ -197,17 +212,21 @@ const GameAPI = {
         // 3. 프롬프트 조합
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
+        const generationConfig = {
+            maxOutputTokens: isMisunderstandingMode ? 12288 : 6144,
+            thinkingConfig: buildThinkingConfig(modelConfig, 'high')
+        };
+        if (modelConfig.allowSampling) {
+            generationConfig.temperature = isMisunderstandingMode ? 0.65 : 0.4;
+        }
+
         // 4. API 호출 (flash 기반 high reasoning / BLOCK_NONE 사용)
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelConfig.id}:generateContent?key=${encodeURIComponent(apiKey)}`, {
+        const response = await fetch(getGeminiGenerateContentUrl(modelConfig.id), {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: getGeminiRequestHeaders(apiKey),
             body: JSON.stringify({
                 contents: [{ parts: [{ text: fullPrompt }] }],
-                generationConfig: {
-                    temperature: isMisunderstandingMode ? 0.65 : 0.4,
-                    maxOutputTokens: isMisunderstandingMode ? 12288 : 6144,
-                    thinkingConfig: buildThinkingConfig(modelConfig, 'high')
-                },
+                generationConfig,
                 safetySettings: [
                     { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_NONE' },
                     { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_NONE' },
@@ -312,7 +331,7 @@ function buildThinkingConfig(modelConfig, thinkingLevel = 'high') {
     }
 
     return {
-        thinkingLevel: normalizeThinkingLevel(modelConfig && modelConfig.id === 'gemini-3.1-flash-lite' && thinkingLevel === 'high' ? 'medium' : thinkingLevel)
+        thinkingLevel: normalizeThinkingLevel(thinkingLevel)
     };
 }
 
@@ -451,11 +470,9 @@ async function requestLumiQuestion(apiKey, history, options = {}) {
     const requestSignal = createRequestSignal(signal, timeoutMs);
 
     try {
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelConfig.id}:generateContent?key=${encodeURIComponent(apiKey)}`, {
+        const response = await fetch(getGeminiGenerateContentUrl(modelConfig.id), {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: getGeminiRequestHeaders(apiKey),
             body: JSON.stringify(payload),
             signal: requestSignal.signal
         });
@@ -933,7 +950,7 @@ const LumiQuestionRuntime = {
                     ? getLumiOrbSystemInstruction(this.searchEnabled)
                     : session.systemInstruction,
                 enableSearch: this.searchEnabled && session.enableSearch && !(session.mode === 'toeic-review' && modelConfig.flashLike),
-                thinkingLevel: session.mode === 'toeic-review' && modelConfig.id === 'gemini-3.1-flash-lite' ? 'medium' : session.thinkingLevel,
+                thinkingLevel: session.mode === 'toeic-review' && modelConfig.id === GEMINI_FLASH_LITE_MODEL_ID ? 'medium' : session.thinkingLevel,
                 model: modelConfig.id,
                 signal: controller.signal,
                 timeoutMs: 120000
@@ -983,8 +1000,8 @@ window.LumiQuestionRuntime = LumiQuestionRuntime;
 
 // --- Date System ---
 
-const DATE_PRIMARY_MODEL_ID = 'gemini-3-flash-preview';
-const DATE_FALLBACK_MODEL_ID = 'gemini-3.1-flash-lite';
+const DATE_PRIMARY_MODEL_ID = GEMINI_FLASH_MODEL_ID;
+const DATE_FALLBACK_MODEL_ID = GEMINI_FLASH_LITE_MODEL_ID;
 
 const DATE_LUMI_PERSONA = `# Role: 대현자 루미 (Grand Sage Rumi)
 
@@ -1094,15 +1111,12 @@ GameAPI.getDateContent = async function (apiKey, dateParams, options = {}) {
         `[비밀플래그]: ${dateParams.secret ? 'on' : 'off'}` +
         lonelinessPart + secretPart;
 
-    const temperature = innuendoInstruction ? 0.85 : 0.8;
-
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent?key=${encodeURIComponent(apiKey)}`, {
+    const response = await fetch(getGeminiGenerateContentUrl(modelId), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getGeminiRequestHeaders(apiKey),
         body: JSON.stringify({
             contents: [{ parts: [{ text: fullPrompt }] }],
             generationConfig: {
-                temperature: temperature,
                 maxOutputTokens: 12288,
                 thinkingConfig
             },
@@ -1138,8 +1152,8 @@ GameAPI.getDateContent = async function (apiKey, dateParams, options = {}) {
 
 // --- Fortune Cookie System ---
 
-const FORTUNE_PRIMARY_MODEL_ID = 'gemini-3-flash-preview';
-const FORTUNE_FALLBACK_MODEL_ID = 'gemini-3.1-flash-lite';
+const FORTUNE_PRIMARY_MODEL_ID = GEMINI_FLASH_MODEL_ID;
+const FORTUNE_FALLBACK_MODEL_ID = GEMINI_FLASH_LITE_MODEL_ID;
 
 const FORTUNE_LUMI_PERSONA = `# Role: 포춘쿠키 요정 루미 (Fortune Cookie Fairy Rumi)
 
@@ -1210,13 +1224,12 @@ GameAPI.getFortuneContent = async function (apiKey, fortuneParams, options = {})
         `${timePart}` +
         eventPart;
 
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent?key=${encodeURIComponent(apiKey)}`, {
+    const response = await fetch(getGeminiGenerateContentUrl(modelId), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getGeminiRequestHeaders(apiKey),
         body: JSON.stringify({
             contents: [{ parts: [{ text: fullPrompt }] }],
             generationConfig: {
-                temperature: 0.8,
                 maxOutputTokens: 2048,
                 thinkingConfig
             },

--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -221,6 +221,8 @@ const BattleRuntime = {
         const hasAttackSwap = rpg.battle.players.some(player => player && player.proto && player.proto.trait.type === 'reverse_atk_matk_party');
         const normalAttackTrait = rpg.battle.players.find(player => player && player.proto && player.proto.trait.type === 'party_normal_attack_dmg');
         const guardBoostTrait = rpg.battle.players.find(player => player && player.proto && player.proto.trait.type === 'guardian_hidden_trait');
+        const manaCostTrait = rpg.battle.players.find(player => player && player.proto && player.proto.trait.type === 'party_all_stats_mana_cost');
+        const alternatingStatsTrait = rpg.battle.players.find(player => player && player.proto && player.proto.trait.type === 'alternate_party_atk_matk_turn');
         if (hasAttackSwap || normalAttackTrait) {
             rpg.battle.players.forEach(player => {
                 if (!player) return;
@@ -235,6 +237,22 @@ const BattleRuntime = {
                 player.guardDamageReduction = Math.max(player.guardDamageReduction || 0, guardReduction);
             });
             rpg.log('[특성] 가디언: 덱 전체 가드 효과가 강화됩니다!');
+        }
+        if (manaCostTrait) {
+            const costMult = manaCostTrait.proto.trait.costMult || 2.0;
+            rpg.battle.players.forEach(player => {
+                if (!player || !Array.isArray(player.skills)) return;
+                player.skills.forEach(skill => {
+                    if (Number.isFinite(skill.cost)) skill.cost = Math.floor(skill.cost * costMult);
+                });
+            });
+            rpg.log(`[특성] ${manaCostTrait.name}: 덱 전체 스킬 마나 소비 ${costMult}배!`);
+        }
+        if (alternatingStatsTrait) {
+            const shift = alternatingStatsTrait.proto.trait.val || 50;
+            rpg.battle.players.forEach(player => {
+                if (player) player.alternatingAttackStatPercent = shift;
+            });
         }
         rpg.battle.fieldBuffs = [];
         rpg.battle.delayedEffects = [];
@@ -293,10 +311,13 @@ const BattleRuntime = {
                 rpg.log(`=== ${battle.turn}턴 ===`, 'info');
                 BattleRuntime.expireFieldBuffs(rpg, battle.turn);
 
-                if (rpg.hasArtifact('kaleidoscope')) {
+                const hasProphetTrait = BattleRuntime.hasActiveTrait(rpg, 'field_kaleidoscope_each_turn');
+                if (rpg.hasArtifact('kaleidoscope') || hasProphetTrait) {
                     const count = battle.fieldBuffs.length;
                     if (count > 0) {
-                        rpg.log('[아티팩트] 만화경: 필드 버프 재구성!');
+                        rpg.log(hasProphetTrait
+                            ? '[특성] 예언자: 필드 버프 재구성!'
+                            : '[아티팩트] 만화경: 필드 버프 재구성!');
                         BattleRuntime.replaceFieldBuffsLikeKaleidoscope(rpg);
                     }
                 }
@@ -457,7 +478,7 @@ const BattleRuntime = {
             if (Logic.checkEvasion(target, skill.type, battle.fieldBuffs, rpg.state.mode, rpg.state.artifacts || [], battle.turn)) {
                 rpg.log(`${target.name} 회피 성공! (${skill.name} 회피)`);
                 if (rpg.hasArtifact('lucky_vicky')) {
-                    target.mp = Math.min(GAME_CONSTANTS.MAX_MP, target.mp + 10);
+                    target.mp = Math.min(getMaxMana(target), target.mp + 10);
                     rpg.log('[아티팩트] 럭키비키: 회피 성공! 마나 10 회복!');
                 }
                 if (target.proto && target.proto.trait && target.proto.trait.type === 'on_evasion_stun') {
@@ -571,6 +592,17 @@ const BattleRuntime = {
         }
 
         applyStackMap(rpg, killer, result.killerDebuffs);
+
+        if (victim && victim.proto && victim.proto.trait && victim.proto.trait.type === 'death_next_ally_max_mana') {
+            const amount = victim.proto.trait.val || 20;
+            const players = Array.isArray(rpg.battle.players) ? rpg.battle.players : [];
+            const nextAlly = players.find(player => player && !player.isDead && player.pos > victim.pos);
+            if (nextAlly) {
+                nextAlly.maxMp = getMaxMana(nextAlly) + amount;
+                nextAlly.mp = Math.min(nextAlly.maxMp, nextAlly.mp + amount);
+                rpg.log(`[특성] ${victim.name}: 다음 아군 ${nextAlly.name}의 최대마나와 현재마나 ${amount} 증가!`);
+            }
+        }
     },
 
     handleLinkedDeathTraits(rpg, victim, killer) {
@@ -588,6 +620,7 @@ const BattleRuntime = {
                 name: player.name,
                 hp: player.proto.stats.hp,
                 maxHp: player.proto.stats.hp,
+                maxMp: GAME_CONSTANTS.MAX_MP,
                 mp: GAME_CONSTANTS.MAX_MP,
                 atk: player.proto.stats.atk,
                 matk: player.proto.stats.matk,
@@ -677,9 +710,34 @@ const BattleRuntime = {
         return (rpg.battle.activeTraits || []).includes(id);
     },
 
+    restoreDelayedTriggerMana(rpg, source, skill) {
+        if (
+            !source ||
+            !skill ||
+            !skill.isActualDelayedTrigger ||
+            !BattleRuntime.hasActiveTrait(rpg, 'vanguard_delayed_mana_restore')
+        ) {
+            return 0;
+        }
+
+        const tracker = (rpg.battle.players || []).find(player =>
+            player && player.proto && player.proto.trait &&
+            player.proto.trait.type === 'vanguard_delayed_mana_restore' &&
+            player.pos === 0
+        );
+        const amount = tracker ? (tracker.proto.trait.val || 10) : 10;
+        const before = source.mp;
+        source.mp = Math.min(getMaxMana(source), source.mp + amount);
+        const restored = source.mp - before;
+        rpg.log(`[특성] 혜성추적자: 지연 스킬 발동! ${source.name}의 마나 ${restored} 회복!`);
+        return restored;
+    },
+
     executeSkill(rpg, source, target, skill, isDelayed = false) {
         if (rpg.battle && rpg.battle.isFinished) return false;
         if (!target || target.hp <= 0 || !source || source.isDead) return false;
+
+        if (isDelayed) BattleRuntime.restoreDelayedTriggerMana(rpg, source, skill);
 
         const cost = Number.isFinite(skill.cost) ? skill.cost : 0;
         if (!isDelayed) {
@@ -695,6 +753,17 @@ const BattleRuntime = {
                 rpg.log('[아티팩트] 블루문: 마나 소비 없이 스킬 사용!');
             } else {
                 source.mp -= cost;
+            }
+
+            if (source.proto && source.proto.trait && source.proto.trait.type === 'alternate_skill_type_mana') {
+                const previousType = source.lastManualSkillType;
+                if (previousType && previousType !== skill.type) {
+                    const amount = source.proto.trait.val || 10;
+                    const before = source.mp;
+                    source.mp = Math.min(getMaxMana(source), source.mp + amount);
+                    rpg.log(`[특성] ${source.name}: 스킬 타입 전환! 마나 ${source.mp - before} 회복!`);
+                }
+                source.lastManualSkillType = skill.type;
             }
         }
 
@@ -794,7 +863,10 @@ const BattleRuntime = {
                         announce: nightmareMessages[index] || `${resolvedDelayedSkill.name} 발동!`
                     });
                 });
-                rpg.log(`${skill.name} 준비... (1~5턴 뒤 연속 발동)`);
+                const firstTurn = Math.min(...nightmareTurns);
+                const lastTurn = Math.max(...nightmareTurns);
+                const turnLabel = firstTurn === lastTurn ? `${firstTurn}턴 뒤` : `${firstTurn}~${lastTurn}턴 뒤`;
+                rpg.log(`${skill.name} 준비... (${turnLabel} 연속 발동)`);
                 BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
                 BattleRuntime.resolveSourceDeath(rpg, source, target);
                 if (target.hp <= 0) {
@@ -808,6 +880,7 @@ const BattleRuntime = {
             if (BattleRuntime.hasActiveTrait(rpg, 'instant_delayed_skills')) {
                 rpg.log('[특성] 시간의마술사: 지연 스킬 즉시 발동!');
                 modifiedSkill = resolvedDelayedSkill;
+                BattleRuntime.restoreDelayedTriggerMana(rpg, source, modifiedSkill);
             } else {
                 rpg.log(`${skill.name} 준비... (${delayedEff.turns}턴 뒤 발동)`);
                 rpg.battle.delayedEffects.push({
@@ -835,7 +908,7 @@ const BattleRuntime = {
         }
 
         if (dmgResult.luckyVicky) {
-            source.mp = Math.min(GAME_CONSTANTS.MAX_MP, source.mp + 10);
+            source.mp = Math.min(getMaxMana(source), source.mp + 10);
             rpg.log('[아티팩트] 럭키비키: 치명타 발생! 마나 10 회복!');
         }
 

--- a/card/data.js
+++ b/card/data.js
@@ -1094,6 +1094,146 @@ const BONUS_CARD_EXPANSION = [
             { name: '일체지광', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '디바인 부여', effects: [{ type: 'debuff', id: 'divine', stack: 1 }] },
             { name: '파쇄륜', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '모든 필드버프를 소모하고 제거한 수 x1.5 만큼 위력 증가', effects: [{ type: 'consume_field_all', multPerStack: 1.5 }] }
         ]
+    },
+
+    // ─── August–October 2026 Bonus Card Wave ───────────────────────────────────
+    {
+        id: 'discipline_captain', name: '선도부장', grade: 'normal', element: 'nature', role: 'balancer', unlockSource: 'bonus', releaseDate: '2026-08-01',
+        stats: { hp: 330, atk: 65, matk: 65, def: 60, mdef: 60 },
+        trait: { type: 'vanguard_all_grade_party_def_mdef', gradeRequired: 'normal', val: 100, desc: '선봉 배치 및 덱 전체 일반등급 시 덱 전체 방어력/마법방어력 100% 증가' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '잔소리', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '물리 2배율, 침묵 부여', effects: [{ type: 'debuff', id: 'silence' }] },
+            { name: '기강확립', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 약화 부여', effects: [{ type: 'debuff', id: 'weak' }] }
+        ]
+    },
+    {
+        id: 'supernova', name: '초신성', grade: 'legend', element: 'fire', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-08-01',
+        stats: { hp: 500, atk: 125, matk: 105, def: 60, mdef: 60 },
+        trait: { type: 'death_dmg_phy_debuff', val: 4.0, debuff: 'burn', stack: 3, logName: '초신성', desc: '사망 시 적에게 400% 물리대미지와 작열 3스택 부여' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '파이널버스트', type: 'phy', tier: 3, cost: 30, val: 6.0, desc: '물리 6배율, 사용 후 사망', effects: [{ type: 'suicide' }] },
+            { name: '코어멜트다운', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열을 전부 소모하고 소모한 스택당 2.0배율 추가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.0 }] }
+        ]
+    },
+    {
+        id: 'shooting_star_boy', name: '별똥별소년', grade: 'normal', element: 'light', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-08-15',
+        stats: { hp: 290, atk: 85, matk: 60, def: 45, mdef: 55 },
+        trait: { type: 'opening_self_atk_party_mdef_down', turns: 2, atkBoost: 100, mdefDown: 50, desc: '전투 시작 후 2턴간 공격력 100% 증가 / 덱 전체 마법방어력 50% 감소' },
+        skills: [
+            { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '스타폴대쉬', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] },
+            { name: '슈팅플레어', type: 'mag', tier: 2, cost: 20, val: 1.5, desc: '마법 1.5배율, 작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
+        ]
+    },
+    {
+        id: 'victoria', name: '빅토리아', grade: 'legend', element: 'light', role: 'buffer', unlockSource: 'bonus', releaseDate: '2026-08-15',
+        stats: { hp: 540, atk: 100, matk: 95, def: 80, mdef: 75 },
+        trait: { type: 'leader_field_stat_double', val: 2.0, desc: '대장 배치 시 아레나를 제외한 필드버프의 능력치 효과를 2배로 받음' },
+        skills: [
+            { name: '디바인아머', type: 'sup', tier: 2, cost: 20, desc: '3턴간 받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 3 }] },
+            { name: '에태르랜스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 부식 부여', effects: [{ type: 'debuff', id: 'corrosion' }] },
+            { name: '기적의증명', type: 'sup', tier: 3, cost: 30, desc: '3턴 뒤 필드버프 여신강림과 트윙클파티 부여', effects: [{ type: 'delayed_field_buffs', turns: 3, buffs: ['goddess_descent', 'twinkle_party'] }] }
+        ]
+    },
+    {
+        id: 'holy_night', name: '홀리밤', grade: 'normal', element: 'light', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-09-01',
+        stats: { hp: 300, atk: 85, matk: 55, def: 45, mdef: 45 },
+        trait: { type: 'death_dmg_phy', val: 3.0, desc: '사망 시 적에게 300% 물리대미지' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '샤이닝팝', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '물리 2배율', effects: [] },
+            { name: '라스트캐럴', type: 'phy', tier: 3, cost: 30, val: 4.0, desc: '디바인을 전부 소모하고 소모한 스택당 2.0배율 추가, 사용 후 사망', effects: [{ type: 'consume_debuff_all', debuff: 'divine', multPerStack: 2.0 }, { type: 'suicide' }] }
+        ]
+    },
+    {
+        id: 'paladin', name: '팔라딘', grade: 'epic', element: 'light', role: 'balancer', unlockSource: 'bonus', releaseDate: '2026-09-01',
+        stats: { hp: 400, atk: 105, matk: 75, def: 70, mdef: 70 },
+        trait: { type: 'pos_stat_boost', pos: 1, stat: 'atk', val: 100, desc: '중견 배치 시 공격력 100% 증가' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '디바인아머', type: 'sup', tier: 2, cost: 20, desc: '3턴간 받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 3 }] },
+            { name: '홀리그라운드', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '마법 1배율, 필드버프 성역 부여', effects: [{ type: 'field_buff', id: 'sanctuary' }] },
+            { name: '듀얼브레이커', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '아레나 소모 시 대미지 3배', effects: [{ type: 'consume_field_buff_dmg', buff: 'arena', mult: 3.0 }] }
+        ]
+    },
+    {
+        id: 'mad_scientist', name: '매드사이언티스트', grade: 'rare', element: 'nature', role: 'balancer', unlockSource: 'bonus', releaseDate: '2026-09-15',
+        stats: { hp: 350, atk: 80, matk: 80, def: 55, mdef: 55 },
+        trait: { type: 'party_all_stats_mana_cost', statVal: 30, costMult: 2.0, desc: '덱 전체 공격력/마법공격력/방어력/마법방어력 30% 증가 / 스킬 마나 소비 2배' },
+        skills: [
+            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
+            { name: '익스페리먼트', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '침묵 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'silence', mult: 2.0 }] },
+            { name: '다크인젝션', type: 'phy', tier: 2, cost: 20, val: 1.5, desc: '물리 1.5배율, 암흑 부여', effects: [{ type: 'debuff', id: 'darkness' }] }
+        ]
+    },
+    {
+        id: 'grand_merchant', name: '대상인', grade: 'rare', element: 'light', role: 'balancer', unlockSource: 'bonus', releaseDate: '2026-09-15',
+        stats: { hp: 340, atk: 75, matk: 90, def: 55, mdef: 60 },
+        trait: { type: 'death_next_ally_max_mana', val: 20, desc: '사망 시 다음 아군의 최대마나와 현재마나 20 증가' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '마나콜렉트', type: 'sup', tier: 1, cost: 10, desc: '마나 30 회복', effects: [{ type: 'mana_restore', val: 30 }] },
+            { name: '골드러쉬', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '약화 상태의 적에게 대미지 2.5배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'weak', mult: 2.5 }] }
+        ]
+    },
+    {
+        id: 'comet_tracker', name: '혜성추적자', grade: 'rare', element: 'fire', role: 'balancer', unlockSource: 'bonus', releaseDate: '2026-10-01',
+        stats: { hp: 345, atk: 65, matk: 100, def: 55, mdef: 60 },
+        trait: { type: 'vanguard_delayed_mana_restore', val: 10, desc: '선봉 배치 시 덱의 지연 스킬이 실제 발동할 때 시전자가 마나 10 회복' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '코멧트래킹', type: 'mag', tier: 3, cost: 30, val: 4.0, desc: '2턴 뒤 발동하는 마법 4배율 공격', effects: [{ type: 'delayed_attack', turns: 2 }] },
+            { name: '코멧플레임', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
+        ]
+    },
+    {
+        id: 'prophet', name: '예언자', grade: 'legend', element: 'water', role: 'buffer', unlockSource: 'bonus', releaseDate: '2026-10-01',
+        stats: { hp: 500, atk: 90, matk: 110, def: 75, mdef: 85 },
+        trait: { type: 'field_kaleidoscope_each_turn', desc: '매 턴 시작 시 모든 필드버프를 무작위로 변경' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '샤이닝오라클', type: 'sup', tier: 2, cost: 20, desc: '랜덤한 필드버프 생성', effects: [{ type: 'random_field_buff' }] },
+            { name: '슈퍼내추럴', type: 'sup', tier: 3, cost: 30, desc: '데스티니룰렛과 동일한 풀에서 랜덤 스킬 발동', effects: [{ type: 'random_skill_trigger_from_list' }] }
+        ]
+    },
+    {
+        id: 'fireworks_girl', name: '폭죽소녀', grade: 'epic', element: 'fire', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-10-15',
+        stats: { hp: 390, atk: 100, matk: 80, def: 55, mdef: 55 },
+        trait: { type: 'death_dmg_phy_same_grade', val: 8.0, desc: '덱 전체가 같은 등급일 경우 사망 시 적에게 800% 물리대미지' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            {
+                name: '페스티벌나이트', type: 'phy', tier: 3, cost: 30, val: 1.5,
+                desc: '1~3턴 뒤 연속 발동, 작열 상태의 적에게 대미지 2배',
+                effects: [
+                    { type: 'multi_delayed_attack', turns: [1, 2, 3], messages: ['첫번째 폭죽이 터진다!', '두번째 폭죽이 터진다!', '마지막 폭죽이 터진다!'] },
+                    { type: 'dmg_boost', condition: 'target_debuff', debuff: 'burn', mult: 2.0 }
+                ]
+            },
+            { name: '스파클캐논', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '마법 2배율, 작열 부여', effects: [{ type: 'debuff', id: 'burn', stack: 1 }] }
+        ]
+    },
+    {
+        id: 'astrologer', name: '점성술사', grade: 'epic', element: 'water', role: 'dealer', unlockSource: 'hidden',
+        stats: { hp: 390, atk: 90, matk: 95, def: 60, mdef: 65 },
+        trait: { type: 'alternate_party_atk_matk_turn', val: 50, desc: '덱 전체가 홀수 턴에는 공격력 50% 감소·마법공격력 50% 증가, 짝수 턴에는 마법공격력 50% 감소·공격력 50% 증가' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '스텔라리딩', type: 'sup', tier: 3, cost: 30, desc: '달의축복 부여, 이미 있으면 소모하고 태양의축복 부여', effects: [{ type: 'moon_to_sun' }] },
+            { name: '솔라브레이커', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '태양의축복 소모 시 대미지 4배', effects: [{ type: 'consume_field_buff_dmg', buff: 'sun_bless', mult: 4.0 }] }
+        ]
+    },
+    {
+        id: 'sun_moon_sword_maiden', name: '일월검희', grade: 'legend', element: 'light', role: 'dealer', unlockSource: 'hidden',
+        stats: { hp: 500, atk: 130, matk: 110, def: 65, mdef: 70 },
+        trait: { type: 'alternate_skill_type_mana', val: 10, desc: '이전에 사용한 스킬과 다른 타입의 스킬 사용 시 마나 10 회복' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '솔라크레센토', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '태양의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'sun_bless', mult: 2.0 }] },
+            { name: '루나트레센토', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '달의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.0 }] }
+        ]
     }
 ];
 

--- a/card/fortune_cookie.js
+++ b/card/fortune_cookie.js
@@ -358,7 +358,7 @@ const FortuneCookie = {
     this.showFortunePhase(result);
 
     // API 호출
-    this.callFortuneApi(result, 'gemini-3-flash-preview');
+    this.callFortuneApi(result, FORTUNE_PRIMARY_MODEL_ID);
   },
 
   async callFortuneApi(result, modelId) {
@@ -390,7 +390,7 @@ const FortuneCookie = {
 
     } catch (e) {
       console.error("포춘쿠키 API 실패", e);
-      if (modelId === 'gemini-3-flash-preview') {
+      if (modelId === FORTUNE_PRIMARY_MODEL_ID) {
         msgBox.innerHTML = `<div style="text-align:center; color:#ef5350;">운세를 불러오다 깜빡했어요.<br><span style="font-size:0.8rem;">(API 호출 실패)</span></div>`;
         retryBtn.style.display = 'block';
         this._lastResultForRetry = result; // 재시도를 위해 임시 저장
@@ -403,7 +403,7 @@ const FortuneCookie = {
 
   retryWithFallback() {
     if (!this._lastResultForRetry) return;
-    this.callFortuneApi(this._lastResultForRetry, 'gemini-3.1-flash-lite');
+    this.callFortuneApi(this._lastResultForRetry, FORTUNE_FALLBACK_MODEL_ID);
   },
 
   renderFortuneMessage(result) {

--- a/card/index.html
+++ b/card/index.html
@@ -3644,7 +3644,7 @@
 
                     let hpPct = (p.hp / p.maxHp) * 100;
                     document.getElementById('p-hp-bar').style.width = `${Math.max(0, hpPct)}%`;
-                    let mpPct = (p.mp / 100) * 100;
+                    let mpPct = (p.mp / (p.maxMp || GAME_CONSTANTS.MAX_MP)) * 100;
                     document.getElementById('p-mp-bar').style.width = `${Math.max(0, mpPct)}%`;
 
                     let buffTxt = Object.keys(p.buffs).map(k => BUFF_NAMES[k] || k).join(',');
@@ -4044,7 +4044,7 @@
                 };
 
                 let content = `<b>[${char.name}]</b><br>HP: ${char.hp}/${char.maxHp}<br>`;
-                if (side === 'player') content += `MP: ${char.mp}<br>`;
+                if (side === 'player') content += `MP: ${char.mp}/${char.maxMp || GAME_CONSTANTS.MAX_MP}<br>`;
                 content += `ATK: ${colorize(eff.atk, getBase('atk', char.atk))} / MATK: ${colorize(eff.matk, getBase('matk', char.matk))}<br>`;
                 content += `DEF: ${colorize(eff.def, getBase('def', char.def))} / MDEF: ${colorize(eff.mdef, getBase('mdef', char.mdef))}<br>`;
                 content += `치명타율: ${colorize(eff.crit, (char.baseCrit || 10))}% / 회피율: ${colorize(eff.evasion, (char.baseEva || 0) + 5)}%<br>`;
@@ -5356,7 +5356,7 @@
                 const contentBox = document.getElementById('date-content');
                 if (!contentBox || !dateParams) return;
 
-                const isFallback = modelId === 'gemini-3.1-flash-lite';
+                const isFallback = modelId === DATE_FALLBACK_MODEL_ID;
                 const modelNote = isFallback
                     ? `<br><span style="font-size:0.8rem; color:#81d4fa;">${LumiQuestionRuntime.getModelLabel(modelId)} 모델로 다시 시도 중...</span>`
                     : '';
@@ -5382,7 +5382,7 @@
                 const contentBox = document.getElementById('date-content');
                 if (!contentBox || !dateParams) return false;
 
-                const isFallback = modelId === 'gemini-3.1-flash-lite';
+                const isFallback = modelId === DATE_FALLBACK_MODEL_ID;
                 this.isApiLoading = true;
                 this.updateDateRetryButton({ visible: isFallback, disabled: true });
                 this.setDateLoadingState(dateParams, modelId);
@@ -5434,7 +5434,7 @@
                 // Show date modal
                 document.getElementById('modal-date').classList.add('active');
                 this.updateDateRetryButton({ visible: false, disabled: true });
-                await this.loadDateContent(key, dateParams, 'gemini-3-flash-preview');
+                await this.loadDateContent(key, dateParams, DATE_PRIMARY_MODEL_ID);
             },
 
             async retryDateWithFallback() {
@@ -5446,7 +5446,7 @@
                 const key = this.ensureApiKey('데이트를 다시 시도하려면');
                 if (!key) return this.showAlert("API 키가 없어 데이트를 다시 시도할 수 없습니다.");
 
-                await this.loadDateContent(key, dateParams, 'gemini-3.1-flash-lite');
+                await this.loadDateContent(key, dateParams, DATE_FALLBACK_MODEL_ID);
             },
 
             finishDate() {

--- a/card/logic.js
+++ b/card/logic.js
@@ -940,6 +940,10 @@ function getEffectiveFieldBuffs(char, fieldBuffs) {
     return isFieldBuffImmune(char) ? [] : fieldBuffs;
 }
 
+function getMaxMana(char) {
+    return char && Number.isFinite(char.maxMp) ? char.maxMp : GAME_CONSTANTS.MAX_MP;
+}
+
 const DELAYED_SKILL_EFFECT_TYPES = [
     'delayed_attack',
     'delayed_attack_field',
@@ -950,6 +954,7 @@ const DELAYED_SKILL_EFFECT_TYPES = [
     'phantom_nightmare',
     'delayed_attack_random_field',
     'delayed_attack_debuffs',
+    'delayed_field_buffs',
     'multi_delayed_attack'
 ];
 
@@ -964,6 +969,7 @@ function buildResolvedDelayedSkill(skill, delayedEff, currentTurn) {
     if (delayedEff.type === 'delayed_turn_scale_attack') {
         return {
             ...skill,
+            isActualDelayedTrigger: true,
             effects: [
                 ...(skill.effects || []).filter(effect => effect !== delayedEff),
                 { type: 'dmg_boost_turn_scale', scale: delayedEff.scale, startTurn: currentTurn }
@@ -974,6 +980,7 @@ function buildResolvedDelayedSkill(skill, delayedEff, currentTurn) {
     if (delayedEff.type === 'delayed_attack_debuff_scale') {
         return {
             ...skill,
+            isActualDelayedTrigger: true,
             effects: [
                 ...(skill.effects || []).filter(effect => effect !== delayedEff),
                 { type: 'dmg_boost', condition: 'target_debuff_count_scale', multPerDebuff: delayedEff.multPerDebuff }
@@ -985,6 +992,7 @@ function buildResolvedDelayedSkill(skill, delayedEff, currentTurn) {
         return {
             ...skill,
             isDelayed: true,
+            isActualDelayedTrigger: true,
             effects: [
                 ...(skill.effects || []).filter(effect => effect !== delayedEff),
                 {
@@ -1003,6 +1011,7 @@ function buildResolvedDelayedSkill(skill, delayedEff, currentTurn) {
         return {
             ...skill,
             isDelayed: true,
+            isActualDelayedTrigger: true,
             effects: [
                 ...(skill.effects || []).filter(effect => effect !== delayedEff),
                 { type: 'random_field_buff' }
@@ -1015,6 +1024,7 @@ function buildResolvedDelayedSkill(skill, delayedEff, currentTurn) {
         return {
             ...skill,
             isDelayed: true,
+            isActualDelayedTrigger: true,
             effects: [
                 ...(skill.effects || []).filter(effect => effect !== delayedEff),
                 ...delayedEff.debuffs.map(id => ({
@@ -1030,13 +1040,17 @@ function buildResolvedDelayedSkill(skill, delayedEff, currentTurn) {
         return {
             ...skill,
             isDelayed: true,
+            isActualDelayedTrigger: true,
             effects: [
                 ...(skill.effects || []).filter(effect => effect !== delayedEff)
             ]
         };
     }
 
-    return skill;
+    return {
+        ...skill,
+        isActualDelayedTrigger: true
+    };
 }
 
 function resolveRandomMultiplier(eff, source) {
@@ -1413,6 +1427,13 @@ const SideEffects = {
             ctx.source.hp = Math.min(ctx.source.maxHp, ctx.source.hp + heal);
             ctx.logFn(`HP ${heal} 회복!`);
         },
+        'mana_restore': (ctx, eff) => {
+            const amount = eff.val || eff.amount || 0;
+            if (!ctx.source || amount <= 0) return;
+            const before = ctx.source.mp;
+            ctx.source.mp = Math.min(getMaxMana(ctx.source), ctx.source.mp + amount);
+            ctx.logFn(`마나 ${ctx.source.mp - before} 회복!`);
+        },
         'random_field_buff': (ctx, eff) => {
             const pool = eff.pool || ['sun_bless', 'moon_bless', 'sanctuary', 'goddess_descent', 'earth_bless', 'twinkle_party', 'star_powder', 'arena'];
             const pick = pool[Math.floor(Math.random() * pool.length)];
@@ -1534,6 +1555,17 @@ const SideEffects = {
                 ctx.logFn("소모할 작열이 없어 대지의 축복을 불러옵니다.");
             }
         },
+        'moon_to_sun': (ctx) => {
+            const moonIndex = ctx.battle.fieldBuffs.findIndex(buff => buff.name === 'moon_bless');
+            if (moonIndex === -1) {
+                ctx.applyFieldBuff('moon_bless');
+                return;
+            }
+
+            ctx.battle.fieldBuffs.splice(moonIndex, 1);
+            ctx.logFn('필드버프 [달의축복] 소모!');
+            ctx.applyFieldBuff('sun_bless');
+        },
         'check_divine_3_stun_else_add': (ctx, eff) => {
             if ((ctx.target.buffs['divine'] || 0) >= 3) {
                 ctx.target.buffs['stun'] = 1;
@@ -1598,6 +1630,9 @@ const SideEffects = {
         'delayed_attack_debuffs': (ctx, eff) => {
             // handled via buildResolvedDelayedSkill → debuff effects
         },
+        'delayed_field_buffs': (ctx, eff) => {
+            (eff.buffs || []).forEach(buffId => ctx.applyFieldBuff(buffId));
+        },
         'delayed_turn_scale_attack': (ctx, eff) => {
             const resolvedSkill = buildResolvedDelayedSkill(ctx.skill, eff, ctx.battle.turn);
             if (ctx.activeTraits && ctx.activeTraits.includes('instant_delayed_skills')) {
@@ -1629,6 +1664,7 @@ const SideEffects = {
             ctx.logFn(`제로그라비티! ${eff.turns}턴 후 발동합니다!`);
         },
         'random_skill_trigger_from_list': (ctx, eff) => {
+            const triggerName = ctx.skill && ctx.skill.name ? ctx.skill.name : '데스티니룰렛';
             const skillMap = [
                 { id: 'gold_dragon', skill: '얼티밋브레스' },
                 { id: 'zeke', skill: '라그나로크' },
@@ -1652,7 +1688,7 @@ const SideEffects = {
                 const resolvedSkill = buildResolvedDelayedSkill(skill, delayedEff, ctx.battle.turn);
 
                 if (delayedEff) {
-                    ctx.logFn(`[데스티니룰렛] ${card.name}의 ${skill.name} 발동!`);
+                    ctx.logFn(`[${triggerName}] ${card.name}의 ${skill.name} 발동!`);
                     if (ctx.activeTraits && ctx.activeTraits.includes('instant_delayed_skills')) {
                         ctx.logFn('[특성] 시간의마술사: 지연 스킬 즉시 발동!');
                         ctx.executeSkill(ctx.source, ctx.target, resolvedSkill, true);
@@ -1665,7 +1701,7 @@ const SideEffects = {
                         ctx.logFn(`(지연 발동) ${delayedEff.turns}턴 뒤에 공격합니다.`);
                     }
                 } else {
-                    ctx.logFn(`[데스티니룰렛] ${card.name}의 ${skill.name} 발동!`);
+                    ctx.logFn(`[${triggerName}] ${card.name}의 ${skill.name} 발동!`);
                     ctx.executeSkill(ctx.source, ctx.target, skill, true);
                 }
             }
@@ -1707,11 +1743,11 @@ const SideEffects = {
                             logMsg.push("대지(완전회복)");
                             break;
                         case 'star_powder':
-                            ctx.source.mp = Math.min(GAME_CONSTANTS.MAX_MP, ctx.source.mp + 30);
+                            ctx.source.mp = Math.min(getMaxMana(ctx.source), ctx.source.mp + 30);
                             logMsg.push("스타(MP+30)");
                             break;
                         case 'sanctuary':
-                            ctx.source.mp = Math.min(GAME_CONSTANTS.MAX_MP, ctx.source.mp + 20);
+                            ctx.source.mp = Math.min(getMaxMana(ctx.source), ctx.source.mp + 20);
                             logMsg.push("성역(MP+20)");
                             break;
                         case 'goddess_descent':
@@ -1802,6 +1838,19 @@ const Logic = {
             m.atk += boost;
             m.matk += boost;
         }
+        if (trait && trait.type === 'opening_self_atk_party_mdef_down' && battleTurn <= (trait.turns || 2)) {
+            m.atk += (trait.atkBoost || 0) / 100;
+        }
+        if (char.alternatingAttackStatPercent) {
+            const shift = char.alternatingAttackStatPercent / 100;
+            if (battleTurn % 2 === 0) {
+                m.atk += shift;
+                m.matk -= shift;
+            } else {
+                m.atk -= shift;
+                m.matk += shift;
+            }
+        }
         if (trait && trait.type === 'cond_sanctuary_atk_def' && effectiveFieldBuffs.some(b => b.name === 'sanctuary')) {
             const boost = (trait.val || 0) / 100;
             m.atk += boost;
@@ -1815,6 +1864,9 @@ const Logic = {
                 const bonus = GAME_CONSTANTS.FIELD_BUFF_STATS[fb.name];
                 if (bonus) {
                     let artifactBuffMult = 1.0;
+                    const personalBuffMult = fb.name === 'arena'
+                        ? 1.0
+                        : (char.fieldBuffStatMult || 1.0);
                     if (fb.name === 'earth_bless') {
                         if (artifacts.includes('divine_flora')) artifactBuffMult = 2.5;
                         else if (artifacts.includes('nature_blessing')) artifactBuffMult = 2.0;
@@ -1824,12 +1876,13 @@ const Logic = {
                         else if (artifacts.includes('milkshake')) artifactBuffMult = 2.0;
                     }
 
-                    if (bonus.atk) m.atk += (bonus.atk * buffMult * artifactBuffMult);
-                    if (bonus.matk) m.matk += (bonus.matk * buffMult * artifactBuffMult);
-                    if (bonus.def) m.def += (bonus.def * buffMult * artifactBuffMult);
-                    if (bonus.mdef) m.mdef += (bonus.mdef * buffMult * artifactBuffMult);
-                    if (bonus.crit) stats.crit += (bonus.crit * buffMult * artifactBuffMult);
-                    if (bonus.evasion) stats.evasion += (bonus.evasion * buffMult * artifactBuffMult);
+                    const totalBuffMult = buffMult * artifactBuffMult * personalBuffMult;
+                    if (bonus.atk) m.atk += (bonus.atk * totalBuffMult);
+                    if (bonus.matk) m.matk += (bonus.matk * totalBuffMult);
+                    if (bonus.def) m.def += (bonus.def * totalBuffMult);
+                    if (bonus.mdef) m.mdef += (bonus.mdef * totalBuffMult);
+                    if (bonus.crit) stats.crit += (bonus.crit * totalBuffMult);
+                    if (bonus.evasion) stats.evasion += (bonus.evasion * totalBuffMult);
                 }
             });
         }
@@ -2308,7 +2361,8 @@ const Logic = {
     calculateInitialStats: function (playerProto, deck, allCards, idx) {
         // Base stats copy
         let p = {
-            maxHp: playerProto.stats.hp, hp: playerProto.stats.hp, mp: GAME_CONSTANTS.MAX_MP || 100,
+            maxHp: playerProto.stats.hp, hp: playerProto.stats.hp,
+            maxMp: GAME_CONSTANTS.MAX_MP || 100, mp: GAME_CONSTANTS.MAX_MP || 100,
             atk: playerProto.stats.atk, matk: playerProto.stats.matk,
             def: playerProto.stats.def, mdef: playerProto.stats.mdef,
             baseCrit: GAME_CONSTANTS.BASE_CRIT, baseEva: 0
@@ -2344,8 +2398,32 @@ const Logic = {
             }
         }
 
-        if (t.type === 'party_normal_attack_dmg' || t.type === 'reverse_atk_matk_party') {
+        if ([
+            'party_normal_attack_dmg',
+            'reverse_atk_matk_party',
+            'party_all_stats_mana_cost',
+            'alternate_party_atk_matk_turn',
+            'field_kaleidoscope_each_turn',
+            'alternate_skill_type_mana',
+            'opening_self_atk_party_mdef_down'
+        ].includes(t.type)) {
             active = true;
+        }
+
+        if (t.type === 'vanguard_delayed_mana_restore' && idx === 0) {
+            active = true;
+        }
+
+        if (t.type === 'vanguard_all_grade_party_def_mdef' && idx === 0) {
+            const grades = deckCtx.cards.map(card => card.grade);
+            if (grades.length > 0 && grades.every(grade => grade === (t.gradeRequired || 'normal'))) {
+                active = true;
+            }
+        }
+
+        if (t.type === 'leader_field_stat_double' && idx === 2) {
+            active = true;
+            p.fieldBuffStatMult = t.val || 2.0;
         }
 
         // 프리즘트윈/앤트로피: 패시브 특성 활성화 표시
@@ -2485,6 +2563,23 @@ const Logic = {
             }
             else if (tr && tr.type === 'syn_dark_full_party_crit' && deckCtx.countElement('dark') >= 3) {
                 partyBoost.crit += (tr.val || 0);
+            }
+            else if (tr && tr.type === 'party_all_stats_mana_cost') {
+                const boost = tr.statVal || 0;
+                partyBoost.atk += boost;
+                partyBoost.matk += boost;
+                partyBoost.def += boost;
+                partyBoost.mdef += boost;
+            }
+            else if (tr && tr.type === 'opening_self_atk_party_mdef_down') {
+                partyBoost.mdef -= (tr.mdefDown || 0);
+            }
+            else if (tr && tr.type === 'vanguard_all_grade_party_def_mdef' && originalIdx === 0) {
+                const grades = fullDeckCards.filter(Boolean).map(card => card.grade);
+                if (grades.length > 0 && grades.every(grade => grade === (tr.gradeRequired || 'normal'))) {
+                    partyBoost.def += (tr.val || 0);
+                    partyBoost.mdef += (tr.val || 0);
+                }
             }
             else if (tr && tr.type === 'mid_party_mdef_boost' && originalIdx === 1) {
                 partyBoost.mdef += (tr.val || 0);
@@ -2762,10 +2857,12 @@ const Logic = {
             this._applyDeathDamage(result, victim, killer, { name: '사망 반격', type: 'mag', val: count * t.val }, fieldBuffs, logFn, deck, turn, artifacts, `[특성] 사망 반격! (필드버프 ${count}개)`);
         }
         else if (t.type === 'death_dmg_phy_debuff') {
-            this._applyDeathDamage(result, victim, killer, { name: '사망 반격', type: 'phy', val: t.val }, fieldBuffs, logFn, deck, turn, artifacts, '[특성] 맹독 폭발!');
+            const effectName = t.logName || '맹독';
+            this._applyDeathDamage(result, victim, killer, { name: '사망 반격', type: 'phy', val: t.val }, fieldBuffs, logFn, deck, turn, artifacts, `[특성] ${effectName} 폭발!`);
             if (killer) {
-                result.killerDebuffs[t.debuff] = (result.killerDebuffs[t.debuff] || 0) + 1;
-                logFn(`[특성] 맹독 발동! 적에게 [${getBuffName(t.debuff)}] 부여.`);
+                const stack = t.stack || 1;
+                result.killerDebuffs[t.debuff] = (result.killerDebuffs[t.debuff] || 0) + stack;
+                logFn(`[특성] ${effectName} 발동! 적에게 [${getBuffName(t.debuff)}] ${stack > 1 ? `${stack}스택 ` : ''}부여.`);
             }
         }
         else if (t.type === 'death_clear_field_add_buff') {
@@ -2805,6 +2902,15 @@ const Logic = {
                     result.killerDebuffs['stun'] = (result.killerDebuffs['stun'] || 0) + 1;
                     logFn('[특성] 팅커벨: 적에게 기절 부여!');
                 }
+            }
+        }
+        else if (t.type === 'death_dmg_phy_same_grade') {
+            const deckCards = (deck || []).filter(Boolean).map(cardId => {
+                return GameUtils.getCardById(cardId);
+            }).filter(Boolean);
+            const grades = deckCards.map(card => card.grade);
+            if (grades.length > 0 && grades.every(grade => grade === grades[0])) {
+                this._applyDeathDamage(result, victim, killer, { name: '축제의 피날레', type: 'phy', val: t.val }, fieldBuffs, logFn, deck, turn, artifacts, '[특성] 폭죽소녀: 축제의 피날레!');
             }
         }
 

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -34,7 +34,7 @@
             title: '스페셜미션(해변)',
             bossId: 'thor_swimsuit',
             bossName: '토르(수영복)',
-            rewardCardIds: ['jasmine_swimsuit', 'rumi_swimsuit', 'zeke_swimsuit',
+            rewardCardIds: ['luna_swimsuit', 'jasmine_swimsuit', 'rumi_swimsuit', 'zeke_swimsuit',
                             'snow_rabbit_swimsuit', 'night_rabbit_swimsuit', 'silver_rabbit_swimsuit']
         },
         halloween: {
@@ -481,8 +481,8 @@
     },
 
 
-    getReleasedStandardBonusCards() {
-        const today = new Date();
+    getReleasedStandardBonusCards(date = new Date()) {
+        const today = date;
         const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
         return this.getAllStandardBonusCards().filter(card => {
             if (!card.releaseDate) return true;

--- a/card_remaster/api.js
+++ b/card_remaster/api.js
@@ -1,3 +1,17 @@
+const GEMINI_FLASH_MODEL_ID = 'gemini-3.6-flash';
+const GEMINI_GENERATE_CONTENT_ROOT = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+function getGeminiGenerateContentUrl(modelId) {
+    return `${GEMINI_GENERATE_CONTENT_ROOT}/${encodeURIComponent(modelId)}:generateContent`;
+}
+
+function getGeminiRequestHeaders(apiKey) {
+    return {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey
+    };
+}
+
 const LUMI_PERSONA = `# Role: 대현자 루미 (Grand Sage Rumi)
 
 ## 1. 정체성 (Identity)
@@ -78,14 +92,13 @@ const GameAPI = {
         // 3. 프롬프트 조합
         const fullPrompt = `${LUMI_PERSONA}\n${secretInstruction}\n\n${LECTURE_FORMAT}\n\n${targetInfo}`;
 
-        // 4. API 호출 (온도는 0.6~0.7 추천: 창의적인 상황 부여 필요)
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+        // 4. API 호출
+        const response = await fetch(getGeminiGenerateContentUrl(GEMINI_FLASH_MODEL_ID), {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: getGeminiRequestHeaders(apiKey),
             body: JSON.stringify({
                 contents: [{ parts: [{ text: fullPrompt }] }],
                 generationConfig: {
-                    temperature: isMisunderstandingMode ? 0.65 : 0.4,
                     thinkingConfig: {
                         thinkingLevel: 'high'
                     }
@@ -193,11 +206,9 @@ GameAPI.askLumiQuestion = async function (apiKey, history, options = {}) {
         { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_NONE' }
     ];
 
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=${encodeURIComponent(apiKey)}`, {
+    const response = await fetch(getGeminiGenerateContentUrl('gemini-3.1-pro-preview'), {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
+        headers: getGeminiRequestHeaders(apiKey),
         body: JSON.stringify(payload)
     });
 
@@ -611,15 +622,12 @@ GameAPI.getDateContent = async function (apiKey, dateParams) {
         `[비밀플래그]: ${dateParams.secret ? 'on' : 'off'}` +
         lonelinessPart + secretPart;
 
-    const temperature = innuendoInstruction ? 0.85 : 0.8;
-
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${apiKey}`, {
+    const response = await fetch(getGeminiGenerateContentUrl(GEMINI_FLASH_MODEL_ID), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: getGeminiRequestHeaders(apiKey),
         body: JSON.stringify({
             contents: [{ parts: [{ text: fullPrompt }] }],
             generationConfig: {
-                temperature: temperature,
                 thinkingConfig: {
                     thinkingLevel: 'high'
                 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/toeic.js && node --check card/api.js && node --check card/battle_runtime.js && node --check card/rpg_features.js",
-    "test:smoke": "node scripts/verify_card_smoke.js && node scripts/verify_card_combat_regressions.js && node scripts/verify_card_remaster_smoke.js && node scripts/verify_idle_hero_smoke.js",
+    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/toeic.js && node --check card/api.js && node --check card/battle_runtime.js && node --check card/rpg_features.js && node --check card/fortune_cookie.js && node --check card_remaster/api.js",
+    "test:smoke": "node scripts/verify_card_smoke.js && node scripts/verify_card_combat_regressions.js && node scripts/verify_gemini_api_models.js && node scripts/verify_card_remaster_smoke.js && node scripts/verify_idle_hero_smoke.js",
     "verify": "npm run lint && npm run test:smoke"
   },
   "dependencies": {

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -31,7 +31,7 @@ function run() {
 
   const cardRoot = path.join(process.cwd(), 'card');
   assert.strictEqual(fs.readFileSync(path.join(cardRoot, 'index.html'), 'utf8').includes('#448af f'), false);
-  ['data.js', 'logic.js', 'battle_runtime.js'].forEach(fileName => {
+  ['data.js', 'logic.js', 'battle_runtime.js', 'rpg_features.js'].forEach(fileName => {
     const filePath = path.join(cardRoot, fileName);
     vm.runInContext(fs.readFileSync(filePath, 'utf8'), sandbox, { filename: filePath });
   });
@@ -40,7 +40,7 @@ function run() {
     const quiet = () => {};
     const getCard = id => GameUtils.getCardById(id);
     const makeUnit = (overrides = {}) => ({
-      id: 'unit', name: 'unit', hp: 1000, maxHp: 1000, mp: 100,
+      id: 'unit', name: 'unit', hp: 1000, maxHp: 1000, mp: 100, maxMp: 100,
       atk: 100, matk: 100, def: 0, mdef: 0,
       baseCrit: -100, baseEva: 0, buffs: {}, element: null,
       ...overrides
@@ -54,6 +54,220 @@ function run() {
     assert.strictEqual(golem.skills.find(skill => skill.name === '차지어택').val, 3.0);
     assert.strictEqual(getCard('prism_twin').skills.find(skill => skill.name === '프리즘셔플').effects[0].type, 'prism_shuffle_field');
     assert.strictEqual(getCard('joker').skills.find(skill => skill.name === '레인보우룰렛').effects[0].type, 'roulette_field');
+
+    // The complete August–October wave is registered with deterministic release gates.
+    const bonusWaveExpectations = [
+      ['discipline_captain', '선도부장', 'normal', 'nature', 'balancer', '2026-08-01', [330, 65, 65, 60, 60]],
+      ['supernova', '초신성', 'legend', 'fire', 'dealer', '2026-08-01', [500, 125, 105, 60, 60]],
+      ['shooting_star_boy', '별똥별소년', 'normal', 'light', 'dealer', '2026-08-15', [290, 85, 60, 45, 55]],
+      ['victoria', '빅토리아', 'legend', 'light', 'buffer', '2026-08-15', [540, 100, 95, 80, 75]],
+      ['holy_night', '홀리밤', 'normal', 'light', 'dealer', '2026-09-01', [300, 85, 55, 45, 45]],
+      ['paladin', '팔라딘', 'epic', 'light', 'balancer', '2026-09-01', [400, 105, 75, 70, 70]],
+      ['mad_scientist', '매드사이언티스트', 'rare', 'nature', 'balancer', '2026-09-15', [350, 80, 80, 55, 55]],
+      ['grand_merchant', '대상인', 'rare', 'light', 'balancer', '2026-09-15', [340, 75, 90, 55, 60]],
+      ['comet_tracker', '혜성추적자', 'rare', 'fire', 'balancer', '2026-10-01', [345, 65, 100, 55, 60]],
+      ['prophet', '예언자', 'legend', 'water', 'buffer', '2026-10-01', [500, 90, 110, 75, 85]],
+      ['fireworks_girl', '폭죽소녀', 'epic', 'fire', 'dealer', '2026-10-15', [390, 100, 80, 55, 55]],
+      ['astrologer', '점성술사', 'epic', 'water', 'dealer', null, [390, 90, 95, 60, 65]],
+      ['sun_moon_sword_maiden', '일월검희', 'legend', 'light', 'dealer', null, [500, 130, 110, 65, 70]]
+    ];
+    const bonusWaveIds = bonusWaveExpectations.map(entry => entry[0]);
+    bonusWaveExpectations.forEach(([id, name, grade, element, role, releaseDate, stats]) => {
+      const card = getCard(id);
+      assert(card, 'missing bonus card: ' + id);
+      assert.deepStrictEqual(
+        [card.name, card.grade, card.element, card.role, card.releaseDate || null],
+        [name, grade, element, role, releaseDate]
+      );
+      assert.deepStrictEqual(
+        [card.stats.hp, card.stats.atk, card.stats.matk, card.stats.def, card.stats.mdef],
+        stats
+      );
+      assert.strictEqual(card.unlockSource, releaseDate ? 'bonus' : 'hidden');
+      assert(card.trait.desc && card.trait.desc.trim());
+      assert(card.skills.every(skill => skill.desc && skill.desc.trim()));
+    });
+    assert.strictEqual(
+      GameUtils.getBonusCards().filter(card => bonusWaveIds.includes(card.id)).length,
+      bonusWaveIds.length
+    );
+
+    const dragonClaw = getCard('gold_dragon').skills.find(skill => skill.name === '드래곤크로');
+    const starfallDash = getCard('shooting_star_boy').skills.find(skill => skill.name === '스타폴대쉬');
+    const comparableSkill = skill => JSON.stringify({
+      type: skill.type,
+      tier: skill.tier,
+      cost: skill.cost,
+      val: skill.val,
+      desc: skill.desc,
+      effects: skill.effects
+    });
+    assert.strictEqual(comparableSkill(starfallDash), comparableSkill(dragonClaw));
+
+    const traitWiring = {
+      discipline_captain: { type: 'vanguard_all_grade_party_def_mdef', gradeRequired: 'normal', val: 100 },
+      supernova: { type: 'death_dmg_phy_debuff', val: 4, debuff: 'burn', stack: 3 },
+      shooting_star_boy: { type: 'opening_self_atk_party_mdef_down', turns: 2, atkBoost: 100, mdefDown: 50 },
+      victoria: { type: 'leader_field_stat_double', val: 2 },
+      holy_night: { type: 'death_dmg_phy', val: 3 },
+      paladin: { type: 'pos_stat_boost', pos: 1, stat: 'atk', val: 100 },
+      mad_scientist: { type: 'party_all_stats_mana_cost', statVal: 30, costMult: 2 },
+      grand_merchant: { type: 'death_next_ally_max_mana', val: 20 },
+      comet_tracker: { type: 'vanguard_delayed_mana_restore', val: 10 },
+      prophet: { type: 'field_kaleidoscope_each_turn' },
+      fireworks_girl: { type: 'death_dmg_phy_same_grade', val: 8 },
+      astrologer: { type: 'alternate_party_atk_matk_turn', val: 50 },
+      sun_moon_sword_maiden: { type: 'alternate_skill_type_mana', val: 10 }
+    };
+    Object.entries(traitWiring).forEach(([cardId, expected]) => {
+      const trait = getCard(cardId).trait;
+      Object.entries(expected).forEach(([key, value]) => {
+        assert.strictEqual(trait[key], value, cardId + ' trait.' + key);
+      });
+    });
+
+    const expectedSkills = [
+      ['discipline_captain', '잔소리', 'phy', 2, 20, 2, [{ type: 'debuff', id: 'silence' }]],
+      ['discipline_captain', '기강확립', 'mag', 2, 20, 2, [{ type: 'debuff', id: 'weak' }]],
+      ['supernova', '파이널버스트', 'phy', 3, 30, 6, [{ type: 'suicide' }]],
+      ['supernova', '코어멜트다운', 'mag', 3, 30, 2.5, [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2 }]],
+      ['shooting_star_boy', '슈팅플레어', 'mag', 2, 20, 1.5, [{ type: 'debuff', id: 'burn', stack: 1 }]],
+      ['victoria', '디바인아머', 'sup', 2, 20, null, [{ type: 'buff', id: 'guard', duration: 3 }]],
+      ['victoria', '에태르랜스', 'mag', 2, 20, 2, [{ type: 'debuff', id: 'corrosion' }]],
+      ['victoria', '기적의증명', 'sup', 3, 30, null, [{ type: 'delayed_field_buffs', turns: 3, buffs: ['goddess_descent', 'twinkle_party'] }]],
+      ['holy_night', '샤이닝팝', 'phy', 2, 20, 2, []],
+      ['holy_night', '라스트캐럴', 'phy', 3, 30, 4, [{ type: 'consume_debuff_all', debuff: 'divine', multPerStack: 2 }, { type: 'suicide' }]],
+      ['paladin', '디바인아머', 'sup', 2, 20, null, [{ type: 'buff', id: 'guard', duration: 3 }]],
+      ['paladin', '홀리그라운드', 'mag', 3, 30, 1, [{ type: 'field_buff', id: 'sanctuary' }]],
+      ['paladin', '듀얼브레이커', 'mag', 2, 20, 2, [{ type: 'consume_field_buff_dmg', buff: 'arena', mult: 3 }]],
+      ['mad_scientist', '익스페리먼트', 'mag', 2, 20, 2, [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'silence', mult: 2 }]],
+      ['mad_scientist', '다크인젝션', 'phy', 2, 20, 1.5, [{ type: 'debuff', id: 'darkness' }]],
+      ['grand_merchant', '마나콜렉트', 'sup', 1, 10, null, [{ type: 'mana_restore', val: 30 }]],
+      ['grand_merchant', '골드러쉬', 'mag', 3, 30, 2, [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'weak', mult: 2.5 }]],
+      ['comet_tracker', '코멧트래킹', 'mag', 3, 30, 4, [{ type: 'delayed_attack', turns: 2 }]],
+      ['comet_tracker', '코멧플레임', 'mag', 3, 30, 2.5, [{ type: 'debuff', id: 'burn', stack: 1 }]],
+      ['prophet', '샤이닝오라클', 'sup', 2, 20, null, [{ type: 'random_field_buff' }]],
+      ['prophet', '슈퍼내추럴', 'sup', 3, 30, null, [{ type: 'random_skill_trigger_from_list' }]],
+      ['fireworks_girl', '스파클캐논', 'mag', 2, 20, 2, [{ type: 'debuff', id: 'burn', stack: 1 }]],
+      ['astrologer', '스텔라리딩', 'sup', 3, 30, null, [{ type: 'moon_to_sun' }]],
+      ['astrologer', '솔라브레이커', 'mag', 2, 20, 2, [{ type: 'consume_field_buff_dmg', buff: 'sun_bless', mult: 4 }]],
+      ['sun_moon_sword_maiden', '솔라크레센토', 'phy', 3, 30, 2.5, [{ type: 'dmg_boost', condition: 'field_buff', buff: 'sun_bless', mult: 2 }]],
+      ['sun_moon_sword_maiden', '루나트레센토', 'mag', 3, 30, 2.5, [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2 }]]
+    ];
+    expectedSkills.forEach(([cardId, name, type, tier, cost, val, effects]) => {
+      const skill = getCard(cardId).skills.find(candidate => candidate.name === name);
+      assert(skill, cardId + ' is missing ' + name);
+      assert.deepStrictEqual(
+        [skill.type, skill.tier, skill.cost, Number.isFinite(skill.val) ? skill.val : null],
+        [type, tier, cost, val]
+      );
+      assert.strictEqual(JSON.stringify(skill.effects), JSON.stringify(effects), cardId + ' ' + name);
+    });
+    const festivalWiring = getCard('fireworks_girl').skills.find(skill => skill.name === '페스티벌나이트');
+    assert.deepStrictEqual(
+      [
+        festivalWiring.type,
+        festivalWiring.tier,
+        festivalWiring.cost,
+        festivalWiring.val,
+        JSON.stringify(festivalWiring.effects[0].turns),
+        festivalWiring.effects[1].debuff,
+        festivalWiring.effects[1].mult
+      ],
+      ['phy', 3, 30, 1.5, '[1,2,3]', 'burn', 2]
+    );
+    assert.strictEqual(getCard('paladin').skills.length, 4);
+    assert.strictEqual(getCard('victoria').skills.length, 3);
+
+    const featureHost = {
+      global: { unlocked_special_cards: [] },
+      getCardData: getCard
+    };
+    RPGFeatureModules.install(featureHost);
+    const datedWaveIds = bonusWaveExpectations.filter(entry => entry[5]).map(entry => entry[0]);
+    const releasedWaveIds = date => featureHost.getReleasedStandardBonusCards(date)
+      .map(card => card.id)
+      .filter(id => datedWaveIds.includes(id))
+      .sort();
+    const expectedReleasedIds = ids => [...ids].sort();
+    assert.deepStrictEqual(releasedWaveIds(new Date(2026, 6, 31, 12)), []);
+    assert.deepStrictEqual(
+      releasedWaveIds(new Date(2026, 7, 1, 12)),
+      expectedReleasedIds(['discipline_captain', 'supernova'])
+    );
+    assert.deepStrictEqual(
+      releasedWaveIds(new Date(2026, 7, 15, 12)),
+      expectedReleasedIds(['discipline_captain', 'supernova', 'shooting_star_boy', 'victoria'])
+    );
+    assert.deepStrictEqual(
+      releasedWaveIds(new Date(2026, 8, 1, 12)),
+      expectedReleasedIds([
+        'discipline_captain', 'supernova', 'shooting_star_boy', 'victoria',
+        'holy_night', 'paladin'
+      ])
+    );
+    assert.deepStrictEqual(
+      releasedWaveIds(new Date(2026, 8, 15, 12)),
+      expectedReleasedIds([
+        'discipline_captain', 'supernova', 'shooting_star_boy', 'victoria',
+        'holy_night', 'paladin', 'mad_scientist', 'grand_merchant'
+      ])
+    );
+    assert.deepStrictEqual(
+      releasedWaveIds(new Date(2026, 9, 1, 12)),
+      expectedReleasedIds([
+        'discipline_captain', 'supernova', 'shooting_star_boy', 'victoria',
+        'holy_night', 'paladin', 'mad_scientist', 'grand_merchant',
+        'comet_tracker', 'prophet'
+      ])
+    );
+    assert.deepStrictEqual(
+      releasedWaveIds(new Date(2026, 9, 15, 12)),
+      expectedReleasedIds(datedWaveIds)
+    );
+    assert(featureHost.getHiddenBonusCards().some(card => card.id === 'astrologer'));
+    assert(featureHost.getHiddenBonusCards().some(card => card.id === 'sun_moon_sword_maiden'));
+    assert.strictEqual(
+      featureHost.getReleasedStandardBonusCards(new Date(2030, 0, 1))
+        .some(card => ['astrologer', 'sun_moon_sword_maiden'].includes(card.id)),
+      false
+    );
+    const allHiddenBonusIds = featureHost.getHiddenBonusCards().map(card => card.id);
+    ['astrologer', 'sun_moon_sword_maiden'].forEach(targetId => {
+      const monthlyMissionHost = {
+        global: {
+          unlocked_bonus_cards: allHiddenBonusIds.filter(id => id !== targetId)
+        },
+        getCardData: getCard
+      };
+      RPGFeatureModules.install(monthlyMissionHost);
+      assert.strictEqual(
+        monthlyMissionHost.createMonthlyMissionState().rewardCardId,
+        targetId,
+        targetId + ' must remain obtainable from the monthly mission'
+      );
+    });
+
+    // Swimsuit Luna is reachable through the real beach mission reward selection.
+    const beachHost = {
+      global: {
+        unlocked_special_cards: [
+          'jasmine_swimsuit', 'rumi_swimsuit', 'zeke_swimsuit',
+          'snow_rabbit_swimsuit', 'night_rabbit_swimsuit', 'silver_rabbit_swimsuit'
+        ]
+      },
+      getCardData: getCard
+    };
+    RPGFeatureModules.install(beachHost);
+    assert.deepStrictEqual(
+      Array.from(beachHost.getRemainingSpecialRewardCards('beach'), card => card.id),
+      ['luna_swimsuit']
+    );
+    const beachMission = beachHost.createSpecialMissionState({
+      season: beachHost.getCurrentSpecialSeason(new Date(2026, 6, 15)),
+      unlocked: true
+    });
+    assert.strictEqual(beachMission.rewardCardId, 'luna_swimsuit');
 
     // One Joker can fill only one missing slot in a conjunctive card requirement.
     assert.strictEqual(
@@ -180,6 +394,145 @@ function run() {
     const blackSwanInit = Logic.calculateInitialStats(blackSwan, ['black_swan', 'vampire', 'vampire'], GameUtils.getAllCards(), 0);
     assert.strictEqual(blackSwanInit.stats.baseCrit, GAME_CONSTANTS.BASE_CRIT + 20);
 
+    const allCardData = GameUtils.getAllCards();
+    const buildWaveUnit = (id, deck, idx) => {
+      const proto = getCard(id);
+      const init = Logic.calculateInitialStats(proto, deck, allCardData, idx);
+      return makeUnit({
+        id,
+        name: proto.name,
+        ...init.stats,
+        proto,
+        activeTrait: init.activeTrait,
+        pos: idx,
+        isDead: false,
+        skills: JSON.parse(JSON.stringify(proto.skills)),
+        buffs: {}
+      });
+    };
+
+    // New positional, opening-turn, party-stat, and field-stat traits use engine conventions.
+    const allNormalDeck = ['discipline_captain', 'marshmallow', 'kobold'];
+    const disciplineFront = buildWaveUnit('discipline_captain', allNormalDeck, 0);
+    const disciplinedPeer = buildWaveUnit('marshmallow', allNormalDeck, 1);
+    assert.strictEqual(disciplineFront.activeTrait, 'vanguard_all_grade_party_def_mdef');
+    assert.deepStrictEqual([disciplineFront.def, disciplineFront.mdef], [120, 120]);
+    assert.deepStrictEqual([disciplinedPeer.def, disciplinedPeer.mdef], [100, 100]);
+    const mixedDiscipline = buildWaveUnit(
+      'discipline_captain',
+      ['discipline_captain', 'marshmallow', 'paladin'],
+      0
+    );
+    assert.strictEqual(mixedDiscipline.activeTrait, null);
+    assert.deepStrictEqual([mixedDiscipline.def, mixedDiscipline.mdef], [60, 60]);
+
+    const starDeck = ['shooting_star_boy', 'marshmallow', 'kobold'];
+    const shootingStar = buildWaveUnit('shooting_star_boy', starDeck, 0);
+    assert.strictEqual(shootingStar.mdef, 27);
+    assert.strictEqual(Logic.calculateStats(shootingStar, [], 'default', [], 1).atk, 170);
+    assert.strictEqual(Logic.calculateStats(shootingStar, [], 'default', [], 2).atk, 170);
+    assert.strictEqual(Logic.calculateStats(shootingStar, [], 'default', [], 3).atk, 85);
+    const starSkillTarget = makeUnit({ hp: 5000, maxHp: 5000 });
+    const fullHpStar = { ...shootingStar, hp: shootingStar.maxHp, baseCrit: -100 };
+    const hurtStar = { ...shootingStar, hp: shootingStar.maxHp - 1, baseCrit: -100 };
+    const fullHpStarDamage = Logic.calculateDamage(
+      fullHpStar, starSkillTarget, starfallDash, [], [], quiet, 'default', starDeck, 3, []
+    ).dmg;
+    const hurtStarDamage = Logic.calculateDamage(
+      hurtStar, starSkillTarget, starfallDash, [], [], quiet, 'default', starDeck, 3, []
+    ).dmg;
+    assert.strictEqual(fullHpStarDamage, hurtStarDamage * 2);
+
+    const madDeck = ['mad_scientist', 'luna', 'paladin'];
+    const madScientist = buildWaveUnit('mad_scientist', madDeck, 0);
+    const madScientistPeer = buildWaveUnit('luna', madDeck, 1);
+    assert.deepStrictEqual(
+      [madScientist.atk, madScientist.matk, madScientist.def, madScientist.mdef],
+      [104, 104, 71, 71]
+    );
+    assert.deepStrictEqual(
+      [madScientistPeer.atk, madScientistPeer.matk, madScientistPeer.def, madScientistPeer.mdef],
+      [169, 169, 78, 84]
+    );
+
+    assert.strictEqual(
+      buildWaveUnit('paladin', ['marshmallow', 'paladin', 'kobold'], 1).atk,
+      210
+    );
+    assert.strictEqual(
+      buildWaveUnit('paladin', ['paladin', 'marshmallow', 'kobold'], 0).atk,
+      105
+    );
+
+    const victoriaLeader = buildWaveUnit('victoria', ['marshmallow', 'kobold', 'victoria'], 2);
+    const victoriaFront = buildWaveUnit('victoria', ['victoria', 'marshmallow', 'kobold'], 0);
+    assert.strictEqual(victoriaLeader.fieldBuffStatMult, 2);
+    assert.strictEqual(victoriaFront.fieldBuffStatMult, undefined);
+    assert.deepStrictEqual(
+      [
+        Logic.calculateStats(victoriaLeader, [{ name: 'sun_bless' }], 'default', [], 1).atk,
+        Logic.calculateStats(victoriaFront, [{ name: 'sun_bless' }], 'default', [], 1).atk
+      ],
+      [160, 130]
+    );
+
+    const alternatingUnit = makeUnit({ atk: 100, matk: 100, alternatingAttackStatPercent: 50 });
+    assert.deepStrictEqual(
+      [
+        Logic.calculateStats(alternatingUnit, [], 'default', [], 1).atk,
+        Logic.calculateStats(alternatingUnit, [], 'default', [], 1).matk
+      ],
+      [50, 150]
+    );
+    assert.deepStrictEqual(
+      [
+        Logic.calculateStats(alternatingUnit, [], 'default', [], 2).atk,
+        Logic.calculateStats(alternatingUnit, [], 'default', [], 2).matk
+      ],
+      [150, 50]
+    );
+
+    // New death effects preserve exact damage and stack conditions.
+    const deathTarget = makeUnit({ hp: 10000, maxHp: 10000, baseCrit: -100 });
+    const supernovaUnit = buildWaveUnit('supernova', ['supernova'], 0);
+    supernovaUnit.baseCrit = -100;
+    const supernovaDeath = Logic.handleDeathTraits(
+      supernovaUnit, deathTarget, [], quiet, ['supernova'], 1, []
+    );
+    assert.strictEqual(supernovaDeath.damageToKiller, 500);
+    assert.strictEqual(supernovaDeath.killerDebuffs.burn, 3);
+
+    const fireworksUnit = buildWaveUnit(
+      'fireworks_girl',
+      ['fireworks_girl', 'astrologer', 'paladin'],
+      0
+    );
+    fireworksUnit.baseCrit = -100;
+    assert.strictEqual(
+      Logic.handleDeathTraits(
+        fireworksUnit,
+        deathTarget,
+        [],
+        quiet,
+        ['fireworks_girl', 'astrologer', 'paladin'],
+        1,
+        []
+      ).damageToKiller,
+      800
+    );
+    assert.strictEqual(
+      Logic.handleDeathTraits(
+        fireworksUnit,
+        deathTarget,
+        [],
+        quiet,
+        ['fireworks_girl', 'supernova'],
+        1,
+        []
+      ).damageToKiller,
+      0
+    );
+
     const makeRpg = (source, deck, fieldBuffs = []) => ({
       state: { deck, artifacts: [], mode: 'default' },
       battle: { players: [source], enemy: makeUnit({ id: 'enemy' }), fieldBuffs, activeTraits: [], delayedEffects: [], turn: 1, currentPlayerIdx: 0, phase: 'player-ready', isFinished: false },
@@ -192,6 +545,236 @@ function run() {
       renderBattleView: quiet,
       renderBattleControls: quiet
     });
+
+    // Battle initialization applies the scientist's cost penalty and astrologer's party cycle.
+    const makeBattleInitRpg = deck => ({
+      state: {
+        deck,
+        artifacts: [],
+        chaosBuffs: [],
+        mode: 'default',
+        gameType: 'standard',
+        enemyScale: 0,
+        hardMode: false
+      },
+      battle: {},
+      NORMAL_ATTACK: { name: '일반 공격', type: 'phy', tier: 1, cost: 0, val: 1, effects: [] },
+      getCardData: getCard,
+      getCurrentStageEnemyData: () => ENEMIES[0],
+      hasArtifact: () => false,
+      showBattleScreen: quiet,
+      showAlert: message => { throw new Error(message); },
+      clearBattleLog: quiet,
+      log: quiet,
+      renderBattleView: quiet,
+      renderBattleControls: quiet,
+      winBattle: quiet,
+      loseBattle: quiet
+    });
+    const startPlayerTurnOriginal = BattleRuntime.TurnManager.startPlayerTurn;
+    BattleRuntime.TurnManager.startPlayerTurn = quiet;
+    const waveInitRpg = makeBattleInitRpg(['mad_scientist', 'astrologer', 'grand_merchant']);
+    BattleRuntime.startBattleInit(waveInitRpg);
+    BattleRuntime.TurnManager.startPlayerTurn = startPlayerTurnOriginal;
+    assert.deepStrictEqual(
+      Array.from(waveInitRpg.battle.players[0].skills, skill => skill.cost),
+      [20, 40, 40]
+    );
+    assert(waveInitRpg.battle.players.every(unit => unit.alternatingAttackStatPercent === 50));
+    assert(waveInitRpg.battle.players.every(unit => unit.maxMp === 100 && unit.mp === 100));
+
+    // The merchant hands 20 maximum and current mana to the next living ally.
+    const merchantVictim = buildWaveUnit('grand_merchant', ['grand_merchant', 'marshmallow', 'kobold'], 0);
+    merchantVictim.isDead = true;
+    const deadMiddle = makeUnit({ name: 'dead middle', pos: 1, isDead: true });
+    const merchantSuccessor = makeUnit({ name: 'successor', pos: 2, isDead: false, mp: 100, maxMp: 100 });
+    const merchantRpg = makeRpg(merchantVictim, ['grand_merchant', 'marshmallow', 'kobold']);
+    merchantRpg.battle.players = [merchantVictim, deadMiddle, merchantSuccessor];
+    BattleRuntime.handleDeathTraits(merchantRpg, merchantVictim, merchantRpg.battle.enemy);
+    assert.deepStrictEqual([merchantSuccessor.mp, merchantSuccessor.maxMp], [120, 120]);
+    BattleRuntime.applySkillEffects(
+      merchantRpg,
+      merchantSuccessor,
+      merchantRpg.battle.enemy,
+      getCard('grand_merchant').skills.find(skill => skill.name === '마나콜렉트')
+    );
+    assert.deepStrictEqual([merchantSuccessor.mp, merchantSuccessor.maxMp], [120, 120]);
+
+    // The comet trait recovers mana only when a reserved delayed skill actually fires.
+    scheduledCallbacks.length = 0;
+    const cometSource = buildWaveUnit('comet_tracker', ['comet_tracker'], 0);
+    const cometRpg = makeRpg(cometSource, ['comet_tracker']);
+    cometRpg.battle.activeTraits = ['vanguard_delayed_mana_restore'];
+    cometRpg.battle.enemy = makeUnit({ id: 'comet-target', hp: 5000, maxHp: 5000 });
+    const cometTracking = cometSource.skills.find(skill => skill.name === '코멧트래킹');
+    BattleRuntime.executeSkill(cometRpg, cometSource, cometRpg.battle.enemy, cometTracking);
+    assert.strictEqual(cometSource.mp, 70);
+    assert.strictEqual(cometRpg.battle.delayedEffects.length, 1);
+    const reservedComet = cometRpg.battle.delayedEffects[0].skill;
+    assert.strictEqual(reservedComet.isActualDelayedTrigger, true);
+    assert.strictEqual(cometRpg.battle.delayedEffects[0].turn, 3);
+    cometRpg.battle.turn = 3;
+    cometRpg.battle.isNewTurn = false;
+    BattleRuntime.TurnManager.startPlayerTurn(cometRpg);
+    assert.strictEqual(cometSource.mp, 80);
+    assert.strictEqual(cometRpg.battle.delayedEffects.length, 0);
+    cometSource.mp = 50;
+    BattleRuntime.executeSkill(
+      cometRpg,
+      cometSource,
+      cometRpg.battle.enemy,
+      { name: '즉시 랜덤 보조', type: 'sup', cost: 0, effects: [] },
+      true
+    );
+    assert.strictEqual(cometSource.mp, 50);
+
+    const instantTracker = buildWaveUnit(
+      'comet_tracker',
+      ['comet_tracker', 'time_ruler', 'time_magician'],
+      0
+    );
+    const instantDelayedCaster = buildWaveUnit(
+      'time_ruler',
+      ['comet_tracker', 'time_ruler', 'time_magician'],
+      1
+    );
+    const instantTimeMagician = buildWaveUnit(
+      'time_magician',
+      ['comet_tracker', 'time_ruler', 'time_magician'],
+      2
+    );
+    const instantDelayRpg = makeRpg(
+      instantTracker,
+      ['comet_tracker', 'time_ruler', 'time_magician']
+    );
+    instantDelayRpg.battle.players = [instantTracker, instantDelayedCaster, instantTimeMagician];
+    instantDelayRpg.battle.currentPlayerIdx = 1;
+    instantDelayRpg.battle.activeTraits = ['vanguard_delayed_mana_restore', 'instant_delayed_skills'];
+    instantDelayRpg.battle.enemy = makeUnit({ id: 'instant-delay-target', hp: 5000, maxHp: 5000 });
+    BattleRuntime.executeSkill(
+      instantDelayRpg,
+      instantDelayedCaster,
+      instantDelayRpg.battle.enemy,
+      instantDelayedCaster.skills.find(skill => skill.name === '종언의예고')
+    );
+    assert.strictEqual(instantDelayedCaster.mp, 80);
+    assert.strictEqual(instantDelayRpg.battle.delayedEffects.length, 0);
+
+    // Victoria's proof resolves after three turns and creates both fixed field buffs.
+    scheduledCallbacks.length = 0;
+    const proofSource = buildWaveUnit('victoria', ['victoria'], 0);
+    const proofRpg = makeRpg(proofSource, ['victoria']);
+    proofRpg.battle.enemy = makeUnit({ id: 'proof-target', hp: 5000, maxHp: 5000 });
+    const miracleProof = proofSource.skills.find(skill => skill.name === '기적의증명');
+    BattleRuntime.executeSkill(proofRpg, proofSource, proofRpg.battle.enemy, miracleProof);
+    assert.strictEqual(proofRpg.battle.delayedEffects[0].turn, 4);
+    proofRpg.battle.turn = 4;
+    proofRpg.battle.isNewTurn = false;
+    BattleRuntime.TurnManager.startPlayerTurn(proofRpg);
+    assert.strictEqual(proofRpg.battle.delayedEffects.length, 0);
+    assert.deepStrictEqual(
+      Array.from(proofRpg.battle.fieldBuffs, buff => buff.name).sort(),
+      ['goddess_descent', 'twinkle_party']
+    );
+
+    // Festival Night schedules exactly three Phantom-style hits and checks burn on every hit.
+    scheduledCallbacks.length = 0;
+    const fireworksSource = buildWaveUnit('fireworks_girl', ['fireworks_girl'], 0);
+    fireworksSource.baseCrit = -100;
+    const fireworksRpg = makeRpg(fireworksSource, ['fireworks_girl']);
+    fireworksRpg.battle.enemy = makeUnit({
+      id: 'festival-target',
+      hp: 10000,
+      maxHp: 10000,
+      buffs: { burn: 1 }
+    });
+    const festivalNight = fireworksSource.skills.find(skill => skill.name === '페스티벌나이트');
+    BattleRuntime.executeSkill(fireworksRpg, fireworksSource, fireworksRpg.battle.enemy, festivalNight);
+    assert.deepStrictEqual(
+      Array.from(fireworksRpg.battle.delayedEffects, effect => effect.turn),
+      [2, 3, 4]
+    );
+    BattleRuntime.executeSkill(
+      fireworksRpg,
+      fireworksSource,
+      fireworksRpg.battle.enemy,
+      fireworksRpg.battle.delayedEffects[0].skill,
+      true
+    );
+    delete fireworksRpg.battle.enemy.buffs.burn;
+    fireworksRpg.battle.delayedEffects.slice(1).forEach(effect => {
+      BattleRuntime.executeSkill(fireworksRpg, fireworksSource, fireworksRpg.battle.enemy, effect.skill, true);
+    });
+    assert.strictEqual(fireworksRpg.battle.enemy.hp, 9400);
+
+    // Stellar Reading alternates moon creation and moon-to-sun conversion.
+    const astrologerSource = buildWaveUnit('astrologer', ['astrologer'], 0);
+    const astrologerRpg = makeRpg(astrologerSource, ['astrologer']);
+    const stellarReading = astrologerSource.skills.find(skill => skill.name === '스텔라리딩');
+    BattleRuntime.applySkillEffects(astrologerRpg, astrologerSource, astrologerRpg.battle.enemy, stellarReading);
+    assert.deepStrictEqual(
+      Array.from(astrologerRpg.battle.fieldBuffs, buff => buff.name),
+      ['moon_bless']
+    );
+    BattleRuntime.applySkillEffects(astrologerRpg, astrologerSource, astrologerRpg.battle.enemy, stellarReading);
+    assert.deepStrictEqual(
+      Array.from(astrologerRpg.battle.fieldBuffs, buff => buff.name),
+      ['sun_bless']
+    );
+
+    // Prophet and the Kaleidoscope artifact share one replacement pass per turn.
+    const prophetTraitSource = buildWaveUnit('prophet', ['prophet'], 0);
+    const prophetTraitRpg = makeRpg(prophetTraitSource, ['prophet'], [{ name: 'sun_bless' }]);
+    prophetTraitRpg.battle.activeTraits = ['field_kaleidoscope_each_turn'];
+    prophetTraitRpg.battle.isNewTurn = true;
+    let kaleidoscopeReplacementCount = 0;
+    const replaceFieldBuffsOriginal = BattleRuntime.replaceFieldBuffsLikeKaleidoscope;
+    BattleRuntime.replaceFieldBuffsLikeKaleidoscope = rpg => {
+      kaleidoscopeReplacementCount++;
+      return replaceFieldBuffsOriginal(rpg);
+    };
+    BattleRuntime.TurnManager.startPlayerTurn(prophetTraitRpg);
+    assert.strictEqual(kaleidoscopeReplacementCount, 1);
+    assert.strictEqual(prophetTraitRpg.battle.fieldBuffs.length, 1);
+
+    const prophetCombinedSource = buildWaveUnit('prophet', ['prophet'], 0);
+    const prophetCombinedRpg = makeRpg(
+      prophetCombinedSource,
+      ['prophet'],
+      [{ name: 'sun_bless' }]
+    );
+    prophetCombinedRpg.battle.activeTraits = ['field_kaleidoscope_each_turn'];
+    prophetCombinedRpg.battle.isNewTurn = true;
+    prophetCombinedRpg.hasArtifact = id => id === 'kaleidoscope';
+    kaleidoscopeReplacementCount = 0;
+    BattleRuntime.TurnManager.startPlayerTurn(prophetCombinedRpg);
+    BattleRuntime.replaceFieldBuffsLikeKaleidoscope = replaceFieldBuffsOriginal;
+    assert.strictEqual(kaleidoscopeReplacementCount, 1);
+    assert.strictEqual(prophetCombinedRpg.battle.fieldBuffs.length, 1);
+
+    // Sun-Moon Sword Maiden restores mana only after a manual skill-type change.
+    scheduledCallbacks.length = 0;
+    const swordMaiden = buildWaveUnit('sun_moon_sword_maiden', ['sun_moon_sword_maiden'], 0);
+    swordMaiden.mp = 60;
+    const swordRpg = makeRpg(swordMaiden, ['sun_moon_sword_maiden']);
+    swordRpg.battle.enemy = makeUnit({ id: 'sword-target', hp: 10000, maxHp: 10000 });
+    const useSwordSkill = (name, type) => {
+      swordRpg.battle.phase = 'player-ready';
+      assert.strictEqual(
+        BattleRuntime.executeSkill(
+          swordRpg,
+          swordMaiden,
+          swordRpg.battle.enemy,
+          { name, type, cost: 10, val: type === 'sup' ? undefined : 1, effects: [] }
+        ),
+        true
+      );
+      return swordMaiden.mp;
+    };
+    assert.strictEqual(useSwordSkill('첫 물리', 'phy'), 50);
+    assert.strictEqual(useSwordSkill('같은 물리', 'phy'), 40);
+    assert.strictEqual(useSwordSkill('마법 전환', 'mag'), 40);
+    assert.strictEqual(useSwordSkill('보조 전환', 'sup'), 40);
 
     // The complete effect context lets Flare Ribbon inspect special-card grades.
     const flare = makeUnit({ id: 'flare_ribbon', proto: getCard('flare_ribbon') });

--- a/scripts/verify_card_special_flow.js
+++ b/scripts/verify_card_special_flow.js
@@ -33,10 +33,13 @@ async function run() {
 
     localStorage.clear();
     RPG.loadGlobalData();
+    const getCurrentSpecialSeasonOriginal = RPG.getCurrentSpecialSeason;
+    const beachSeason = getCurrentSpecialSeasonOriginal.call(RPG, new Date(2026, 6, 15));
+    RPG.getCurrentSpecialSeason = () => beachSeason;
 
     const titleButtons = [...document.querySelectorAll('.title-screen-actions button')].map(btn => btn.innerText.trim());
     assert(
-      JSON.stringify(titleButtons) === JSON.stringify(['새로하기', '이어하기', '질문하기', '미션확인']),
+      JSON.stringify(titleButtons) === JSON.stringify(['새로하기', '이어하기', '포춘쿠키', '질문하기', '미션확인']),
       'title_menu',
       titleButtons.join(', ')
     );
@@ -186,6 +189,7 @@ async function run() {
     );
 
     const rewardId = RPG.global.specialMission.rewardCardId;
+    assert(rewardId === 'luna_swimsuit', 'swimsuit_luna_reward', rewardId);
     RPG.global.specialMission.missions.challenge3.progress = 3;
     RPG.global.specialMission.missions.toeic3.progress = 3;
     RPG.global.specialMission.missions.boss.progress = 1;
@@ -214,6 +218,7 @@ async function run() {
       `${rewardId} replaces ${rewardCard.specialBaseId}`
     );
 
+    RPG.getCurrentSpecialSeason = getCurrentSpecialSeasonOriginal;
     return output;
   });
 

--- a/scripts/verify_gemini_api_models.js
+++ b/scripts/verify_gemini_api_models.js
@@ -1,0 +1,181 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const FLASH_MODEL_ID = 'gemini-3.6-flash';
+const FLASH_LITE_MODEL_ID = 'gemini-3.5-flash-lite';
+const LEGACY_MODEL_IDS = ['gemini-3-flash-preview', 'gemini-3.1-flash-lite'];
+
+function countMatches(source, pattern) {
+  return (source.match(pattern) || []).length;
+}
+
+function assertOfficialRequestShape(filePath) {
+  const source = fs.readFileSync(filePath, 'utf8');
+  LEGACY_MODEL_IDS.forEach(modelId => {
+    assert.strictEqual(source.includes(modelId), false, `${filePath} still references ${modelId}`);
+  });
+  assert.strictEqual(source.includes('?key='), false, `${filePath} still sends the API key in the URL`);
+
+  const fetchLines = source.split(/\r?\n/).filter(line => line.includes('fetch('));
+  assert(fetchLines.length > 0, `${filePath} has no Gemini request to verify`);
+  fetchLines.forEach(line => {
+    assert(
+      line.includes('fetch(getGeminiGenerateContentUrl('),
+      `${filePath} has a request that bypasses the shared generateContent URL helper`
+    );
+  });
+  assert.strictEqual(
+    countMatches(source, /headers:\s*getGeminiRequestHeaders\(/g),
+    fetchLines.length,
+    `${filePath} must use the official API-key header on every request`
+  );
+}
+
+function makeGeminiResponse() {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => '',
+    json: async () => ({
+      candidates: [{
+        content: {
+          role: 'model',
+          parts: [{ text: 'ok' }]
+        }
+      }]
+    })
+  };
+}
+
+async function run() {
+  const root = process.cwd();
+  const cardApiPath = path.join(root, 'card', 'api.js');
+  const remasterApiPath = path.join(root, 'card_remaster', 'api.js');
+  const relatedFiles = [
+    cardApiPath,
+    path.join(root, 'card', 'index.html'),
+    path.join(root, 'card', 'fortune_cookie.js'),
+    remasterApiPath
+  ];
+
+  relatedFiles.forEach(filePath => {
+    const source = fs.readFileSync(filePath, 'utf8');
+    LEGACY_MODEL_IDS.forEach(modelId => {
+      assert.strictEqual(source.includes(modelId), false, `${filePath} still references ${modelId}`);
+    });
+  });
+  assertOfficialRequestShape(cardApiPath);
+  assertOfficialRequestShape(remasterApiPath);
+  const remasterApiSource = fs.readFileSync(remasterApiPath, 'utf8');
+  assert(
+    remasterApiSource.includes(`const GEMINI_FLASH_MODEL_ID = '${FLASH_MODEL_ID}';`),
+    'card_remaster/api.js must target the current Flash model'
+  );
+  assert.strictEqual(
+    remasterApiSource.includes('temperature'),
+    false,
+    'card_remaster/api.js must not send removed sampling parameters to Gemini 3.x'
+  );
+
+  const requests = [];
+  const sandbox = {
+    console,
+    AbortController,
+    DOMException,
+    setTimeout,
+    clearTimeout,
+    fetch: async (url, options) => {
+      requests.push({
+        url: String(url),
+        headers: { ...(options.headers || {}) },
+        body: JSON.parse(options.body)
+      });
+      return makeGeminiResponse();
+    },
+    RPG: {
+      global: { tutoringEventEnabled: false },
+      state: { enemyScale: 0 }
+    },
+    GAME_CONSTANTS: {
+      TUTORING_EVENT: {
+        STAGE_THRESHOLD: 30,
+        PROB_HIGH: 0.5,
+        PROB_BASE: 0.3
+      }
+    }
+  };
+  sandbox.window = sandbox;
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(cardApiPath, 'utf8'), sandbox, { filename: cardApiPath });
+
+  const evaluate = source => vm.runInContext(source, sandbox, { filename: 'gemini-api-regression' });
+  const modelOptions = JSON.parse(evaluate(
+    'JSON.stringify(LumiQuestionRuntime.MODEL_OPTIONS.map(option => option.id))'
+  ));
+  assert.deepStrictEqual(modelOptions, ['gemini-2.5-pro', FLASH_MODEL_ID, FLASH_LITE_MODEL_ID]);
+
+  for (const modelId of [FLASH_MODEL_ID, FLASH_LITE_MODEL_ID]) {
+    await evaluate(`GameAPI.getTutoringContent(
+      'test-key',
+      { word: 'sample', meaning: '표본' },
+      'word',
+      { model: '${modelId}' }
+    )`);
+    await evaluate(`requestLumiQuestion(
+      'test-key',
+      [{ role: 'user', parts: [{ text: 'hello' }] }],
+      { model: '${modelId}', enableSearch: false, timeoutMs: 0 }
+    )`);
+    await evaluate(`GameAPI.getDateContent(
+      'test-key',
+      {
+        theme: '도서관',
+        outfit: '교복',
+        weather: '실내',
+        keyword: '귀여운 실수',
+        word: 'study',
+        secret: false,
+        daysSinceLastDate: 4
+      },
+      { model: '${modelId}' }
+    )`);
+    await evaluate(`GameAPI.getFortuneContent(
+      'test-key',
+      {
+        grade: '대길',
+        gradeDescription: '좋은 하루',
+        keyword: '반짝이는 영감',
+        timeOfDay: 'morning',
+        event: null
+      },
+      { model: '${modelId}' }
+    )`);
+  }
+
+  assert.strictEqual(requests.length, 8);
+  requests.forEach((request, index) => {
+    const expectedModel = index < 4 ? FLASH_MODEL_ID : FLASH_LITE_MODEL_ID;
+    assert(
+      request.url.endsWith(`/v1beta/models/${expectedModel}:generateContent`),
+      `request ${index + 1} used the wrong model URL: ${request.url}`
+    );
+    assert.strictEqual(request.url.includes('?'), false);
+    assert.strictEqual(request.headers['Content-Type'], 'application/json');
+    assert.strictEqual(request.headers['x-goog-api-key'], 'test-key');
+    assert.strictEqual(
+      Object.hasOwn(request.body.generationConfig || {}, 'temperature'),
+      false,
+      `request ${index + 1} sent a deprecated sampling parameter`
+    );
+  });
+
+  console.log('Gemini API model verification passed.');
+}
+
+run().catch(error => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## 변경 사항

- 2026년 8월~10월 날짜 보너스 카드 11장을 추가했습니다.
- 날짜와 무관하게 월간 미션으로 획득하는 히든 카드 `점성술사`, `일월검희`를 추가했습니다.
- 신규 특성/스킬에 필요한 지연 발동, 턴별 스탯 교대, 사망 효과, 필드버프, 최대마나 120 처리 등을 전투 엔진에 연결했습니다.
- 해변 스페셜 미션 보상 풀에서 누락됐던 `루나(수영복)`를 연결했습니다.
- Gemini Flash/Lite를 각각 `gemini-3.6-flash`, `gemini-3.5-flash-lite`로 갱신하고 모든 호출을 공식 `generateContent` 엔드포인트와 `x-goog-api-key` 인증 방식으로 통일했습니다.
- 신규 카드, 날짜 경계, 월간 히든 보상, 실제 지연 발동, 루나 미션, Gemini 요청 형식을 검증하는 회귀 테스트를 추가했습니다.

## 배경 및 원인

신규 보너스 카드 데이터와 이를 실행할 일부 전투 훅이 아직 없었고, `luna_swimsuit`은 카드/변형 정의는 존재하지만 해변 미션의 `rewardCardIds`에서만 누락돼 실제 보상으로 선택되지 않았습니다. 또한 Gemini 호출부에는 이전 Flash/Lite 모델 식별자와 URL 쿼리 기반 API 키 전달 방식이 남아 있었습니다.

## 영향

- 표준 보너스 카드는 지정 출시일부터 보상 풀에 나타납니다.
- 히든 2장은 출시일 제한 없이 기존 월간 미션 보상 규칙으로만 획득합니다.
- 수영복 루나는 해변 미션 완료 후 획득하고 기본 루나를 대체할 수 있습니다.
- 메인 카드 앱과 리마스터의 Gemini 호출이 최신 모델/요청 형식을 사용합니다.

## 검증

- `npm run verify`
- `node scripts/verify_card_patch.js`
- `node scripts/verify_card_special_flow.js`
- `git diff --check`
- 이전 Gemini Flash/Lite 모델 ID 잔존 여부 검색 (0건)
