### PR TITLE
일월검희 스킬명 '루나크레센토'로 수정

### DIFF
--- a/card/data.js
+++ b/card/data.js
@@ -1232,7 +1232,7 @@ const BONUS_CARD_EXPANSION = [
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '솔라크레센토', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '태양의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'sun_bless', mult: 2.0 }] },
-            { name: '루나트레센토', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '달의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.0 }] }
+            { name: '루나크레센토', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '달의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.0 }] }
         ]
     }
 ];

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -152,7 +152,7 @@ function run() {
       ['astrologer', '스텔라리딩', 'sup', 3, 30, null, [{ type: 'moon_to_sun' }]],
       ['astrologer', '솔라브레이커', 'mag', 2, 20, 2, [{ type: 'consume_field_buff_dmg', buff: 'sun_bless', mult: 4 }]],
       ['sun_moon_sword_maiden', '솔라크레센토', 'phy', 3, 30, 2.5, [{ type: 'dmg_boost', condition: 'field_buff', buff: 'sun_bless', mult: 2 }]],
-      ['sun_moon_sword_maiden', '루나트레센토', 'mag', 3, 30, 2.5, [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2 }]]
+      ['sun_moon_sword_maiden', '루나크레센토', 'mag', 3, 30, 2.5, [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2 }]]
     ];
     expectedSkills.forEach(([cardId, name, type, tier, cost, val, effects]) => {
       const skill = getCard(cardId).skills.find(candidate => candidate.name === name);


### PR DESCRIPTION
### Motivation
- 카드 데이터에 있는 일월검희의 마법 스킬명이 오타(`루나트레센토`)로 되어 있어 의도한 명칭(`루나크레센토`)으로 정정했습니다.

### Description
- `card/data.js`에서 일월검희(sun_moon_sword_maiden) 스킬 이름을 `루나트레센토`에서 `루나크레센토`로 변경했습니다.
- `scripts/verify_card_combat_regressions.js`의 기대 스킬명 배열에서도 동일하게 `루나크레센토`로 갱신했습니다.

### Testing
- 자동 검증으로 `npm run verify`를 실행했으며(린트 및 스모크/회귀 검증 포함) 모든 검증 스크립트가 통과했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64eb44226483228420882915339cab)