### PR TITLE
feat(card): 모바일 환경 메뉴 잘림 수정을 위한 아티팩트 메뉴 이동

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -2915,7 +2915,7 @@
                     gachaArea.style.display = 'flex';
                 }
 
-                if (this.state.mode === 'artifact_chaos' && artifactArea && artifactMenuBtn) {
+                /* if (this.state.mode === 'artifact_chaos' && artifactArea && artifactMenuBtn) {
                     artifactArea.style.display = 'block';
                     artifactMenuBtn.innerText = `현재 활성 아티팩트 (${(this.state.artifacts || []).length}/${GAME_CONSTANTS.MAX_ARTIFACTS})`;
                 }
@@ -2930,7 +2930,7 @@
                     } else {
                         artifactMenuBtn.innerText = `아티팩트 풀 관리 (${(this.state.artifacts || []).length}/${GAME_CONSTANTS.MAX_ARTIFACTS} 활성)`;
                     }
-                }
+                } */
             },
             toTitle() {
                 // No saveRecord here
@@ -3070,7 +3070,25 @@
                 const sageDesc = document.getElementById('great-sage-desc');
                 if (artBtn) {
                     artBtn.style.display = isArtifactMode ? 'block' : 'none';
-                    artBtn.innerText = this.state.mode === 'artifact_reserve' ? '아티팩트 풀 관리' : '아티팩트 확인';
+                    if (this.state.mode === 'artifact_chaos') {
+                        artBtn.innerText = `현재 활성 아티팩트 (${(this.state.artifacts || []).length}/${GAME_CONSTANTS.MAX_ARTIFACTS})`;
+                        artBtn.onclick = () => this.openArtifactCheck();
+                    } else if (this.state.mode === 'artifact_reserve') {
+                        if (this.state.artifactReserveDraft && this.state.artifactReserveDraft.active) {
+                            artBtn.innerText = `아티팩트 리저브 선택 계속 (${this.state.artifactReserveDraft.round}/${this.state.artifactReserveDraft.maxRounds})`;
+                            artBtn.onclick = () => {
+                                document.getElementById('modal-chaos').classList.remove('active');
+                                this.showScreen('screen-artifact-reserve-draft');
+                                this.renderArtifactReserveDraftScreen();
+                            };
+                        } else {
+                            artBtn.innerText = `아티팩트 풀 관리 (${(this.state.artifacts || []).length}/${GAME_CONSTANTS.MAX_ARTIFACTS} 활성)`;
+                            artBtn.onclick = () => this.openArtifactCheck();
+                        }
+                    } else {
+                        artBtn.innerText = '아티팩트 확인';
+                        artBtn.onclick = () => this.openArtifactCheck();
+                    }
                 }
                 if (sageDesc) {
                     sageDesc.innerText = this.state.mode === 'puzzle'


### PR DESCRIPTION
## 작업 내용\n- 아티팩트 리저브 모드와 아티팩트 카오스 모드에서 메뉴가 길어 모바일 환경에서 짤리는 현상 수정\n- 전투 로비에 노출되던 아티팩트 확인/관리 메뉴를 축복의 제단 모달 내부로 이동\n- 이동 시 일반 아티팩트 모드와 동일한 모바일 압축 레이아웃 적용\n\n## 테스트\n- npm run verify 통과\n- 실제 브라우저 모바일 해상도(390x844) 시뮬레이터에서 모달 내 메뉴 잘림 없는지 확인 완료