### PR TITLE
Fix mobile layouts for bonus pool grid and chaos modal

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -473,7 +473,7 @@
 
         .bonus-pool-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(85px, 1fr));
             gap: 8px;
             margin-top: 10px;
         }
@@ -482,8 +482,12 @@
             background: #2a2a2a;
             border: 1px solid #444;
             border-radius: 10px;
-            padding: 8px;
-            text-align: left;
+            padding: 6px;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: space-between;
         }
 
         .bonus-pool-item.is-disabled {
@@ -492,23 +496,24 @@
         }
 
         .bonus-pool-name {
-            font-size: 0.85rem;
+            font-size: 0.75rem;
             font-weight: bold;
-            margin: 8px 0 4px 0;
+            margin: 5px 0 2px 0;
             word-break: keep-all;
         }
 
         .bonus-pool-grade {
-            font-size: 0.72rem;
+            font-size: 0.65rem;
             color: #aaa;
-            margin-bottom: 6px;
+            margin-bottom: 5px;
         }
 
         .bonus-pool-toggle {
             display: flex;
             align-items: center;
-            gap: 6px;
-            font-size: 0.8rem;
+            justify-content: center;
+            gap: 4px;
+            font-size: 0.75rem;
             color: #ddd;
         }
 
@@ -630,6 +635,34 @@
             .modal-content {
                 /* Inline desktop widths must still be clamped on narrow phones. */
                 max-width: calc(100vw - 16px) !important;
+            }
+
+            #modal-chaos .modal-content {
+                padding-top: 10px;
+                padding-bottom: 10px;
+            }
+
+            #modal-chaos .chaos-title {
+                margin: 5px 0 8px 0;
+            }
+
+            #modal-chaos .chaos-desc {
+                margin: 0 0 8px 0;
+                line-height: 1.3;
+            }
+
+            #modal-chaos .chaos-uses {
+                margin-bottom: 8px !important;
+            }
+
+            #modal-chaos .menu-btn {
+                margin-bottom: 6px;
+                padding: 10px;
+            }
+
+            #modal-chaos .chaos-close-btn {
+                margin-top: 6px !important;
+                padding: 10px;
             }
         }
 


### PR DESCRIPTION
This commit fixes the mobile UI layouts for the Bonus Card Deck Editor grid by adjusting the grid item sizes and inner paddings to fit 3 cards per row instead of 2. It also adds a media query for `#modal-chaos` (Altar of Chaos) to shrink its elements' heights, margins, and paddings so the modal can be viewed without scrolling on smaller screens.

---
*PR created automatically by Jules for task [8152317714072081901](https://jules.google.com/task/8152317714072081901) started by @romarin0325-cell*