### PR TITLE
Add artifact chaos and reserve modes

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -78,7 +78,7 @@ function buildBattleEnemy(rpg) {
     let steps = 0;
     if (rpg.state.mode === 'puzzle') {
         steps = 2;
-    } else if (['artifact', 'flood', 'curse'].includes(rpg.state.mode)) {
+    } else if (['artifact', 'artifact_chaos', 'artifact_reserve', 'flood', 'curse'].includes(rpg.state.mode)) {
         if (rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') {
             steps = 1;
         }
@@ -199,6 +199,10 @@ const BattleRuntime = {
     },
 
     startBattleInit(rpg) {
+        if (rpg.state.mode === 'artifact_reserve' && rpg.state.artifactReserveDraft && rpg.state.artifactReserveDraft.active) {
+            return rpg.showAlert("아티팩트 리저브 선택을 먼저 완료해주세요.");
+        }
+
         if (rpg.state.mode === 'puzzle') {
             if (!rpg.state.puzzlePiecesClaimed) {
                 return rpg.showAlert("퍼즐 모드는 먼저 퍼즐조각획득을 완료해야 합니다.");
@@ -210,6 +214,10 @@ const BattleRuntime = {
 
         if (rpg.state.deck.every(cardId => cardId === null)) {
             return rpg.showAlert("덱을 완성해주세요.");
+        }
+
+        if (rpg.state.mode === 'artifact_reserve' && typeof rpg.consumeArtifactReserveUsesForBattle === 'function') {
+            rpg.consumeArtifactReserveUsesForBattle();
         }
 
         rpg.showBattleScreen();
@@ -342,6 +350,10 @@ const BattleRuntime = {
                 battle.currentPlayerIdx++;
                 BattleRuntime.TurnManager.startPlayerTurn(rpg);
                 return;
+            }
+
+            if (!Number.isFinite(player.enteredAtTurn)) {
+                player.enteredAtTurn = battle.turn;
             }
 
             const dueEffects = battle.delayedEffects.filter(effect => effect.turn === battle.turn);

--- a/card/data.js
+++ b/card/data.js
@@ -1120,7 +1120,7 @@ const BONUS_CARD_EXPANSION = [
     {
         id: 'shooting_star_boy', name: '별똥별소년', grade: 'normal', element: 'light', role: 'dealer', unlockSource: 'bonus', releaseDate: '2026-08-15',
         stats: { hp: 290, atk: 85, matk: 60, def: 45, mdef: 55 },
-        trait: { type: 'opening_self_atk_party_mdef_down', turns: 2, atkBoost: 100, mdefDown: 50, desc: '전투 시작 후 2턴간 공격력 100% 증가 / 덱 전체 마법방어력 50% 감소' },
+        trait: { type: 'opening_self_atk_party_mdef_down', turns: 2, atkBoost: 100, mdefDown: 30, desc: '등장 후 2턴간 공격력 100% 증가 / 덱 전체 마법방어력 30% 감소' },
         skills: [
             { name: '배리어', type: 'sup', tier: 1, cost: 10, desc: '물리공격 무효', effects: [{ type: 'buff', id: 'barrier', duration: 1 }] },
             { name: '스타폴대쉬', type: 'phy', tier: 2, cost: 20, val: 2.0, desc: '2배 물리 피해 (자신의 생명력이 100%일시 위력 2배)', effects: [{ type: 'dmg_boost', condition: 'hp_full', mult: 2.0, log: 'HP 100% 특수 효과! 위력 2배!' }] },

--- a/card/index.html
+++ b/card/index.html
@@ -972,6 +972,12 @@
                     카오스 셔플 (티켓 1장)
                 </button>
             </div>
+            <div id="menu-artifact-area" style="display:none; margin-bottom:10px;">
+                <button id="btn-artifact-menu" class="menu-btn" onclick="RPG.openArtifactCheck()"
+                    style="border-color:#ffd700; color:#ffd700;">
+                    아티팩트 확인
+                </button>
+            </div>
             <button class="menu-btn" onclick="RPG.openDeck()">덱 구성</button>
             <button class="menu-btn" onclick="RPG.openCollection()">카드 확인</button>
             <button class="menu-btn" onclick="RPG.openLibrary()">도서관</button>
@@ -1007,6 +1013,27 @@
                 <button class="menu-btn" onclick="RPG.openFactoryViewDeck()" style="width:200px; background:#333; color:#4fc3f7; border-color:#4fc3f7;">
                     현재 구성 중인 덱 보기
                 </button>
+                <button class="menu-btn" onclick="RPG.toMenu()" style="width:200px;">나가기</button>
+            </div>
+        </div>
+        <div id="screen-artifact-reserve-draft" class="screen">
+            <h3 style="margin:5px 0;">아티팩트 리저브 (<span id="artifact-reserve-round-text">1/4 선택</span>)</h3>
+            <div style="text-align:center; margin-bottom:5px; font-size:0.86rem; color:#ccc;">
+                두 아티팩트 세트 중 하나를 선택하세요.<br>(선택하지 않은 아티팩트는 다음 선택지에 다시 등장할 수 있습니다)
+            </div>
+            <div style="display:flex; flex:1; gap:8px; padding:5px; overflow-y:auto; justify-content:center; min-height:0;">
+                <div id="artifact-reserve-bundle-0" onclick="RPG.selectArtifactReserveBundle(0)"
+                    style="flex:1; min-width:0; display:flex; flex-direction:column; gap:6px; border:2px solid #6a5d18; border-radius:8px; padding:7px; background:#222; cursor:pointer;">
+                    <div style="text-align:center; font-weight:bold; color:#ffd700;">A 세트 선택</div>
+                    <div id="artifact-reserve-bundle-0-items" style="display:flex; flex-direction:column; gap:6px;"></div>
+                </div>
+                <div id="artifact-reserve-bundle-1" onclick="RPG.selectArtifactReserveBundle(1)"
+                    style="flex:1; min-width:0; display:flex; flex-direction:column; gap:6px; border:2px solid #6a5d18; border-radius:8px; padding:7px; background:#222; cursor:pointer;">
+                    <div style="text-align:center; font-weight:bold; color:#ffd700;">B 세트 선택</div>
+                    <div id="artifact-reserve-bundle-1-items" style="display:flex; flex-direction:column; gap:6px;"></div>
+                </div>
+            </div>
+            <div style="margin-top:auto; margin-bottom:40px; padding-bottom:10px; display:flex; justify-content:center;">
                 <button class="menu-btn" onclick="RPG.toMenu()" style="width:200px;">나가기</button>
             </div>
         </div>
@@ -1114,7 +1141,7 @@
     </div>
 
     <div id="modal-mode-select" class="modal">
-        <div class="modal-content" style="height:auto; min-height:400px; width: 360px;">
+        <div class="modal-content" style="height:auto; min-height:400px; max-height:88vh; overflow-y:auto; width: 360px;">
             <div style="position:relative; margin-bottom: 10px;">
                 <h3 style="margin: 0;">게임 모드 선택</h3>
                 <button id="btn-chaos-roulette" onclick="RPG.openChaosRoulette()"
@@ -1423,8 +1450,8 @@
 
     <div id="modal-artifact-check" class="modal" style="z-index: 200;">
         <div class="modal-content" style="height:auto;">
-            <h3 style="color:#ffd700;">보유 아티팩트</h3>
-            <div id="artifact-check-list" style="text-align:left; font-size:0.85rem; line-height:1.6;"></div>
+            <h3 id="artifact-check-title" style="color:#ffd700;">보유 아티팩트</h3>
+            <div id="artifact-check-list" style="text-align:left; font-size:0.85rem; line-height:1.6; max-height:55vh; overflow-y:auto;"></div>
             <button onclick="document.getElementById('modal-artifact-check').classList.remove('active')"
                 style="margin-top:10px; width:100%; padding:10px;">닫기</button>
         </div>
@@ -2727,17 +2754,20 @@
                     { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'chaos', name: '카오스', desc: '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+                    { id: 'artifact_chaos', name: '아티팩트카오스', desc: '카오스모드와 동일하지만, 매 스테이지마다 랜덤 아티팩트 4개를 추가로 받습니다.\n메뉴에서 활성 아티팩트를 확인할 수 있고, 셔플 시 아티팩트도 초기화됩니다. 강화된 적 출현.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
                     { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'factory', name: '팩토리', desc: '시작 시 40장의 카드를 번들 단위로 드래프트하여 덱 풀을 구성합니다.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 30 스테이지)' }
+                    { id: 'factory', name: '팩토리', desc: '시작 시 40장의 카드를 번들 단위로 드래프트하여 덱 풀을 구성.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+                    { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 30 스테이지)' },
+                    { id: 'artifact_reserve', name: '아티팩트리저브', desc: '아티팩트 세트 선택을 4회 반복해 12개 풀을 구성. 각 아티팩트는 2회 사용 가능하며 전투 전 최대 4개를 수동 활성화합니다. 강화된 적 출현.\n(성공조건: 24 스테이지)' }
                 ];
 
                 if (this.tempGameType === 'endless') {
-                    MODES = MODES.filter(m => ['origin', 'draft', 'chaos', 'artifact'].includes(m.id));
+                    MODES = MODES.filter(m => ['origin', 'draft', 'chaos', 'artifact', 'artifact_reserve'].includes(m.id));
                     MODES.forEach(m => {
                         if (m.id === 'chaos') m.desc = '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
                         if (m.id === 'draft') m.desc = '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
                         if (m.id === 'artifact') m.desc = '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 없음 / 무한)';
+                        if (m.id === 'artifact_reserve') m.desc = '아티팩트 세트 선택을 4회 반복해 12개 풀을 구성. 각 아티팩트는 2회 사용 가능하며 전투 전 최대 4개를 수동 활성화합니다. 강화된 적 출현.\n(성공조건: 없음 / 무한)';
                     });
                     if (this.global.hiddenStudyReady) {
                         MODES.push({
@@ -2747,7 +2777,10 @@
                         });
                     }
                 } else if (this.tempGameType === 'challenge') {
-                    MODES = MODES.filter(m => m.id !== 'origin');
+                    MODES = MODES.filter(m => !['origin', 'archive'].includes(m.id));
+                } else {
+                    // 신규 아티팩트 변형은 챌린지 전용이며, 리저브만 엔드리스에도 제공한다.
+                    MODES = MODES.filter(m => !['artifact_chaos', 'artifact_reserve'].includes(m.id));
                 }
 
                 MODES.forEach(m => {
@@ -2776,7 +2809,7 @@
                             let steps = 0;
                             if (m.id === 'puzzle') {
                                 steps = 2;
-                            } else if (['artifact', 'flood', 'curse'].includes(m.id)) {
+                            } else if (['artifact', 'artifact_chaos', 'artifact_reserve', 'flood', 'curse'].includes(m.id)) {
                                 steps = 1;
                             }
                             if (this.hardModeActive) {
@@ -2818,7 +2851,7 @@
                         () => {
                             this.initNewGame(this.selectedModeId);
                             modal.classList.remove('active');
-                            if (this.selectedModeId !== 'factory') {
+                            if (!['factory', 'artifact_reserve'].includes(this.selectedModeId)) {
                                 this.toMenu();
                             }
                         }
@@ -2844,6 +2877,8 @@
                 const gachaArea = document.getElementById('menu-gacha-area');
                 const draftArea = document.getElementById('menu-draft-area');
                 const chaosArea = document.getElementById('menu-chaos-area');
+                const artifactArea = document.getElementById('menu-artifact-area');
+                const artifactMenuBtn = document.getElementById('btn-artifact-menu');
                 const normalGachaBtn = document.getElementById('btn-normal-gacha');
                 const challengeGachaBtn = document.getElementById('btn-challenge-gacha');
 
@@ -2855,16 +2890,18 @@
                     challengeGachaBtn.innerText = '도전 뽑기';
                     challengeGachaBtn.onclick = () => this.openChallengeGacha();
                 }
+                if (artifactMenuBtn) artifactMenuBtn.onclick = () => this.openArtifactCheck();
 
                 // Hide all first
                 gachaArea.style.display = 'none';
                 draftArea.style.display = 'none';
                 if (chaosArea) chaosArea.style.display = 'none';
+                if (artifactArea) artifactArea.style.display = 'none';
 
                 if (this.state.mode === 'draft') {
                     draftArea.style.display = 'block';
                 }
-                else if (this.state.mode === 'chaos') {
+                else if (['chaos', 'artifact_chaos'].includes(this.state.mode)) {
                     if (chaosArea) chaosArea.style.display = 'block';
                 }
                 else if (this.state.mode === 'puzzle') {
@@ -2876,6 +2913,23 @@
                 }
                 else {
                     gachaArea.style.display = 'flex';
+                }
+
+                if (this.state.mode === 'artifact_chaos' && artifactArea && artifactMenuBtn) {
+                    artifactArea.style.display = 'block';
+                    artifactMenuBtn.innerText = `현재 활성 아티팩트 (${(this.state.artifacts || []).length}/${GAME_CONSTANTS.MAX_ARTIFACTS})`;
+                }
+                if (this.state.mode === 'artifact_reserve' && artifactArea && artifactMenuBtn) {
+                    artifactArea.style.display = 'block';
+                    if (this.state.artifactReserveDraft && this.state.artifactReserveDraft.active) {
+                        artifactMenuBtn.innerText = `아티팩트 리저브 선택 계속 (${this.state.artifactReserveDraft.round}/${this.state.artifactReserveDraft.maxRounds})`;
+                        artifactMenuBtn.onclick = () => {
+                            this.showScreen('screen-artifact-reserve-draft');
+                            this.renderArtifactReserveDraftScreen();
+                        };
+                    } else {
+                        artifactMenuBtn.innerText = `아티팩트 풀 관리 (${(this.state.artifacts || []).length}/${GAME_CONSTANTS.MAX_ARTIFACTS} 활성)`;
+                    }
                 }
             },
             toTitle() {
@@ -2913,7 +2967,7 @@
                         factoryPool: this.state.factoryPool,
                         specialCardSelections: this.state.activeSpecialCardSelections
                     });
-                } else if (mode === 'chaos') {
+                } else if (['chaos', 'artifact_chaos'].includes(mode)) {
                     // 카오스: state.chaosPool (초월 포함 가능)
                     const ids = this.state.chaosPool || [];
                     pool = ids.map(id => this.getCardData(id)).filter(Boolean);
@@ -2940,8 +2994,8 @@
                 // Info text
                 const modeLabel = { origin: '오리진', restriction: '제약의 시련', balance: '균형의 도전',
                     suffering: '고난의 여정', puzzle: '퍼즐', archive: '아카이브',
-                    curse: '저주의 증폭', flood: '축복의 범람', chaos: '카오스',
-                    draft: '드래프트', factory: '팩토리', artifact: '아티팩트',
+                    curse: '저주의 증폭', flood: '축복의 범람', chaos: '카오스', artifact_chaos: '아티팩트카오스',
+                    draft: '드래프트', factory: '팩토리', artifact: '아티팩트', artifact_reserve: '아티팩트리저브',
                     overdrive: '오버드라이브', dream_corridor: '꿈의회랑' };
                 const label = modeLabel[mode] || mode;
                 document.getElementById('card-pool-info').innerText =
@@ -3005,16 +3059,18 @@
                 document.getElementById('sage-uses').innerText = this.state.greatSageBlessingUses;
 
                 const chaosModal = document.getElementById('modal-chaos');
-                const isArtifactMobileLayout = this.state.mode === 'artifact' &&
+                const isArtifactMode = ['artifact', 'artifact_chaos', 'artifact_reserve'].includes(this.state.mode);
+                const isArtifactMobileLayout = isArtifactMode &&
                     (this.state.gameType === 'challenge' || this.state.gameType === 'endless');
                 chaosModal.classList.toggle('artifact-mobile-compact', isArtifactMobileLayout);
 
-                // Show artifact check button only in artifact mode
+                // Artifact variants expose their current artifact state here.
                 const artBtn = document.getElementById('btn-artifact-check');
                 const modal = document.getElementById('modal-chaos');
                 const sageDesc = document.getElementById('great-sage-desc');
                 if (artBtn) {
-                    artBtn.style.display = (this.state.mode === 'artifact') ? 'block' : 'none';
+                    artBtn.style.display = isArtifactMode ? 'block' : 'none';
+                    artBtn.innerText = this.state.mode === 'artifact_reserve' ? '아티팩트 풀 관리' : '아티팩트 확인';
                 }
                 if (sageDesc) {
                     sageDesc.innerText = this.state.mode === 'puzzle'
@@ -3022,7 +3078,7 @@
                         : '문법 퀴즈 성공 시 12명에게 축복 + 티켓 1장';
                 }
 
-                if (this.state.mode === 'artifact') {
+                if (isArtifactMode) {
                     modal.classList.add('artifact-mode');
                 } else {
                     modal.classList.remove('artifact-mode');
@@ -3142,31 +3198,26 @@
                     return this.showAlert("셔플할 티켓이 부족합니다.");
                 }
 
+                const isArtifactChaos = this.state.mode === 'artifact_chaos';
+
                 this.showDoubleConfirm(
-                    `현재 보유한 모든 카드와 덱 구성이 사라집니다.<br>
+                    `현재 보유한 모든 카드와 덱 구성${isArtifactChaos ? ', 활성 아티팩트' : ''}이 사라집니다.<br>
             티켓 1장을 사용하여 새로운 15장을 받으시겠습니까?`,
-                    `정말 셔플하시겠습니까?<br>현재 덱과 인벤토리가 모두 초기화됩니다.`,
+                    `정말 셔플하시겠습니까?<br>현재 덱과 인벤토리${isArtifactChaos ? ', 아티팩트' : ''}가 모두 초기화됩니다.`,
                     () => {
                         this.state.tickets -= GAME_CONSTANTS.COSTS.CHAOS_SHUFFLE;
                         document.getElementById('ui-tickets').innerText = this.state.tickets;
 
-                        let allCards = GameUtils.buildCardPool(this.global, {
-                            includeTranscendence: true,
-                            activeTranscendenceCards: this.state.activeTranscendenceCards,
-                            factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
-                            activeBonusPoolIds: this.state.activeBonusPoolIds,
-                            specialCardSelections: this.state.activeSpecialCardSelections,
-                            // [목적] 카오스 셔플 시 획득한 이벤트 카드를 풀에 포함
-                            activeEventCards: this.state.activeEventCards
-                        });
+                        const artifactIds = isArtifactChaos
+                            ? this.resetArtifactChaosRound()
+                            : (() => {
+                                this.state.deck = [null, null, null];
+                                this.resetChaosRunPool();
+                                return [];
+                            })();
+                        const newPicks = this.state.chaosPool || [];
 
-                        const newPicks = this.buildChaosPoolCardIds(allCards);
-
-                        this.state.chaosPool = newPicks;
-                        this.state.inventory = [...newPicks];
-                        this.state.deck = [null, null, null];
-
-                        this.saveGame();
+                        this.saveGame(false);
 
                         let legendCnt = 0, epicCnt = 0;
                         newPicks.forEach(id => {
@@ -3175,10 +3226,16 @@
                             if (c.grade === 'epic') epicCnt++;
                         });
 
+                        const artifactText = artifactIds.length > 0
+                            ? `<br><br><b>새 아티팩트 (${artifactIds.length}개)</b><br>${artifactIds.map(id => {
+                                const artifact = GameUtils.getArtifactById(id);
+                                return artifact ? `${artifact.name}: ${artifact.desc}` : id;
+                            }).join('<br>')}`
+                            : '';
                         this.showAlert(
-                            `<b>카오스 셔플 완료!</b><br><br>
+                            `<b>${isArtifactChaos ? '아티팩트카오스' : '카오스'} 셔플 완료!</b><br><br>
                     새로운 15장이 지급되었습니다.<br>
-                    (전설: ${legendCnt}, 에픽: ${epicCnt})<br><br>
+                    (전설: ${legendCnt}, 에픽: ${epicCnt})${artifactText}<br><br>
                     * 덱이 초기화되었으니 다시 구성해주세요.`
                         );
                     }
@@ -3390,7 +3447,7 @@
             // --- Wordbook & Quiz ---
             openWordbook() {
                 document.getElementById('modal-library').classList.remove('active');
-                if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+                if (['chaos', 'artifact_chaos', 'draft'].includes(this.state.mode)) {
                     this.openCollocationBook();
                     return;
                 }
@@ -3424,7 +3481,7 @@
             },
 
             resetWrongWords() {
-                if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+                if (['chaos', 'artifact_chaos', 'draft'].includes(this.state.mode)) {
                     this.state.wrongCollocations = [];
                     Storage.remove(Storage.keys.COLLOCATION);
                     this.showAlert("숙어/구동사 복습 상태가 초기화되었습니다.");
@@ -3706,6 +3763,30 @@
                 }
             },
 
+            renderArtifactReserveDraftScreen() {
+                const draft = this.state.artifactReserveDraft;
+                if (!draft) return;
+
+                document.getElementById('artifact-reserve-round-text').innerText = `${draft.round}/${draft.maxRounds} 선택`;
+                const containers = [
+                    document.getElementById('artifact-reserve-bundle-0-items'),
+                    document.getElementById('artifact-reserve-bundle-1-items')
+                ];
+
+                containers.forEach((container, index) => {
+                    container.innerHTML = '';
+                    const bundle = (draft.currentBundles || [])[index] || [];
+                    bundle.forEach(id => {
+                        const artifact = GameUtils.getArtifactById(id);
+                        if (!artifact) return;
+                        const entry = document.createElement('div');
+                        entry.style.cssText = 'padding:7px; background:#302d1f; border:1px solid #6a5d18; border-radius:5px; text-align:left;';
+                        entry.innerHTML = `<b style="color:#ffd700; font-size:0.83rem;">${artifact.name}</b><br><span style="color:#ddd; font-size:0.75rem; line-height:1.35;">${artifact.desc}</span>`;
+                        container.appendChild(entry);
+                    });
+                });
+            },
+
             openFactoryViewDeck() {
                 const pool = this.state.factoryDraft.pool;
                 document.getElementById('screen-factory-draft').classList.remove('active');
@@ -3802,6 +3883,7 @@
                 }
 
                 if (this.state.mode === 'chaos') msg += "<br><br>카오스 모드: 덱과 인벤토리가 초기화되었습니다.";
+                if (this.state.mode === 'artifact_chaos') msg += "<br><br>아티팩트카오스 모드: 덱과 인벤토리, 아티팩트가 초기화되었습니다.";
                 if (this.state.mode === 'draft') msg += "<br><br>드래프트 모드: 덱과 인벤토리가 초기화되었습니다.";
 
                 if (deadMsg) msg += "<br><br>" + deadMsg;
@@ -3883,7 +3965,7 @@
                                 }
                             );
                         }
-                        else if (this.state.mode === 'chaos' || this.state.mode === 'draft') {
+                        else if (['chaos', 'artifact_chaos', 'draft'].includes(this.state.mode)) {
                             this.showConfirm("추가 보상을 위한 콜로케이션 퀴즈에 도전하시겠습니까?\n(성공 시 드로우권 1장 획득)",
                                 () => {
                                     this.startCollocationQuiz((success) => {
@@ -4524,10 +4606,10 @@
 
             openPrivateTutoring() {
                 const mode = this.state.mode;
-                let list = (mode === 'chaos' || mode === 'draft') ? this.state.wrongCollocations : this.state.wrongWords;
+                let list = (['chaos', 'artifact_chaos', 'draft'].includes(mode)) ? this.state.wrongCollocations : this.state.wrongWords;
 
                 if (!list || list.length === 0) {
-                    let msg = (mode === 'chaos' || mode === 'draft') ? "오답노트에 등록된 숙어/구동사가 없습니다." : "오답노트에 등록된 단어가 없습니다.";
+                    let msg = (['chaos', 'artifact_chaos', 'draft'].includes(mode)) ? "오답노트에 등록된 숙어/구동사가 없습니다." : "오답노트에 등록된 단어가 없습니다.";
                     return this.showAlert(msg);
                 }
 
@@ -4548,7 +4630,7 @@
                 if (!key) return this.showAlert("API 키가 없어 개인과외를 시작할 수 없습니다.");
 
                 const mode = this.state.mode;
-                const isCollocation = (mode === 'chaos' || mode === 'draft');
+                const isCollocation = ['chaos', 'artifact_chaos', 'draft'].includes(mode);
                 let list = isCollocation ? this.state.wrongCollocations : this.state.wrongWords;
 
                 if (!list || list.length === 0) return this.showAlert("학습할 오답 내용이 없습니다.");
@@ -4759,11 +4841,43 @@
             openArtifactCheck() {
                 const owned = this.state.artifacts || [];
                 const list = document.getElementById('artifact-check-list');
+                const title = document.getElementById('artifact-check-title');
+
+                if (this.state.mode === 'artifact_reserve') {
+                    const reservePool = this.state.artifactReservePool || [];
+                    const activeCount = owned.length;
+                    if (title) title.innerText = `아티팩트 풀 (${activeCount}/${GAME_CONSTANTS.MAX_ARTIFACTS} 활성)`;
+                    list.innerHTML = '';
+
+                    reservePool.forEach(entry => {
+                        const artifact = GameUtils.getArtifactById(entry.id);
+                        if (!artifact) return;
+                        const isActive = owned.includes(entry.id);
+                        const remainingUses = Math.max(0, entry.remainingUses || 0);
+                        const button = document.createElement('button');
+                        button.className = 'menu-btn';
+                        button.disabled = remainingUses <= 0;
+                        button.style.cssText = `margin:0 0 8px; padding:9px; text-align:left; border-color:${isActive ? '#4caf50' : '#6a5d18'}; color:${remainingUses > 0 ? '#f5df78' : '#777'}; background:${isActive ? '#263a29' : '#333'};`;
+                        button.innerHTML = `<div style="display:flex; justify-content:space-between; gap:8px;"><b>${artifact.name}</b><span style="white-space:nowrap; color:${isActive ? '#81c784' : '#ffd700'};">${isActive ? '활성' : '비활성'} · ${remainingUses}회</span></div><span style="display:block; margin-top:3px; color:#ccc; font-size:0.78rem; font-weight:normal;">${artifact.desc}</span>`;
+                        button.onclick = () => {
+                            if (this.toggleArtifactReserveArtifact(entry.id)) this.openArtifactCheck();
+                        };
+                        list.appendChild(button);
+                    });
+
+                    if (reservePool.length === 0) {
+                        list.innerHTML = '<div style="color:#aaa; text-align:center;">아티팩트 풀이 아직 완성되지 않았습니다.</div>';
+                    }
+                    document.getElementById('modal-artifact-check').classList.add('active');
+                    return;
+                }
+
+                if (title) title.innerText = this.state.mode === 'artifact_chaos' ? '현재 활성 아티팩트' : '보유 아티팩트';
                 if (owned.length === 0) {
                     list.innerHTML = '<div style="color:#aaa; text-align:center;">보유한 아티팩트가 없습니다.</div>';
                 } else {
                     list.innerHTML = owned.map(id => {
-                        const art = ARTIFACT_LIST.find(a => a.id === id);
+                        const art = GameUtils.getArtifactById(id);
                         if (!art) return '';
                         return `<div style="margin-bottom:8px; padding:8px; background:#333; border-radius:5px; border-left: 3px solid #ffd700;">
                             <b style="color:#ffd700;">${art.name}</b><br>
@@ -5463,7 +5577,7 @@
                     const cardId = dateParams.cardId;
                     const cardName = dateParams.cardName;
 
-                    const isPoolMode = ['chaos', 'draft'].includes(this.state.mode);
+                    const isPoolMode = ['chaos', 'artifact_chaos', 'draft'].includes(this.state.mode);
                     let rewardDetail = "";
 
                     if (isPoolMode) {

--- a/card/logic.js
+++ b/card/logic.js
@@ -202,7 +202,8 @@ window.GAME_CONSTANTS = {
         curse: 10,
         chaos: 0,
         draft: 5,
-        artifact: 10
+        artifact: 10,
+        artifact_chaos: 0
     },
     DECK_SIZE: 3,
     MAX_RECORDS: 5,
@@ -262,13 +263,16 @@ window.GAME_CONSTANTS = {
         flood: 24,
         chaos: 24,
         draft: 24,
-        artifact: 30
+        artifact: 30,
+        artifact_chaos: 24,
+        artifact_reserve: 24
     },
 
     MODE_REWARDS: {
         default: 1,
         suffering: 0,
         chaos: 0,
+        artifact_chaos: 0,
         puzzle: 0
     },
 
@@ -1842,7 +1846,8 @@ const Logic = {
             m.atk += boost;
             m.matk += boost;
         }
-        if (trait && trait.type === 'opening_self_atk_party_mdef_down' && battleTurn <= (trait.turns || 2)) {
+        const turnsSinceEntry = battleTurn - (Number.isFinite(char.enteredAtTurn) ? char.enteredAtTurn : 1);
+        if (trait && trait.type === 'opening_self_atk_party_mdef_down' && turnsSinceEntry >= 0 && turnsSinceEntry < (trait.turns || 2)) {
             m.atk += (trait.atkBoost || 0) / 100;
         }
         if (char.alternatingAttackStatPercent) {
@@ -2012,7 +2017,8 @@ const Logic = {
         if (forceCritChance && Math.random() * 100 < forceCritChance.val) isCrit = true;
 
         let critDmg = GAME_CONSTANTS.BASE_CRIT_MULT;
-        const critBuffMult = (mode === 'flood' && source.proto) ? 2.0 : 1.0;
+        const critBuffMult = ((mode === 'flood' && source.proto) ? 2.0 : 1.0)
+            * (source.fieldBuffStatMult || 1.0);
         if (source.proto && sourceFieldBuffs.some(b => b.name === 'sun_bless')) {
             critDmg += GAME_CONSTANTS.SUN_BLESS_CRIT_BONUS * critBuffMult;
         }
@@ -2544,6 +2550,7 @@ const Logic = {
         const partyBoost = { atk: 0, matk: 0, def: 0, mdef: 0, crit: 0 };
 
         const fullDeckCards = (deck || []).map(id => id ? GameUtils.getCardById(id, allCards) : null);
+        let hasPartyAllStatsManaCost = false;
 
         fullDeckCards.forEach((c, originalIdx) => {
             if (!c) return;
@@ -2568,7 +2575,8 @@ const Logic = {
             else if (tr && tr.type === 'syn_dark_full_party_crit' && deckCtx.countElement('dark') >= 3) {
                 partyBoost.crit += (tr.val || 0);
             }
-            else if (tr && tr.type === 'party_all_stats_mana_cost') {
+            else if (tr && tr.type === 'party_all_stats_mana_cost' && !hasPartyAllStatsManaCost) {
+                hasPartyAllStatsManaCost = true;
                 const boost = tr.statVal || 0;
                 partyBoost.atk += boost;
                 partyBoost.matk += boost;

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -853,8 +853,13 @@
             return;
         }
 
-        if (mode === 'chaos' || mode === 'draft') {
+        if (mode === 'chaos' || mode === 'artifact_chaos' || mode === 'draft') {
             this.state.tickets += 5;
+            return;
+        }
+
+        if (['factory', 'restriction', 'balance'].includes(mode)) {
+            this.state.tickets += 3;
             return;
         }
 
@@ -993,7 +998,12 @@
 
 
     isGradeBalancedRunMode() {
-        return ['chaos', 'draft'].includes(this.state.mode);
+        return ['chaos', 'artifact_chaos', 'draft'].includes(this.state.mode);
+    },
+
+
+    isChaosPoolMode(mode = this.state.mode) {
+        return mode === 'chaos' || mode === 'artifact_chaos';
     },
 
 
@@ -1054,6 +1064,138 @@
     },
 
 
+    buildChaosRunCardPool() {
+        return GameUtils.buildCardPool(this.global, {
+            includeTranscendence: true,
+            activeTranscendenceCards: this.state.activeTranscendenceCards,
+            activeBonusPoolIds: this.state.activeBonusPoolIds,
+            specialCardSelections: this.state.activeSpecialCardSelections,
+            activeEventCards: this.state.activeEventCards
+        });
+    },
+
+
+    resetChaosRunPool() {
+        const picks = this.buildChaosPoolCardIds(this.buildChaosRunCardPool());
+        this.state.chaosPool = picks;
+        this.state.inventory = [...picks];
+        return picks;
+    },
+
+
+    resetArtifactChaosRound() {
+        this.state.inventory = [];
+        this.state.deck = [null, null, null];
+        this.resetChaosRunPool();
+
+        const artifactPool = typeof GameUtils.getArtifactSelectionPool === 'function'
+            ? GameUtils.getArtifactSelectionPool(this.global)
+            : ARTIFACT_LIST;
+        this.state.artifacts = GameUtils.shuffle(artifactPool)
+            .slice(0, GAME_CONSTANTS.MAX_ARTIFACTS)
+            .map(artifact => artifact.id);
+
+        return [...this.state.artifacts];
+    },
+
+
+    getArtifactReserveEntry(id) {
+        return (this.state.artifactReservePool || []).find(entry => entry.id === id) || null;
+    },
+
+
+    generateArtifactReserveBundles() {
+        const draft = this.state.artifactReserveDraft;
+        if (!draft) return;
+
+        const selectedIds = new Set(draft.pool || []);
+        const artifactPool = typeof GameUtils.getArtifactSelectionPool === 'function'
+            ? GameUtils.getArtifactSelectionPool(this.global)
+            : ARTIFACT_LIST;
+        const available = artifactPool.filter(artifact => !selectedIds.has(artifact.id));
+        const picks = GameUtils.shuffle(available).slice(0, 6).map(artifact => artifact.id);
+
+        draft.currentBundles = [picks.slice(0, 3), picks.slice(3, 6)];
+        this.showScreen('screen-artifact-reserve-draft');
+        this.renderArtifactReserveDraftScreen();
+    },
+
+
+    selectArtifactReserveBundle(index) {
+        const draft = this.state.artifactReserveDraft;
+        const bundle = draft && draft.currentBundles && draft.currentBundles[index];
+        if (!Array.isArray(bundle) || bundle.length === 0) return;
+
+        draft.pool.push(...bundle);
+        draft.round++;
+        draft.currentBundles = [];
+
+        if (draft.round > draft.maxRounds) {
+            draft.active = false;
+            this.state.artifactReservePool = draft.pool.map(id => ({ id, remainingUses: 2 }));
+            this.state.artifacts = [];
+            this.showAlert('아티팩트 리저브 풀이 완성되었습니다! 전투마다 최대 4개를 활성화할 수 있습니다.');
+            this.toMenu();
+        } else {
+            this.generateArtifactReserveBundles();
+        }
+
+        this.saveGame(false);
+    },
+
+
+    toggleArtifactReserveArtifact(id) {
+        const entry = this.getArtifactReserveEntry(id);
+        if (!entry) return false;
+
+        const activeIds = [...new Set(this.state.artifacts || [])];
+        if (activeIds.includes(id)) {
+            this.state.artifacts = activeIds.filter(activeId => activeId !== id);
+            this.saveGame(false);
+            return true;
+        }
+
+        if ((entry.remainingUses || 0) <= 0) {
+            this.showAlert('사용 횟수가 모두 소진된 아티팩트입니다.');
+            return false;
+        }
+        if (activeIds.length >= GAME_CONSTANTS.MAX_ARTIFACTS) {
+            this.showAlert(`한 전투에는 아티팩트를 최대 ${GAME_CONSTANTS.MAX_ARTIFACTS}개까지 활성화할 수 있습니다.`);
+            return false;
+        }
+
+        this.state.artifacts = [...activeIds, id];
+        this.saveGame(false);
+        return true;
+    },
+
+
+    consumeArtifactReserveUsesForBattle() {
+        if (this.state.mode !== 'artifact_reserve') return [];
+
+        const entries = this.state.artifactReservePool || [];
+        const activeIds = [...new Set(this.state.artifacts || [])].filter(id => {
+            const entry = entries.find(item => item.id === id);
+            return entry && (entry.remainingUses || 0) > 0;
+        });
+
+        activeIds.forEach(id => {
+            const entry = entries.find(item => item.id === id);
+            entry.remainingUses--;
+        });
+        this.state.artifacts = activeIds;
+        this.saveGame(false);
+        return activeIds;
+    },
+
+
+    resetArtifactReserveActivations() {
+        if (this.state.mode !== 'artifact_reserve') return;
+        this.state.artifacts = [];
+        this.saveGame(false);
+    },
+
+
     resetPendingActiveBonusPoolIds() {
         this.syncPendingActiveBonusPoolIds();
         this.updateBonusPoolEditorButton();
@@ -1093,6 +1235,10 @@
                 if (!this.state.mode) this.state.mode = 'origin';
                 if (!this.state.quiz_stats) this.state.quiz_stats = { correct: 0, total: 0 };
                 if (!this.state.artifacts) this.state.artifacts = [];
+                if (!this.state.artifactReserveDraft) {
+                    this.state.artifactReserveDraft = { active: false, round: 1, maxRounds: 4, pool: [], currentBundles: [] };
+                }
+                if (!Array.isArray(this.state.artifactReservePool)) this.state.artifactReservePool = [];
                 if (this.state.pendingEnemyId === undefined) this.state.pendingEnemyId = null;
                 if (this.state.pendingEnemyStage === undefined) this.state.pendingEnemyStage = null;
                 if (this.state.puzzlePiecesClaimed === undefined) this.state.puzzlePiecesClaimed = false;
@@ -1142,6 +1288,8 @@
             factoryPool: [],
             draft: { active: false, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] },
             factoryDraft: { active: false, round: 1, maxRounds: 10, pool: [], seenCards: [], currentBundles: [] },
+            artifactReserveDraft: { active: false, round: 1, maxRounds: 4, pool: [], currentBundles: [] },
+            artifactReservePool: [],
             artifacts: [],
             pendingEnemyId: null,
             pendingEnemyStage: null,
@@ -1169,20 +1317,11 @@
         this.applyBeginnerChallengeSafety(mode);
 
         if (mode === 'chaos') {
-            let allCards = GameUtils.buildCardPool(this.global, {
-                includeTranscendence: true,
-                activeTranscendenceCards: this.state.activeTranscendenceCards,
-                factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
-                activeBonusPoolIds: this.state.activeBonusPoolIds,
-                specialCardSelections: this.state.activeSpecialCardSelections,
-                // [목적] 해당 런에서 획득한 이벤트 카드를 카오스 모드 시작 풀에 포함
-                activeEventCards: this.state.activeEventCards
-            });
+            this.resetChaosRunPool();
+        }
 
-            const picks = this.buildChaosPoolCardIds(allCards);
-
-            this.state.chaosPool = picks;
-            this.state.inventory = [...picks];
+        if (mode === 'artifact_chaos') {
+            this.resetArtifactChaosRound();
         }
 
         if (mode === 'factory') {
@@ -1194,8 +1333,17 @@
             this.generateFactoryBundles();
         }
 
+        if (mode === 'artifact_reserve') {
+            this.state.artifactReserveDraft.active = true;
+            this.state.artifactReserveDraft.round = 1;
+            this.state.artifactReserveDraft.maxRounds = 4;
+            this.state.artifactReserveDraft.pool = [];
+            this.state.artifactReserveDraft.currentBundles = [];
+            this.generateArtifactReserveBundles();
+        }
+
         // Origin Mode: Add Transcendence Cards directly to Inventory
-        if (mode !== 'chaos' && mode !== 'draft' && this.state.activeTranscendenceCards.length > 0) {
+        if (!this.isChaosPoolMode(mode) && mode !== 'draft' && this.state.activeTranscendenceCards.length > 0) {
             this.state.inventory.push(...this.state.activeTranscendenceCards);
             setTimeout(() => this.showAlert(`초월 카드 ${this.state.activeTranscendenceCards.length}장이 인벤토리에 합류했습니다!`), 500);
         }
@@ -1471,7 +1619,6 @@
             this.state.factoryPool = [...this.state.factoryDraft.pool];
             this.state.inventory = [];
             this.state.deck = [null, null, null];
-            this.state.tickets = 20;
             
             this.showAlert("팩토리 드래프트가 완료되었습니다!<br>방금 구성한 40장의 전용 풀을 바탕으로 모험을 시작합니다.");
             this.toMenu();
@@ -1492,7 +1639,7 @@
 
 
     cleanupTranscendenceCards() {
-        if (['draft', 'chaos'].includes(this.state.mode)) return "";
+        if (this.isChaosPoolMode() || this.state.mode === 'draft') return "";
 
         let removedNames = [];
         this.battle.players.forEach((p, idx) => {
@@ -1603,24 +1750,24 @@
             this.incrementMonthlyMissionProgress('endless35', 1);
         }
 
-        // Chaos/Draft: Reset Deck/Inventory
-        if (mode === 'chaos') {
-            this.state.inventory = [];
-            this.state.deck = [null, null, null];
-
-            let allCards = GameUtils.buildCardPool(this.global, {
-                includeTranscendence: true,
-                activeTranscendenceCards: this.state.activeTranscendenceCards,
-                factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
-                activeBonusPoolIds: this.state.activeBonusPoolIds,
-                specialCardSelections: this.state.activeSpecialCardSelections,
-                // [목적] 전투 승리 후 카오스 풀 초기화 시 획득한 이벤트 카드를 포함
-                activeEventCards: this.state.activeEventCards
-            });
-            const nextPicks = this.buildChaosPoolCardIds(allCards);
-            this.state.chaosPool = nextPicks;
-            this.state.inventory = [...nextPicks];
+        // Chaos: Reset Deck/Inventory. Artifact Chaos also grants a fresh artifact set.
+        if (this.isChaosPoolMode(mode)) {
+            if (mode === 'artifact_chaos') {
+                const artifactIds = this.resetArtifactChaosRound();
+                const artifactNames = artifactIds.map(id => {
+                    const artifact = GameUtils.getArtifactById(id);
+                    return artifact ? artifact.name : id;
+                });
+                const artifactMsg = `아티팩트카오스: 덱과 아티팩트가 초기화되었습니다. 새 아티팩트: ${artifactNames.join(', ')}`;
+                deadMsg = deadMsg ? `${deadMsg}<br>${artifactMsg}` : artifactMsg;
+            } else {
+                this.state.inventory = [];
+                this.state.deck = [null, null, null];
+                this.resetChaosRunPool();
+            }
         }
+
+        this.resetArtifactReserveActivations();
 
         if (mode === 'draft') {
             this.resetDraftState();
@@ -1756,7 +1903,7 @@
         let transMsg = this.cleanupTranscendenceCards();
         // No saveRecord here (User request: only on New Game)
 
-        if (['chaos', 'draft'].includes(this.state.mode)) {
+        if (this.isChaosPoolMode() || this.state.mode === 'draft') {
             this.saveRecord();
         }
 
@@ -1765,7 +1912,7 @@
             this.saveGlobalData();
         }
 
-        if (['chaos', 'draft'].includes(this.state.mode)) {
+        if (this.isChaosPoolMode() || this.state.mode === 'draft') {
             Storage.remove(Storage.keys.SAVE);
 
             let msg = "패배했습니다...<br>이 모드는 패배 시 데이터가 초기화됩니다.";
@@ -1780,6 +1927,7 @@
         this.state.chaosBuffs = [];
         this.state.activeChaosBlessing = [];
         this.state.activeSageBlessing = [];
+        this.resetArtifactReserveActivations();
 
         let deadMsg = this.handlePermadeath(this.battle.players);
         if (this.state.mode === 'dream_corridor') {

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -107,7 +107,7 @@ function run() {
     const traitWiring = {
       discipline_captain: { type: 'vanguard_all_grade_party_def_mdef', gradeRequired: 'normal', val: 100 },
       supernova: { type: 'death_dmg_phy_debuff', val: 4, debuff: 'burn', stack: 3 },
-      shooting_star_boy: { type: 'opening_self_atk_party_mdef_down', turns: 2, atkBoost: 100, mdefDown: 50 },
+      shooting_star_boy: { type: 'opening_self_atk_party_mdef_down', turns: 2, atkBoost: 100, mdefDown: 30 },
       victoria: { type: 'leader_field_stat_double', val: 2 },
       holy_night: { type: 'death_dmg_phy', val: 3 },
       paladin: { type: 'pos_stat_boost', pos: 1, stat: 'atk', val: 100 },
@@ -268,6 +268,80 @@ function run() {
       unlocked: true
     });
     assert.strictEqual(beachMission.rewardCardId, 'luna_swimsuit');
+
+    // Beginner safety gives Factory/Restriction/Balance tickets instead of a free Rumi.
+    ['factory', 'restriction', 'balance'].forEach((mode, index) => {
+      const safetyHost = {
+        global: { unlocked_bonus_cards: [] },
+        state: { gameType: 'challenge', tickets: index === 0 ? 20 : 10, inventory: [] }
+      };
+      RPGFeatureModules.install(safetyHost);
+      safetyHost.applyBeginnerChallengeSafety(mode);
+      assert.strictEqual(safetyHost.state.tickets, index === 0 ? 23 : 13);
+      assert.strictEqual(safetyHost.state.inventory.includes('rumi'), false);
+    });
+
+    // Divine artifact unlocks replace their base artifact in both new mode pools.
+    const divineArtifactPool = GameUtils.getArtifactSelectionPool({ unlocked_divine_artifacts: ['divine_flora'] });
+    assert(divineArtifactPool.some(artifact => artifact.id === 'divine_flora'));
+    assert.strictEqual(divineArtifactPool.some(artifact => artifact.id === 'nature_blessing'), false);
+
+    const reserveHost = {
+      global: { unlocked_divine_artifacts: ['divine_flora'] },
+      state: {
+        mode: 'artifact_reserve',
+        artifacts: [],
+        artifactReservePool: [],
+        artifactReserveDraft: { active: true, round: 1, maxRounds: 4, pool: [], currentBundles: [] }
+      },
+      showScreen: quiet,
+      renderArtifactReserveDraftScreen: quiet,
+      showAlert: quiet,
+      toMenu: quiet
+    };
+    RPGFeatureModules.install(reserveHost);
+    reserveHost.saveGame = quiet;
+    for (let round = 0; round < 4; round++) {
+      reserveHost.generateArtifactReserveBundles();
+      const bundles = reserveHost.state.artifactReserveDraft.currentBundles;
+      assert.deepStrictEqual(Array.from(bundles, bundle => bundle.length), [3, 3]);
+      assert.strictEqual(new Set(bundles.flat()).size, 6);
+      assert.strictEqual(
+        bundles.flat().some(id => reserveHost.state.artifactReserveDraft.pool.includes(id)),
+        false
+      );
+      reserveHost.selectArtifactReserveBundle(0);
+    }
+    assert.strictEqual(reserveHost.state.artifactReserveDraft.active, false);
+    assert.strictEqual(reserveHost.state.artifactReservePool.length, 12);
+    assert.strictEqual(new Set(reserveHost.state.artifactReservePool.map(entry => entry.id)).size, 12);
+    assert(reserveHost.state.artifactReservePool.every(entry => entry.remainingUses === 2));
+    const reserveIds = reserveHost.state.artifactReservePool.map(entry => entry.id);
+    reserveIds.slice(0, 4).forEach(id => assert.strictEqual(reserveHost.toggleArtifactReserveArtifact(id), true));
+    assert.strictEqual(reserveHost.state.artifacts.length, 4);
+    assert.strictEqual(reserveHost.toggleArtifactReserveArtifact(reserveIds[4]), false);
+    assert.deepStrictEqual(Array.from(reserveHost.consumeArtifactReserveUsesForBattle()).sort(), Array.from(reserveIds.slice(0, 4)).sort());
+    assert(reserveHost.state.artifactReservePool.slice(0, 4).every(entry => entry.remainingUses === 1));
+    reserveHost.resetArtifactReserveActivations();
+    assert.strictEqual(reserveHost.state.artifacts.length, 0);
+    reserveHost.state.artifactReservePool[0].remainingUses = 0;
+    assert.strictEqual(reserveHost.toggleArtifactReserveArtifact(reserveIds[0]), false);
+
+    const artifactChaosHost = {
+      global: { unlocked_divine_artifacts: ['divine_flora'], unlocked_bonus_cards: [] },
+      state: {
+        mode: 'artifact_chaos', artifacts: [], chaosPool: [], inventory: [], deck: [null, null, null],
+        activeTranscendenceCards: [], activeBonusPoolIds: [], activeSpecialCardSelections: {}, activeEventCards: []
+      }
+    };
+    RPGFeatureModules.install(artifactChaosHost);
+    const artifactChaosIds = artifactChaosHost.resetArtifactChaosRound();
+    const allowedArtifactIds = new Set(divineArtifactPool.map(artifact => artifact.id));
+    assert.strictEqual(artifactChaosHost.state.chaosPool.length, GAME_CONSTANTS.CHAOS_POOL_SIZE);
+    assert.deepStrictEqual(Array.from(artifactChaosHost.state.inventory), Array.from(artifactChaosHost.state.chaosPool));
+    assert.strictEqual(artifactChaosIds.length, GAME_CONSTANTS.MAX_ARTIFACTS);
+    assert.strictEqual(new Set(artifactChaosIds).size, GAME_CONSTANTS.MAX_ARTIFACTS);
+    assert(artifactChaosIds.every(id => allowedArtifactIds.has(id)));
 
     // One Joker can fill only one missing slot in a conjunctive card requirement.
     assert.strictEqual(
@@ -434,10 +508,16 @@ function run() {
 
     const starDeck = ['shooting_star_boy', 'marshmallow', 'kobold'];
     const shootingStar = buildWaveUnit('shooting_star_boy', starDeck, 0);
-    assert.strictEqual(shootingStar.mdef, 27);
+    assert.strictEqual(shootingStar.mdef, 38);
     assert.strictEqual(Logic.calculateStats(shootingStar, [], 'default', [], 1).atk, 170);
     assert.strictEqual(Logic.calculateStats(shootingStar, [], 'default', [], 2).atk, 170);
     assert.strictEqual(Logic.calculateStats(shootingStar, [], 'default', [], 3).atk, 85);
+    const lateShootingStar = { ...shootingStar, enteredAtTurn: 3 };
+    assert.strictEqual(Logic.calculateStats(lateShootingStar, [], 'default', [], 3).atk, 170);
+    assert.strictEqual(Logic.calculateStats(lateShootingStar, [], 'default', [], 4).atk, 170);
+    assert.strictEqual(Logic.calculateStats(lateShootingStar, [], 'default', [], 5).atk, 85);
+    const duplicateStarDeck = ['shooting_star_boy', 'shooting_star_boy', 'shooting_star_boy'];
+    assert(Logic.calculateInitialStats(getCard('shooting_star_boy'), duplicateStarDeck, GameUtils.getAllCards(), 0).stats.mdef >= 0);
     const starSkillTarget = makeUnit({ hp: 5000, maxHp: 5000 });
     const fullHpStar = { ...shootingStar, hp: shootingStar.maxHp, baseCrit: -100 };
     const hurtStar = { ...shootingStar, hp: shootingStar.maxHp - 1, baseCrit: -100 };
@@ -460,6 +540,17 @@ function run() {
       [madScientistPeer.atk, madScientistPeer.matk, madScientistPeer.def, madScientistPeer.mdef],
       [169, 169, 78, 84]
     );
+    const duplicateMadDeck = ['mad_scientist', 'mad_scientist', 'luna'];
+    const duplicateMadScientist = buildWaveUnit('mad_scientist', duplicateMadDeck, 0);
+    const duplicateMadPeer = buildWaveUnit('luna', duplicateMadDeck, 2);
+    assert.deepStrictEqual(
+      [duplicateMadScientist.atk, duplicateMadScientist.matk, duplicateMadScientist.def, duplicateMadScientist.mdef],
+      [104, 104, 71, 71]
+    );
+    assert.deepStrictEqual(
+      [duplicateMadPeer.atk, duplicateMadPeer.matk, duplicateMadPeer.def, duplicateMadPeer.mdef],
+      [169, 169, 78, 84]
+    );
 
     assert.strictEqual(
       buildWaveUnit('paladin', ['marshmallow', 'paladin', 'kobold'], 1).atk,
@@ -480,6 +571,20 @@ function run() {
         Logic.calculateStats(victoriaFront, [{ name: 'sun_bless' }], 'default', [], 1).atk
       ],
       [160, 130]
+    );
+    const forcedCrit = { name: '검증용 치명타', type: 'phy', val: 1, effects: [{ type: 'force_crit' }] };
+    const critTarget = makeUnit({ def: 0, mdef: 0 });
+    assert.strictEqual(
+      Logic.calculateDamage(victoriaLeader, critTarget, forcedCrit, [{ name: 'sun_bless' }], [], quiet, 'default', [], 1, []).dmg,
+      432
+    );
+    assert.strictEqual(
+      Logic.calculateDamage(victoriaFront, critTarget, forcedCrit, [{ name: 'sun_bless' }], [], quiet, 'default', [], 1, []).dmg,
+      273
+    );
+    assert.strictEqual(
+      Logic.calculateDamage(victoriaLeader, critTarget, forcedCrit, [{ name: 'sun_bless' }], [], quiet, 'flood', [], 1, []).dmg,
+      858
     );
 
     const alternatingUnit = makeUnit({ atk: 100, matk: 100, alternatingAttackStatPercent: 50 });
@@ -646,6 +751,24 @@ function run() {
     );
     assert(waveInitRpg.battle.players.every(unit => unit.alternatingAttackStatPercent === 50));
     assert(waveInitRpg.battle.players.every(unit => unit.maxMp === 100 && unit.mp === 100));
+
+    const reserveBattleRpg = makeBattleInitRpg(['marshmallow', null, null]);
+    reserveBattleRpg.state.mode = 'artifact_reserve';
+    reserveBattleRpg.state.artifactReserveDraft = { active: false };
+    let reserveUseCalls = 0;
+    reserveBattleRpg.consumeArtifactReserveUsesForBattle = () => { reserveUseCalls++; return []; };
+    BattleRuntime.TurnManager.startPlayerTurn = quiet;
+    BattleRuntime.startBattleInit(reserveBattleRpg);
+    BattleRuntime.TurnManager.startPlayerTurn = startPlayerTurnOriginal;
+    assert.strictEqual(reserveUseCalls, 1);
+
+    const buildScaledEnemy = (mode, gameType) => buildBattleEnemy({
+      state: { mode, gameType, enemyScale: 0, hardMode: false },
+      getCurrentStageEnemyData: () => ENEMIES[0]
+    });
+    assert.strictEqual(buildScaledEnemy('default', 'challenge').maxHp, ENEMIES[0].stats.hp);
+    assert.strictEqual(buildScaledEnemy('artifact_chaos', 'challenge').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.1));
+    assert.strictEqual(buildScaledEnemy('artifact_reserve', 'endless').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.1));
 
     // The merchant hands 20 maximum and current mana to the next living ally.
     const merchantVictim = buildWaveUnit('grand_merchant', ['grand_merchant', 'marshmallow', 'kobold'], 0);

--- a/scripts/verify_card_smoke.js
+++ b/scripts/verify_card_smoke.js
@@ -40,7 +40,14 @@ function run() {
     'openBonusPoolEditor()',
     'bonusPoolPresets:',
     'activeBonusPoolPresetIndex:',
-    "name: 'RPGFeatureModules'"
+    "name: 'RPGFeatureModules'",
+    'id="screen-artifact-reserve-draft"',
+    'id="menu-artifact-area"',
+    'id="artifact-check-title"',
+    "id: 'artifact_chaos'",
+    "id: 'artifact_reserve'",
+    "!['origin', 'archive'].includes(m.id)",
+    "!['artifact_chaos', 'artifact_reserve'].includes(m.id)"
   ]);
 
   mustContain(path.join(cardRoot, 'rpg_features.js'), [
@@ -54,7 +61,11 @@ function run() {
     'claimSpecialMissionReward()',
     'tryUnlockSpecialMissionFromDreamCorridor(stageNumber)',
     'getCurrentSpecialSeason(date = new Date())',
-    'activeBonusPoolIds: this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds)'
+    'activeBonusPoolIds: this.normalizeActiveBonusPoolIds(this.pendingActiveBonusPoolIds)',
+    'resetArtifactChaosRound()',
+    'generateArtifactReserveBundles()',
+    'toggleArtifactReserveArtifact(id)',
+    'consumeArtifactReserveUsesForBattle()'
   ]);
 
   mustContain(path.join(cardRoot, 'logic.js'), [
@@ -91,7 +102,8 @@ function run() {
     "syn_water_light_heart_star",
     "skill.name === '하트오버드라이브'",
     "syn_water_light_midnight_twinkle",
-    "skill.name === '미드나잇판타지'"
+    "skill.name === '미드나잇판타지'",
+    "artifact_reserve"
   ]);
   mustContain(path.join(cardRoot, 'toeic.js'), ['const TOEIC_DATA']);
 


### PR DESCRIPTION
## 변경 사항
- 빅토리아·별똥별소년·매드사이언티스트 특성과 초보자 보상을 수정했습니다.
- 챌린지용 아티팩트카오스와 아티팩트리저브를 추가했습니다.
- 리저브의 12개 아티팩트 풀, 사용 횟수, 전투 전 활성화 UI를 구현했습니다.
- 신기 해금 시 두 신규 모드의 선택 풀에서도 기본 아티팩트 대신 신기가 등장하도록 했습니다.

## 동작 영향
- 아티팩트카오스와 아티팩트리저브는 챌린지 적을 한 단계(+10%) 강화합니다.
- 아티팩트리저브는 엔드리스에서도 동일한 강화와 오리진 계열 초월 규칙을 따릅니다.

## 검증
- `npm run verify` 통과