### PR TITLE
Adjust artifact-reserve lifecycle: consume uses on run reset and stop consuming on battle init

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -216,10 +216,6 @@ const BattleRuntime = {
             return rpg.showAlert("덱을 완성해주세요.");
         }
 
-        if (rpg.state.mode === 'artifact_reserve' && typeof rpg.consumeArtifactReserveUsesForBattle === 'function') {
-            rpg.consumeArtifactReserveUsesForBattle();
-        }
-
         rpg.showBattleScreen();
         rpg.battle.enemy = buildBattleEnemy(rpg);
         rpg.battle.activeTraits = [];

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1183,18 +1183,10 @@
             const entry = entries.find(item => item.id === id);
             entry.remainingUses--;
         });
-        this.state.artifacts = activeIds;
+        this.state.artifacts = [];
         this.saveGame(false);
         return activeIds;
     },
-
-
-    resetArtifactReserveActivations() {
-        if (this.state.mode !== 'artifact_reserve') return;
-        this.state.artifacts = [];
-        this.saveGame(false);
-    },
-
 
     resetPendingActiveBonusPoolIds() {
         this.syncPendingActiveBonusPoolIds();
@@ -1246,7 +1238,6 @@
                 this.state.activeSpecialCardSelections = this.normalizeSpecialCardSelections(this.state.activeSpecialCardSelections || this.global.activeSpecialCardSelections);
                 if (this.state.mode === 'dream_corridor' && this.state.dreamCorridorLives === undefined) this.state.dreamCorridorLives = 3;
                 this.loadStudyProgress();
-
                 this.showAlert("불러오기 완료");
                 this.toMenu();
             } else { this.showAlert("저장된 데이터가 없습니다. 새로 시작합니다."); this.openTypeSelect(); }
@@ -1767,7 +1758,7 @@
             }
         }
 
-        this.resetArtifactReserveActivations();
+        this.consumeArtifactReserveUsesForBattle();
 
         if (mode === 'draft') {
             this.resetDraftState();
@@ -1927,7 +1918,7 @@
         this.state.chaosBuffs = [];
         this.state.activeChaosBlessing = [];
         this.state.activeSageBlessing = [];
-        this.resetArtifactReserveActivations();
+        this.consumeArtifactReserveUsesForBattle();
 
         let deadMsg = this.handlePermadeath(this.battle.players);
         if (this.state.mode === 'dream_corridor') {

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -322,7 +322,6 @@ function run() {
     assert.strictEqual(reserveHost.toggleArtifactReserveArtifact(reserveIds[4]), false);
     assert.deepStrictEqual(Array.from(reserveHost.consumeArtifactReserveUsesForBattle()).sort(), Array.from(reserveIds.slice(0, 4)).sort());
     assert(reserveHost.state.artifactReservePool.slice(0, 4).every(entry => entry.remainingUses === 1));
-    reserveHost.resetArtifactReserveActivations();
     assert.strictEqual(reserveHost.state.artifacts.length, 0);
     reserveHost.state.artifactReservePool[0].remainingUses = 0;
     assert.strictEqual(reserveHost.toggleArtifactReserveArtifact(reserveIds[0]), false);
@@ -760,7 +759,7 @@ function run() {
     BattleRuntime.TurnManager.startPlayerTurn = quiet;
     BattleRuntime.startBattleInit(reserveBattleRpg);
     BattleRuntime.TurnManager.startPlayerTurn = startPlayerTurnOriginal;
-    assert.strictEqual(reserveUseCalls, 1);
+    assert.strictEqual(reserveUseCalls, 0);
 
     const buildScaledEnemy = (mode, gameType) => buildBattleEnemy({
       state: { mode, gameType, enemyScale: 0, hardMode: false },


### PR DESCRIPTION
### Motivation

- Ensure artifact-reserve uses are decremented when a run/round is finalized rather than when entering a battle, and avoid unintended consumption during `startBattleInit`.
- Simplify reserve activation handling by clearing active artifacts as part of the consume operation.

### Description

- Change `consumeArtifactReserveUsesForBattle` to decrement `remainingUses`, clear `state.artifacts`, save, and return the list of consumed `activeIds` instead of keeping them active.
- Remove the separate `resetArtifactReserveActivations` function and replace its call sites with `consumeArtifactReserveUsesForBattle` in game flow paths such as new game/round reset and defeat handling (`startGame` and loss flows).
- Remove the automatic call to `rpg.consumeArtifactReserveUsesForBattle()` from `BattleRuntime.startBattleInit` so entering a battle no longer consumes reserve uses.
- Update `scripts/verify_card_combat_regressions.js` to reflect the new behavior by removing the reset call and changing the `startBattleInit` consumption expectation to `0`.

### Testing

- Ran the regression script `scripts/verify_card_combat_regressions.js`, which covers artifact-reserve bundle generation, toggling, consumption, and battle initialization; all assertions passed after updating the expectations.
- The artifact-reserve test asserting consumption during `startBattleInit` was adjusted and the script succeeded with the new expected behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a66277beabc832292d64382acb42652)