### PR TITLE
feat(card): 지연 스킬 타이밍과 신규 카드 추가

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -315,6 +315,11 @@ const BattleRuntime = {
                 rpg.log(`=== ${battle.turn}턴 ===`, 'info');
                 BattleRuntime.expireFieldBuffs(rpg, battle.turn);
 
+                if (BattleRuntime.hasActiveTrait(rpg, 'vanguard_moon_bless_every_3_turns') && battle.turn % 3 === 0) {
+                    BattleRuntime.applyFieldBuff(rpg, 'moon_bless');
+                    rpg.log('[특성] 푸른달의사제: 달의축복 부여!');
+                }
+
                 const hasProphetTrait = BattleRuntime.hasActiveTrait(rpg, 'field_kaleidoscope_each_turn');
                 if (rpg.hasArtifact('kaleidoscope') || hasProphetTrait) {
                     const count = battle.fieldBuffs.length;
@@ -620,7 +625,7 @@ const BattleRuntime = {
         players.forEach(player => {
             if (!player || !player.proto || !player.proto.trait) return;
             if (player.proto.trait.type !== 'ally_light_death_base_matk_mag' && player.proto.trait.type !== 'ally_death_base_atk_phy') return;
-            if (player.isDead && player !== victim) return;
+            if (player.isDead) return;
             if (killer.hp <= 0) return;
             if (player.proto.trait.type === 'ally_light_death_base_matk_mag' && !GameUtils.cardMatchesElement(victim.proto, 'light')) return;
 
@@ -695,7 +700,11 @@ const BattleRuntime = {
     },
 
     maybeTriggerDeathRoulette(rpg, source, skill, isDelayed = false) {
-        if (!rpg.hasArtifact('death_roulette') || isDelayed || skill.name === rpg.NORMAL_ATTACK.name) {
+        const isDelayedReservation = !isDelayed &&
+            typeof findDelayedSkillEffect === 'function' &&
+            findDelayedSkillEffect(skill) &&
+            !BattleRuntime.hasActiveTrait(rpg, 'instant_delayed_skills');
+        if (!rpg.hasArtifact('death_roulette') || isDelayedReservation || skill.name === rpg.NORMAL_ATTACK.name) {
             return false;
         }
         if (Math.random() >= 0.3) return false;
@@ -739,6 +748,28 @@ const BattleRuntime = {
         const restored = source.mp - before;
         rpg.log(`[특성] 혜성추적자: 지연 스킬 발동! ${source.name}의 마나 ${restored} 회복!`);
         return restored;
+    },
+
+    applyLeaderHpCostOnSkill(rpg, source, target, skill) {
+        const trait = source && source.proto && source.proto.trait;
+        if (!trait || trait.type !== 'leader_hp_cost_on_skill' || skill.name === rpg.NORMAL_ATTACK.name) {
+            return false;
+        }
+
+        const leader = (rpg.battle.players || []).find(player => player && player.pos === 2 && !player.isDead);
+        if (!leader) return false;
+
+        const ratio = Number.isFinite(trait.ratio) ? trait.ratio : 0.35;
+        const amount = Math.max(1, Math.round((leader.maxHp || 0) * ratio));
+        if (amount <= 0) return false;
+
+        leader.hp = Math.max(0, leader.hp - amount);
+        rpg.log(`[특성] ${source.name}: 대장 ${leader.name}의 생명력 ${amount} 소모!`);
+        if (leader.hp <= 0) {
+            BattleRuntime.resolveSourceDeath(rpg, leader, target);
+            return true;
+        }
+        return false;
     },
 
     executeSkill(rpg, source, target, skill, isDelayed = false) {
@@ -824,14 +855,23 @@ const BattleRuntime = {
             rpg.log("[특성] 피닉스: 일반 공격 시 작열 부여!");
         }
 
-        if (source.proto && source.proto.trait && isBehemothTraitType(source.proto.trait.type) && Math.random() < 0.2) {
-            target.buffs.stun = 1;
-            rpg.log(`[특성] ${source.name}: 20% 확률로 적을 기절시킵니다!`);
-        }
-
         const delayedEff = typeof findDelayedSkillEffect === 'function'
             ? findDelayedSkillEffect(modifiedSkill)
             : null;
+        const isMultiDelayedEffect = delayedEff &&
+            (delayedEff.type === 'phantom_nightmare' || delayedEff.type === 'multi_delayed_attack');
+        const resolvesImmediately = delayedEff && !isDelayed &&
+            BattleRuntime.hasActiveTrait(rpg, 'instant_delayed_skills') && !isMultiDelayedEffect;
+
+        if (
+            source.proto && source.proto.trait &&
+            isBehemothTraitType(source.proto.trait.type) &&
+            (!delayedEff || isDelayed || resolvesImmediately) &&
+            Math.random() < 0.2
+        ) {
+            target.buffs.stun = 1;
+            rpg.log(`[특성] ${source.name}: 20% 확률로 적을 기절시킵니다!`);
+        }
 
         if (delayedEff && !isDelayed) {
             const resolvedDelayedSkill = typeof buildResolvedDelayedSkill === 'function'
@@ -859,7 +899,6 @@ const BattleRuntime = {
                         rpg.log(message);
                         BattleRuntime.executeSkill(rpg, source, target, resolvedDelayedSkill, true);
                     });
-                    BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
                     BattleRuntime.resolveSourceDeath(rpg, source, target);
                     if (target.hp <= 0) {
                         rpg.winBattle();
@@ -881,7 +920,6 @@ const BattleRuntime = {
                 const lastTurn = Math.max(...nightmareTurns);
                 const turnLabel = firstTurn === lastTurn ? `${firstTurn}턴 뒤` : `${firstTurn}~${lastTurn}턴 뒤`;
                 rpg.log(`${skill.name} 준비... (${turnLabel} 연속 발동)`);
-                BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
                 BattleRuntime.resolveSourceDeath(rpg, source, target);
                 if (target.hp <= 0) {
                     rpg.winBattle();
@@ -902,7 +940,6 @@ const BattleRuntime = {
                     source: source,
                     skill: resolvedDelayedSkill
                 });
-                BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
                 BattleRuntime.resolveSourceDeath(rpg, source, target);
                 if (target.hp <= 0) {
                     rpg.winBattle();
@@ -931,7 +968,8 @@ const BattleRuntime = {
         if (dmgResult.dmg > 0) {
             BattleRuntime.handleOnHitTraits(rpg, target, source);
         }
-        BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
+        BattleRuntime.applyLeaderHpCostOnSkill(rpg, source, target, modifiedSkill);
+        if (!source.isDead) BattleRuntime.maybeTriggerDeathRoulette(rpg, source, modifiedSkill, isDelayed);
         BattleRuntime.resolveSourceDeath(rpg, source, target);
 
         if (target.hp <= 0) {

--- a/card/data.js
+++ b/card/data.js
@@ -1260,7 +1260,7 @@ const BONUS_CARD_EXPANSION = [
         trait: { type: 'deck_turn_modulo_force_crit', mod: 5, desc: '덱 전체가 5의 배수 턴에 반드시 치명타' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
-            { name: '루시드프래시', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '물리 2배율, 5의 배수 턴에 침묵, 저주, 디바인 부여', effects: [{ type: 'turn_modulo_debuffs', mod: 5, debuffs: ['silence', 'curse', 'divine'] }] },
+            { name: '루시드플래시', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '물리 2배율, 5의 배수 턴에 침묵, 저주, 디바인 부여', effects: [{ type: 'turn_modulo_debuffs', mod: 5, debuffs: ['silence', 'curse', 'divine'] }] },
             { name: '파이널앤서', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 5의 배수 턴에는 위력 2배', effects: [{ type: 'turn_modulo_dmg', mod: 5, mult: 2.0 }] }
         ]
     },
@@ -1777,8 +1777,8 @@ const BONUS_TRANSCENDENCE_CARDS = [
             desc: '덱에 불 3장 이상 시 공격력 100% 증가'
         },
         skills: [
-            { name: '앱솔루트아머', type: 'sup', tier: 2, cost: 30, desc: '필드버프 트윙클파티 부여, 3턴간 받는 대미지 50% 감소', effects: [{ type: 'field_buff', id: 'twinkle_party' }, { type: 'buff', id: 'guard', duration: 3 }] },
-            { name: '테라소드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '필드버프 아레나 발동', effects: [{ type: 'field_buff', id: 'arena' }] },
+            { name: '앱솔루트아머', type: 'sup', tier: 3, cost: 30, desc: '필드버프 트윙클파티 부여, 3턴간 받는 대미지 50% 감소', effects: [{ type: 'field_buff', id: 'twinkle_party' }, { type: 'buff', id: 'guard', duration: 3 }] },
+            { name: '테라소드', type: 'phy', tier: 2, cost: 30, val: 2.0, desc: '필드버프 아레나 발동', effects: [{ type: 'field_buff', id: 'arena' }] },
             { name: '마그마이럽션', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열을 전부 소모하고, 소모한 작열 1스택당 배율 2.5 증가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.5 }] }
         ]
     },

--- a/card/data.js
+++ b/card/data.js
@@ -753,7 +753,7 @@ const BONUS_CARDS = [
         trait: { type: 'looter', desc: '이 카드로 승리 시 추가 드로우' },
         skills: [
             { name: '리버설', type: 'sup', tier: 2, cost: 20, desc: '저주 부여 및 마법공격 무효', effects: [{ type: 'debuff', id: 'curse' }, { type: 'buff', id: 'magic_guard', duration: 1 }] },
-            { name: '리플렉션', type: 'sup', tier: 2, cost: 20, desc: '저주 부여 및 물리공격 무효', effects: [{ type: 'debuff', id: 'curse' }, { type: 'buff', id: 'barrier', duration: 1 }] },
+            { name: '리플렉션', type: 'sup', tier: 2, cost: 20, desc: '침묵 부여 및 물리공격 무효', effects: [{ type: 'debuff', id: 'silence' }, { type: 'buff', id: 'barrier', duration: 1 }] },
             { name: '라비린스', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '부식 상태의 적에게 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'target_debuff', debuff: 'corrosion', mult: 2.0 }] }
         ]
     },
@@ -926,7 +926,7 @@ const BONUS_CARD_EXPANSION = [
     {
         id: 'ash', name: '애쉬', grade: 'epic', element: 'fire', role: 'dealer', unlockSource: 'hidden',
         stats: { hp: 420, atk: 120, matk: 70, def: 50, mdef: 50 },
-        trait: { type: 'ally_death_base_atk_phy', val: 3.0, desc: '아군이 사망할 때 자신의 기본 공격력 기준 물리 반격' },
+        trait: { type: 'ally_death_base_atk_phy', val: 3.0, desc: '애쉬가 생존해 있을 경우, 아군 사망 시 자신의 기본 공격력 기준 물리 반격' },
         skills: [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '아마겟돈', type: 'phy', tier: 3, cost: 30, val: 7.0, desc: '현재 생명력 50% 소모, 다음 턴 휴식', effects: [{ type: 'self_hp_cost_ratio', ratio: 0.5 }, { type: 'self_debuff', id: 'stun', duration: 1 }] },
@@ -1152,7 +1152,6 @@ const BONUS_CARD_EXPANSION = [
         stats: { hp: 400, atk: 105, matk: 75, def: 70, mdef: 70 },
         trait: { type: 'pos_stat_boost', pos: 1, stat: 'atk', val: 100, desc: '중견 배치 시 공격력 100% 증가' },
         skills: [
-            { name: '가드', type: 'sup', tier: 1, cost: 10, desc: '대미지 반감', effects: [{ type: 'buff', id: 'guard', duration: 1 }] },
             { name: '디바인아머', type: 'sup', tier: 2, cost: 20, desc: '3턴간 받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 3 }] },
             { name: '홀리그라운드', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '마법 1배율, 필드버프 성역 부여', effects: [{ type: 'field_buff', id: 'sanctuary' }] },
             { name: '듀얼브레이커', type: 'mag', tier: 2, cost: 20, val: 2.0, desc: '아레나 소모 시 대미지 3배', effects: [{ type: 'consume_field_buff_dmg', buff: 'arena', mult: 3.0 }] }
@@ -1216,8 +1215,8 @@ const BONUS_CARD_EXPANSION = [
         ]
     },
     {
-        id: 'astrologer', name: '점성술사', grade: 'epic', element: 'water', role: 'dealer', unlockSource: 'hidden',
-        stats: { hp: 390, atk: 90, matk: 95, def: 60, mdef: 65 },
+        id: 'astrologer', name: '점성술사', grade: 'epic', element: 'water', role: 'buffer', unlockSource: 'hidden',
+        stats: { hp: 390, atk: 90, matk: 85, def: 60, mdef: 70 },
         trait: { type: 'alternate_party_atk_matk_turn', val: 50, desc: '덱 전체가 홀수 턴에는 공격력 50% 감소·마법공격력 50% 증가, 짝수 턴에는 마법공격력 50% 감소·공격력 50% 증가' },
         skills: [
             { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
@@ -1233,6 +1232,46 @@ const BONUS_CARD_EXPANSION = [
             { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
             { name: '솔라크레센토', type: 'phy', tier: 3, cost: 30, val: 2.5, desc: '태양의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'sun_bless', mult: 2.0 }] },
             { name: '루나크레센토', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '달의축복 상태에서 대미지 2배', effects: [{ type: 'dmg_boost', condition: 'field_buff', buff: 'moon_bless', mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'succubus', name: '서큐버스', grade: 'rare', element: 'dark', role: 'debuffer', unlockSource: 'bonus',
+        stats: { hp: 340, atk: 70, matk: 95, def: 55, mdef: 65 },
+        trait: { type: 'death_debuff', debuff: 'silence', desc: '사망 시 적에게 침묵 부여' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '페이탈핑크', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '마법 2배율, 유혹 부여', effects: [{ type: 'debuff', id: 'temptation' }] },
+            { name: '다크판타지', type: 'mag', tier: 3, cost: 30, val: 1.0, desc: '암흑 소모 후 약화, 부식, 저주 부여', effects: [{ type: 'consume_debuff_fixed', debuff: 'darkness', count: 1, mult: 1.0, customLog: '암흑 1스택 소모!' }, { type: 'debuff', id: 'weak' }, { type: 'debuff', id: 'corrosion' }, { type: 'debuff', id: 'curse' }] }
+        ]
+    },
+    {
+        id: 'trauma', name: '트라우마', grade: 'epic', element: 'dark', role: 'dealer', unlockSource: 'bonus',
+        stats: { hp: 400, atk: 75, matk: 115, def: 65, mdef: 75 },
+        trait: { type: 'leader_hp_cost_on_skill', ratio: 0.35, desc: '스킬 발동 시 대장 생명력 35% 소모' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '스티그마', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 저주, 침묵, 암흑 부여', effects: [{ type: 'debuff', id: 'curse' }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'darkness' }] },
+            { name: '마인드브레이커', type: 'mag', tier: 3, cost: 30, val: 7.0, desc: '3턴 뒤 발동하는 마법 7배율 공격', effects: [{ type: 'delayed_attack', turns: 3 }] }
+        ]
+    },
+    {
+        id: 'great_detective', name: '명탐정', grade: 'epic', element: 'water', role: 'balancer', unlockSource: 'bonus',
+        stats: { hp: 395, atk: 90, matk: 90, def: 65, mdef: 65 },
+        trait: { type: 'deck_turn_modulo_force_crit', mod: 5, desc: '덱 전체가 5의 배수 턴에 반드시 치명타' },
+        skills: [
+            { name: '회피태세', type: 'sup', tier: 1, cost: 10, desc: '회피율 50% 증가', effects: [{ type: 'buff', id: 'evasion', duration: 1 }] },
+            { name: '루시드프래시', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '물리 2배율, 5의 배수 턴에 침묵, 저주, 디바인 부여', effects: [{ type: 'turn_modulo_debuffs', mod: 5, debuffs: ['silence', 'curse', 'divine'] }] },
+            { name: '파이널앤서', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '마법 2.5배율, 5의 배수 턴에는 위력 2배', effects: [{ type: 'turn_modulo_dmg', mod: 5, mult: 2.0 }] }
+        ]
+    },
+    {
+        id: 'blue_moon_priest', name: '푸른달의사제', grade: 'legend', element: 'water', role: 'buffer', unlockSource: 'bonus',
+        stats: { hp: 500, atk: 90, matk: 120, def: 75, mdef: 80 },
+        trait: { type: 'vanguard_moon_bless_every_3_turns', mod: 3, desc: '선봉 배치 시 3의 배수 턴마다 달의축복 부여' },
+        skills: [
+            { name: '매직가드', type: 'sup', tier: 1, cost: 10, desc: '마법공격 무효', effects: [{ type: 'buff', id: 'magic_guard', duration: 1 }] },
+            { name: '창조의기도', type: 'mag', tier: 3, cost: 30, val: 2.0, desc: '3턴 뒤 발동, 성역 전개 및 디바인 1스택 부여', effects: [{ type: 'delayed_attack_field', turns: 3, field: 'sanctuary' }, { type: 'debuff', id: 'divine', stack: 1 }] },
+            { name: '파괴의기도', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '사신강림 소모 시 위력 4배', effects: [{ type: 'consume_field_buff_dmg', buff: 'reaper_realm', mult: 4.0 }] }
         ]
     }
 ];
@@ -1407,7 +1446,7 @@ const SPECIAL_CARD_OVERRIDES = {
         ...card,
         role: 'balancer',
         stats: { hp: 500, atk: 85, matk: 110, def: 85, mdef: 85 },
-        trait: { type: 'ally_light_death_base_matk_mag', val: 2.0, desc: '덱의 빛속성 카드가 사망할 때 자신의 기본 마공 기준 2배율 반격' },
+        trait: { type: 'ally_light_death_base_matk_mag', val: 2.0, desc: '자스민이 생존해 있을 경우, 덱의 빛속성 카드 사망 시 자신의 기본 마공 기준 2배율 반격' },
         skills: [
             cloneData(SHARED_MAGIC_GUARD_SKILL),
             {
@@ -1738,8 +1777,8 @@ const BONUS_TRANSCENDENCE_CARDS = [
             desc: '덱에 불 3장 이상 시 공격력 100% 증가'
         },
         skills: [
-            { name: '앱솔루트아머', type: 'sup', tier: 2, cost: 30, desc: '3턴간 받는 대미지 50% 감소', effects: [{ type: 'buff', id: 'guard', duration: 3 }] },
-            { name: '테라소드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '필드버프 아레나, 트윙클파티 발동', effects: [{ type: 'field_buff', id: 'arena' }, { type: 'field_buff', id: 'twinkle_party' }] },
+            { name: '앱솔루트아머', type: 'sup', tier: 2, cost: 30, desc: '필드버프 트윙클파티 부여, 3턴간 받는 대미지 50% 감소', effects: [{ type: 'field_buff', id: 'twinkle_party' }, { type: 'buff', id: 'guard', duration: 3 }] },
+            { name: '테라소드', type: 'phy', tier: 3, cost: 30, val: 2.0, desc: '필드버프 아레나 발동', effects: [{ type: 'field_buff', id: 'arena' }] },
             { name: '마그마이럽션', type: 'mag', tier: 3, cost: 30, val: 2.5, desc: '작열을 전부 소모하고, 소모한 작열 1스택당 배율 2.5 증가', effects: [{ type: 'consume_debuff_all', debuff: 'burn', multPerStack: 2.5 }] }
         ]
     },

--- a/card/data.js
+++ b/card/data.js
@@ -1235,7 +1235,7 @@ const BONUS_CARD_EXPANSION = [
         ]
     },
     {
-        id: 'succubus', name: '서큐버스', grade: 'rare', element: 'dark', role: 'debuffer', unlockSource: 'bonus',
+        id: 'succubus', name: '서큐버스', grade: 'rare', element: 'dark', role: 'debuffer', unlockSource: 'bonus', releaseDate: '2026-10-30',
         stats: { hp: 340, atk: 70, matk: 95, def: 55, mdef: 65 },
         trait: { type: 'death_debuff', debuff: 'silence', desc: '사망 시 적에게 침묵 부여' },
         skills: [
@@ -1245,7 +1245,7 @@ const BONUS_CARD_EXPANSION = [
         ]
     },
     {
-        id: 'trauma', name: '트라우마', grade: 'epic', element: 'dark', role: 'dealer', unlockSource: 'bonus',
+        id: 'trauma', name: '트라우마', grade: 'epic', element: 'dark', role: 'dealer', unlockSource: 'hidden',
         stats: { hp: 400, atk: 75, matk: 115, def: 65, mdef: 75 },
         trait: { type: 'leader_hp_cost_on_skill', ratio: 0.35, desc: '스킬 발동 시 대장 생명력 35% 소모' },
         skills: [
@@ -1255,7 +1255,7 @@ const BONUS_CARD_EXPANSION = [
         ]
     },
     {
-        id: 'great_detective', name: '명탐정', grade: 'epic', element: 'water', role: 'balancer', unlockSource: 'bonus',
+        id: 'great_detective', name: '명탐정', grade: 'epic', element: 'water', role: 'balancer', unlockSource: 'hidden',
         stats: { hp: 395, atk: 90, matk: 90, def: 65, mdef: 65 },
         trait: { type: 'deck_turn_modulo_force_crit', mod: 5, desc: '덱 전체가 5의 배수 턴에 반드시 치명타' },
         skills: [
@@ -1265,7 +1265,7 @@ const BONUS_CARD_EXPANSION = [
         ]
     },
     {
-        id: 'blue_moon_priest', name: '푸른달의사제', grade: 'legend', element: 'water', role: 'buffer', unlockSource: 'bonus',
+        id: 'blue_moon_priest', name: '푸른달의사제', grade: 'legend', element: 'water', role: 'buffer', unlockSource: 'bonus', releaseDate: '2026-10-30',
         stats: { hp: 500, atk: 90, matk: 120, def: 75, mdef: 80 },
         trait: { type: 'vanguard_moon_bless_every_3_turns', mod: 3, desc: '선봉 배치 시 3의 배수 턴마다 달의축복 부여' },
         skills: [

--- a/card/index.html
+++ b/card/index.html
@@ -838,10 +838,9 @@
 
         .lumi-chat-top {
             display: flex;
-            flex-direction: row;
-            align-items: center;
-            justify-content: space-between;
-            gap: 6px;
+            flex-direction: column;
+            align-items: stretch;
+            gap: 8px;
             border-bottom: 1px solid #444;
             padding-bottom: 6px;
         }
@@ -852,12 +851,12 @@
             font-size: 0.95rem;
             flex-shrink: 0;
             white-space: nowrap;
+            align-self: flex-start;
         }
 
         .lumi-chat-controls {
             display: flex;
-            flex: 1;
-            min-width: 0;
+            width: 100%;
             justify-content: flex-end;
             flex-wrap: wrap;
             gap: 4px;
@@ -3442,7 +3441,7 @@
                 }
                 msg += "<br><b>[새로 적용된 축복]</b><br>";
                 newBuffs.forEach(b => {
-                    msg += `[${b.name}] +${Math.round(b.multiplier * 100)}% 치명타/회피↑<br>`;
+                    msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}% 치명타/회피↑<br>`;
                 });
                 msg += `<br><b>(현재 총 활성화된 축복: ${this.state.chaosBuffs.length}개)</b>`;
 

--- a/card/logic.js
+++ b/card/logic.js
@@ -1602,6 +1602,13 @@ const SideEffects = {
                 }
             }
         },
+        'turn_modulo_debuffs': (ctx, eff) => {
+            if (!ctx.turn || !eff.mod || ctx.turn % eff.mod !== 0) return;
+            (eff.debuffs || []).forEach(id => {
+                const isStackable = id === 'burn' || id === 'divine';
+                SideEffects.handlers['debuff'](ctx, { id, stack: isStackable ? 1 : undefined });
+            });
+        },
         'consume_debuff_then_random_debuff': (ctx, eff) => {
             const debuff = eff.debuff;
             const count = eff.count || 1;
@@ -2100,7 +2107,11 @@ const Logic = {
 
         // 1. Critical: chance modifiers are additive percentage points.
         const effects = Array.isArray(skill.effects) ? skill.effects : [];
-        const alwaysCritical = effects.some(effect => effect.type === 'force_crit');
+        const deckTurnForceCrit = Array.isArray(activeTraits) &&
+            activeTraits.includes('deck_turn_modulo_force_crit') &&
+            Number.isFinite(turn) &&
+            turn % 5 === 0;
+        const alwaysCritical = effects.some(effect => effect.type === 'force_crit') || deckTurnForceCrit;
         const criticalBonus = effects
             .filter(effect => effect.type === 'force_crit_chance')
             .reduce((sum, effect) => sum + (Number(effect.val) || 0), 0);
@@ -2116,6 +2127,9 @@ const Logic = {
         }
         if (source.proto && sourceFieldBuffs.some(b => b.name === 'reaper_realm')) {
             critDmg += 0.4 * critBuffMult;
+        }
+        if (deckTurnForceCrit) {
+            logFn('[특성] 명탐정: 5의 배수 턴, 덱 전체 치명타!');
         }
 
         let val = (skill.type === 'phy') ? srcStats.atk : srcStats.matk;
@@ -2327,7 +2341,7 @@ const Logic = {
                         break;
                     case 'moon_bless': // 달: 마방 30% 관통 + 1배율
                         {
-                            let ignore = Math.floor(tgtStats.mdef * 0.3);
+                            let ignore = Math.floor(rawMdef * 0.3);
                             def = Math.max(0, def - ignore);
                             mult += 1.0;
                             logMsg.push(`달(관통 ${ignore}/1.0배)`);
@@ -2363,7 +2377,7 @@ const Logic = {
                         break;
                     case 'reaper_realm': // 사신강림: 마방 50% 관통 + 1배율
                         {
-                            let ignore = Math.floor(tgtStats.mdef * 0.5);
+                            let ignore = Math.floor(rawMdef * 0.5);
                             def = Math.max(0, def - ignore);
                             mult += 1.0;
                             logMsg.push(`사신(관통 ${ignore}/1.0배)`);
@@ -2498,6 +2512,7 @@ const Logic = {
             'party_all_stats_mana_cost',
             'alternate_party_atk_matk_turn',
             'field_kaleidoscope_each_turn',
+            'deck_turn_modulo_force_crit',
             'alternate_skill_type_mana',
             'opening_self_atk_party_mdef_down'
         ].includes(t.type)) {
@@ -2505,6 +2520,10 @@ const Logic = {
         }
 
         if (t.type === 'vanguard_delayed_mana_restore' && idx === 0) {
+            active = true;
+        }
+
+        if (t.type === 'vanguard_moon_bless_every_3_turns' && idx === 0) {
             active = true;
         }
 

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1501,7 +1501,7 @@
 
         let msg = "<b>혼돈의 축복 적용!</b><br>새로운 축복이 부여되었습니다.<br><br><b>[새로 적용된 축복]</b><br>";
         newBuffs.forEach(b => {
-            msg += `[${b.name}] +${Math.round(b.multiplier * 100)}% 치명타/회피↑<br>`;
+            msg += `[${b.name}] 올스탯 +${Math.round(b.multiplier * 100)}% 치명타/회피↑<br>`;
         });
         msg += `<br><b>(현재 총 활성화된 축복: ${this.state.chaosBuffs.length}개)</b><br>(전투 시작 시 해당 카드의 체력이 모두 회복됩니다.)`;
         setTimeout(() => {

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -203,8 +203,8 @@ function run() {
 
     const succubus = getCard('succubus');
     assert.deepStrictEqual(
-      [succubus.name, succubus.grade, succubus.element, succubus.role, succubus.unlockSource],
-      ['서큐버스', 'rare', 'dark', 'debuffer', 'bonus']
+      [succubus.name, succubus.grade, succubus.element, succubus.role, succubus.unlockSource, succubus.releaseDate],
+      ['서큐버스', 'rare', 'dark', 'debuffer', 'bonus', '2026-10-30']
     );
     assert.deepStrictEqual(
       [succubus.stats.hp, succubus.stats.atk, succubus.stats.matk, succubus.stats.def, succubus.stats.mdef],
@@ -224,8 +224,8 @@ function run() {
 
     const trauma = getCard('trauma');
     assert.deepStrictEqual(
-      [trauma.name, trauma.grade, trauma.element, trauma.role, trauma.unlockSource],
-      ['트라우마', 'epic', 'dark', 'dealer', 'bonus']
+      [trauma.name, trauma.grade, trauma.element, trauma.role, trauma.unlockSource, trauma.releaseDate || null],
+      ['트라우마', 'epic', 'dark', 'dealer', 'hidden', null]
     );
     assert.deepStrictEqual(
       [trauma.stats.hp, trauma.stats.atk, trauma.stats.matk, trauma.stats.def, trauma.stats.mdef],
@@ -246,8 +246,8 @@ function run() {
 
     const greatDetective = getCard('great_detective');
     assert.deepStrictEqual(
-      [greatDetective.name, greatDetective.grade, greatDetective.element, greatDetective.role, greatDetective.unlockSource],
-      ['명탐정', 'epic', 'water', 'balancer', 'bonus']
+      [greatDetective.name, greatDetective.grade, greatDetective.element, greatDetective.role, greatDetective.unlockSource, greatDetective.releaseDate || null],
+      ['명탐정', 'epic', 'water', 'balancer', 'hidden', null]
     );
     assert.deepStrictEqual(
       [greatDetective.stats.hp, greatDetective.stats.atk, greatDetective.stats.matk, greatDetective.stats.def, greatDetective.stats.mdef],
@@ -261,8 +261,8 @@ function run() {
 
     const blueMoonPriest = getCard('blue_moon_priest');
     assert.deepStrictEqual(
-      [blueMoonPriest.name, blueMoonPriest.grade, blueMoonPriest.element, blueMoonPriest.role, blueMoonPriest.unlockSource],
-      ['푸른달의사제', 'legend', 'water', 'buffer', 'bonus']
+      [blueMoonPriest.name, blueMoonPriest.grade, blueMoonPriest.element, blueMoonPriest.role, blueMoonPriest.unlockSource, blueMoonPriest.releaseDate],
+      ['푸른달의사제', 'legend', 'water', 'buffer', 'bonus', '2026-10-30']
     );
     assert.deepStrictEqual(
       [blueMoonPriest.stats.hp, blueMoonPriest.stats.atk, blueMoonPriest.stats.matk, blueMoonPriest.stats.def, blueMoonPriest.stats.mdef],
@@ -284,6 +284,7 @@ function run() {
       .map(card => card.id)
       .filter(id => datedWaveIds.includes(id))
       .sort();
+    const october30BonusIds = ['succubus', 'blue_moon_priest'];
     const expectedReleasedIds = ids => [...ids].sort();
     assert.deepStrictEqual(releasedWaveIds(new Date(2026, 6, 31, 12)), []);
     assert.deepStrictEqual(
@@ -319,6 +320,18 @@ function run() {
     assert.deepStrictEqual(
       releasedWaveIds(new Date(2026, 9, 15, 12)),
       expectedReleasedIds(datedWaveIds)
+    );
+    assert.strictEqual(
+      featureHost.getReleasedStandardBonusCards(new Date(2026, 9, 29, 12))
+        .some(card => october30BonusIds.includes(card.id)),
+      false
+    );
+    assert.deepStrictEqual(
+      featureHost.getReleasedStandardBonusCards(new Date(2026, 9, 30, 12))
+        .filter(card => october30BonusIds.includes(card.id))
+        .map(card => card.id)
+        .sort(),
+      october30BonusIds.slice().sort()
     );
     assert(featureHost.getHiddenBonusCards().some(card => card.id === 'astrologer'));
     assert(featureHost.getHiddenBonusCards().some(card => card.id === 'sun_moon_sword_maiden'));

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -195,6 +195,7 @@ function run() {
       JSON.stringify(absoluteArmor.effects),
       JSON.stringify([{ type: 'field_buff', id: 'twinkle_party' }, { type: 'buff', id: 'guard', duration: 3 }])
     );
+    assert.deepStrictEqual([absoluteArmor.tier, terraSword.tier], [3, 2]);
     assert.strictEqual(JSON.stringify(terraSword.effects), JSON.stringify([{ type: 'field_buff', id: 'arena' }]));
 
     assert.strictEqual(getCard('ash').trait.desc.startsWith('애쉬가 생존해 있을 경우,'), true);
@@ -254,7 +255,7 @@ function run() {
     );
     assert.deepStrictEqual([greatDetective.trait.type, greatDetective.trait.mod], ['deck_turn_modulo_force_crit', 5]);
     assert.strictEqual(
-      JSON.stringify(greatDetective.skills.find(skill => skill.name === '루시드프래시').effects),
+      JSON.stringify(greatDetective.skills.find(skill => skill.name === '루시드플래시').effects),
       JSON.stringify([{ type: 'turn_modulo_debuffs', mod: 5, debuffs: ['silence', 'curse', 'divine'] }])
     );
 
@@ -907,7 +908,7 @@ function run() {
     const detectiveSource = buildWaveUnit('great_detective', ['great_detective'], 0);
     detectiveSource.baseCrit = -100;
     const detectiveTarget = makeUnit({ def: 0, mdef: 0, buffs: {} });
-    const lucidFlash = detectiveSource.skills.find(skill => skill.name === '루시드프래시');
+    const lucidFlash = detectiveSource.skills.find(skill => skill.name === '루시드플래시');
     assert.strictEqual(
       Logic.calculateDamage(detectiveSource, detectiveTarget, lucidFlash, [], ['deck_turn_modulo_force_crit'], quiet, 'default', [], 4, []).isCrit,
       false

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -30,7 +30,12 @@ function run() {
   vm.createContext(sandbox);
 
   const cardRoot = path.join(process.cwd(), 'card');
-  assert.strictEqual(fs.readFileSync(path.join(cardRoot, 'index.html'), 'utf8').includes('#448af f'), false);
+  const indexHtml = fs.readFileSync(path.join(cardRoot, 'index.html'), 'utf8');
+  const rpgFeaturesSource = fs.readFileSync(path.join(cardRoot, 'rpg_features.js'), 'utf8');
+  assert.strictEqual(indexHtml.includes('#448af f'), false);
+  assert(indexHtml.includes('올스탯 +${Math.round(b.multiplier * 100)}%'));
+  assert(rpgFeaturesSource.includes('올스탯 +${Math.round(b.multiplier * 100)}%'));
+  assert(/\.lumi-chat-top\s*\{[^}]*flex-direction:\s*column;/s.test(indexHtml));
   ['data.js', 'logic.js', 'battle_runtime.js', 'rpg_features.js'].forEach(fileName => {
     const filePath = path.join(cardRoot, fileName);
     vm.runInContext(fs.readFileSync(filePath, 'utf8'), sandbox, { filename: filePath });
@@ -68,7 +73,7 @@ function run() {
       ['comet_tracker', '혜성추적자', 'rare', 'fire', 'balancer', '2026-10-01', [345, 65, 100, 55, 60]],
       ['prophet', '예언자', 'legend', 'water', 'buffer', '2026-10-01', [500, 90, 110, 75, 85]],
       ['fireworks_girl', '폭죽소녀', 'epic', 'fire', 'dealer', '2026-10-15', [390, 100, 80, 55, 55]],
-      ['astrologer', '점성술사', 'epic', 'water', 'dealer', null, [390, 90, 95, 60, 65]],
+      ['astrologer', '점성술사', 'epic', 'water', 'buffer', null, [390, 90, 85, 60, 70]],
       ['sun_moon_sword_maiden', '일월검희', 'legend', 'light', 'dealer', null, [500, 130, 110, 65, 70]]
     ];
     const bonusWaveIds = bonusWaveExpectations.map(entry => entry[0]);
@@ -176,8 +181,97 @@ function run() {
       ],
       ['phy', 3, 30, 1.5, '[1,2,3]', 'burn', 2]
     );
-    assert.strictEqual(getCard('paladin').skills.length, 4);
+    assert.strictEqual(getCard('paladin').skills.length, 3);
     assert.strictEqual(getCard('victoria').skills.length, 3);
+
+    const auroraReflection = getCard('aurora').skills.find(skill => skill.name === '리플렉션');
+    assert.strictEqual(auroraReflection.effects[0].id, 'silence');
+    assert.strictEqual(auroraReflection.desc.includes('침묵'), true);
+
+    const transAres = getCard('trans_ares');
+    const absoluteArmor = transAres.skills.find(skill => skill.name === '앱솔루트아머');
+    const terraSword = transAres.skills.find(skill => skill.name === '테라소드');
+    assert.strictEqual(
+      JSON.stringify(absoluteArmor.effects),
+      JSON.stringify([{ type: 'field_buff', id: 'twinkle_party' }, { type: 'buff', id: 'guard', duration: 3 }])
+    );
+    assert.strictEqual(JSON.stringify(terraSword.effects), JSON.stringify([{ type: 'field_buff', id: 'arena' }]));
+
+    assert.strictEqual(getCard('ash').trait.desc.startsWith('애쉬가 생존해 있을 경우,'), true);
+    assert.strictEqual(getCard('jasmine_christmas').trait.desc.startsWith('자스민이 생존해 있을 경우,'), true);
+
+    const succubus = getCard('succubus');
+    assert.deepStrictEqual(
+      [succubus.name, succubus.grade, succubus.element, succubus.role, succubus.unlockSource],
+      ['서큐버스', 'rare', 'dark', 'debuffer', 'bonus']
+    );
+    assert.deepStrictEqual(
+      [succubus.stats.hp, succubus.stats.atk, succubus.stats.matk, succubus.stats.def, succubus.stats.mdef],
+      [340, 70, 95, 55, 65]
+    );
+    assert.strictEqual(succubus.trait.type, 'death_debuff');
+    assert.strictEqual(succubus.trait.debuff, 'silence');
+    assert.strictEqual(
+      JSON.stringify(succubus.skills.find(skill => skill.name === '다크판타지').effects),
+      JSON.stringify([
+        { type: 'consume_debuff_fixed', debuff: 'darkness', count: 1, mult: 1.0, customLog: '암흑 1스택 소모!' },
+        { type: 'debuff', id: 'weak' },
+        { type: 'debuff', id: 'corrosion' },
+        { type: 'debuff', id: 'curse' }
+      ])
+    );
+
+    const trauma = getCard('trauma');
+    assert.deepStrictEqual(
+      [trauma.name, trauma.grade, trauma.element, trauma.role, trauma.unlockSource],
+      ['트라우마', 'epic', 'dark', 'dealer', 'bonus']
+    );
+    assert.deepStrictEqual(
+      [trauma.stats.hp, trauma.stats.atk, trauma.stats.matk, trauma.stats.def, trauma.stats.mdef],
+      [400, 75, 115, 65, 75]
+    );
+    assert.deepStrictEqual(
+      [trauma.trait.type, trauma.trait.ratio],
+      ['leader_hp_cost_on_skill', 0.35]
+    );
+    assert.strictEqual(
+      JSON.stringify(trauma.skills.find(skill => skill.name === '스티그마').effects),
+      JSON.stringify([{ type: 'debuff', id: 'curse' }, { type: 'debuff', id: 'silence' }, { type: 'debuff', id: 'darkness' }])
+    );
+    assert.strictEqual(
+      JSON.stringify(trauma.skills.find(skill => skill.name === '마인드브레이커').effects),
+      JSON.stringify([{ type: 'delayed_attack', turns: 3 }])
+    );
+
+    const greatDetective = getCard('great_detective');
+    assert.deepStrictEqual(
+      [greatDetective.name, greatDetective.grade, greatDetective.element, greatDetective.role, greatDetective.unlockSource],
+      ['명탐정', 'epic', 'water', 'balancer', 'bonus']
+    );
+    assert.deepStrictEqual(
+      [greatDetective.stats.hp, greatDetective.stats.atk, greatDetective.stats.matk, greatDetective.stats.def, greatDetective.stats.mdef],
+      [395, 90, 90, 65, 65]
+    );
+    assert.deepStrictEqual([greatDetective.trait.type, greatDetective.trait.mod], ['deck_turn_modulo_force_crit', 5]);
+    assert.strictEqual(
+      JSON.stringify(greatDetective.skills.find(skill => skill.name === '루시드프래시').effects),
+      JSON.stringify([{ type: 'turn_modulo_debuffs', mod: 5, debuffs: ['silence', 'curse', 'divine'] }])
+    );
+
+    const blueMoonPriest = getCard('blue_moon_priest');
+    assert.deepStrictEqual(
+      [blueMoonPriest.name, blueMoonPriest.grade, blueMoonPriest.element, blueMoonPriest.role, blueMoonPriest.unlockSource],
+      ['푸른달의사제', 'legend', 'water', 'buffer', 'bonus']
+    );
+    assert.deepStrictEqual(
+      [blueMoonPriest.stats.hp, blueMoonPriest.stats.atk, blueMoonPriest.stats.matk, blueMoonPriest.stats.def, blueMoonPriest.stats.mdef],
+      [500, 90, 120, 75, 80]
+    );
+    assert.deepStrictEqual([blueMoonPriest.trait.type, blueMoonPriest.trait.mod], ['vanguard_moon_bless_every_3_turns', 3]);
+    assert.strictEqual(
+      JSON.stringify(blueMoonPriest.skills.find(skill => skill.name === '창조의기도').effects),
+      JSON.stringify([{ type: 'delayed_attack_field', turns: 3, field: 'sanctuary' }, { type: 'debuff', id: 'divine', stack: 1 }])
+    );
 
     const featureHost = {
       global: { unlocked_special_cards: [] },
@@ -791,6 +885,191 @@ function run() {
       renderBattleView: quiet,
       renderBattleControls: quiet
     });
+
+    // Ash and Christmas Jasmine retaliate only while their own card is alive.
+    const deadAsh = buildWaveUnit('ash', ['ash'], 0);
+    const ashKiller = makeUnit({ hp: 5000, maxHp: 5000, buffs: {} });
+    const ashLinkedRpg = makeRpg(deadAsh, ['ash']);
+    deadAsh.isDead = true;
+    ashLinkedRpg.battle.players = [deadAsh];
+    BattleRuntime.handleLinkedDeathTraits(ashLinkedRpg, deadAsh, ashKiller);
+    assert.strictEqual(ashKiller.hp, 5000);
+
+    const deadChristmasJasmine = buildWaveUnit('jasmine_christmas', ['jasmine_christmas'], 0);
+    const jasmineKiller = makeUnit({ hp: 5000, maxHp: 5000, buffs: {} });
+    const jasmineLinkedRpg = makeRpg(deadChristmasJasmine, ['jasmine_christmas']);
+    deadChristmasJasmine.isDead = true;
+    jasmineLinkedRpg.battle.players = [deadChristmasJasmine];
+    BattleRuntime.handleLinkedDeathTraits(jasmineLinkedRpg, deadChristmasJasmine, jasmineKiller);
+    assert.strictEqual(jasmineKiller.hp, 5000);
+
+    // Great Detective applies its deck-wide fifth-turn critical and conditional debuffs.
+    const detectiveSource = buildWaveUnit('great_detective', ['great_detective'], 0);
+    detectiveSource.baseCrit = -100;
+    const detectiveTarget = makeUnit({ def: 0, mdef: 0, buffs: {} });
+    const lucidFlash = detectiveSource.skills.find(skill => skill.name === '루시드프래시');
+    assert.strictEqual(
+      Logic.calculateDamage(detectiveSource, detectiveTarget, lucidFlash, [], ['deck_turn_modulo_force_crit'], quiet, 'default', [], 4, []).isCrit,
+      false
+    );
+    assert.strictEqual(
+      Logic.calculateDamage(detectiveSource, detectiveTarget, lucidFlash, [], ['deck_turn_modulo_force_crit'], quiet, 'default', [], 5, []).isCrit,
+      true
+    );
+    const detectiveRpg = makeRpg(detectiveSource, ['great_detective']);
+    detectiveRpg.battle.turn = 5;
+    BattleRuntime.applySkillEffects(detectiveRpg, detectiveSource, detectiveRpg.battle.enemy, lucidFlash);
+    assert.deepStrictEqual(
+      [detectiveRpg.battle.enemy.buffs.silence, detectiveRpg.battle.enemy.buffs.curse, detectiveRpg.battle.enemy.buffs.divine],
+      [1, 1, 1]
+    );
+    const finalAnswer = detectiveSource.skills.find(skill => skill.name === '파이널앤서');
+    const finalAnswerTurnFour = Logic.calculateDamage(
+      detectiveSource, detectiveTarget, finalAnswer, [], [], quiet, 'default', [], 4, []
+    ).dmg;
+    const finalAnswerTurnFive = Logic.calculateDamage(
+      detectiveSource, detectiveTarget, finalAnswer, [], [], quiet, 'default', [], 5, []
+    ).dmg;
+    assert.strictEqual(finalAnswerTurnFive, finalAnswerTurnFour * 2);
+
+    // The Blue Moon Priest vanguard trait remains active after its owner dies.
+    assert.strictEqual(
+      Logic.calculateInitialStats(getCard('blue_moon_priest'), ['blue_moon_priest'], GameUtils.getAllCards(), 0).activeTrait,
+      'vanguard_moon_bless_every_3_turns'
+    );
+    assert.strictEqual(
+      Logic.calculateInitialStats(getCard('blue_moon_priest'), ['blue_moon_priest'], GameUtils.getAllCards(), 1).activeTrait,
+      null
+    );
+    const fallenMoonPriest = buildWaveUnit('blue_moon_priest', ['blue_moon_priest', 'marshmallow'], 0);
+    const moonFallback = buildWaveUnit('marshmallow', ['blue_moon_priest', 'marshmallow'], 1);
+    const moonTraitRpg = makeRpg(fallenMoonPriest, ['blue_moon_priest', 'marshmallow']);
+    fallenMoonPriest.isDead = true;
+    moonTraitRpg.battle.players = [fallenMoonPriest, moonFallback];
+    moonTraitRpg.battle.activeTraits = ['vanguard_moon_bless_every_3_turns'];
+    moonTraitRpg.battle.turn = 3;
+    moonTraitRpg.battle.isNewTurn = true;
+    BattleRuntime.TurnManager.startPlayerTurn(moonTraitRpg);
+    assert.strictEqual(moonTraitRpg.battle.fieldBuffs.some(buff => buff.name === 'moon_bless'), true);
+
+    const originalEndPlayerTurnForNewCards = BattleRuntime.TurnManager.endPlayerTurn;
+    BattleRuntime.TurnManager.endPlayerTurn = quiet;
+
+    // Creation Prayer holds both its field and debuff effects until the delayed hit resolves.
+    const creationCaster = buildWaveUnit('blue_moon_priest', ['blue_moon_priest'], 0);
+    const creationRpg = makeRpg(creationCaster, ['blue_moon_priest']);
+    creationRpg.battle.enemy = makeUnit({ id: 'creation-target', hp: 5000, maxHp: 5000, buffs: {} });
+    const creationPrayer = creationCaster.skills.find(skill => skill.name === '창조의기도');
+    BattleRuntime.executeSkill(creationRpg, creationCaster, creationRpg.battle.enemy, creationPrayer);
+    assert.strictEqual(creationRpg.battle.fieldBuffs.some(buff => buff.name === 'sanctuary'), false);
+    assert.strictEqual(creationRpg.battle.enemy.buffs.divine, undefined);
+    const resolvedCreationPrayer = creationRpg.battle.delayedEffects[0].skill;
+    BattleRuntime.executeSkill(creationRpg, creationCaster, creationRpg.battle.enemy, resolvedCreationPrayer, true);
+    assert.strictEqual(creationRpg.battle.fieldBuffs.some(buff => buff.name === 'sanctuary'), true);
+    assert.strictEqual(creationRpg.battle.enemy.buffs.divine, 1);
+
+    // Trauma drains max-HP-based leader health when a skill actually resolves and permits death traits.
+    const traumaCaster = buildWaveUnit('trauma', ['trauma', null, 'succubus'], 0);
+    const traumaLeader = buildWaveUnit('succubus', ['trauma', null, 'succubus'], 2);
+    const traumaRpg = makeRpg(traumaCaster, ['trauma', null, 'succubus']);
+    traumaRpg.battle.players = [traumaCaster, null, traumaLeader];
+    traumaRpg.battle.enemy = makeUnit({ id: 'trauma-target', hp: 5000, maxHp: 5000, buffs: {} });
+    const traumaTestSkill = { name: '검증용 스킬', type: 'sup', cost: 0, effects: [] };
+    const traumaLeaderHp = [];
+    for (let use = 0; use < 3; use++) {
+      traumaRpg.battle.phase = 'player-ready';
+      assert.strictEqual(BattleRuntime.executeSkill(traumaRpg, traumaCaster, traumaRpg.battle.enemy, traumaTestSkill), true);
+      traumaLeaderHp.push(traumaLeader.hp);
+    }
+    assert.deepStrictEqual(traumaLeaderHp, [221, 102, 0]);
+    assert.strictEqual(traumaLeader.isDead, true);
+    assert.strictEqual(traumaRpg.battle.enemy.buffs.silence, 1);
+
+    const delayedTraumaCaster = buildWaveUnit('trauma', ['trauma', null, 'succubus'], 0);
+    const delayedTraumaLeader = buildWaveUnit('succubus', ['trauma', null, 'succubus'], 2);
+    const delayedTraumaRpg = makeRpg(delayedTraumaCaster, ['trauma', null, 'succubus']);
+    delayedTraumaRpg.battle.players = [delayedTraumaCaster, null, delayedTraumaLeader];
+    delayedTraumaRpg.battle.enemy = makeUnit({ id: 'delayed-trauma-target', hp: 5000, maxHp: 5000, buffs: {} });
+    const mindBreaker = delayedTraumaCaster.skills.find(skill => skill.name === '마인드브레이커');
+    BattleRuntime.executeSkill(delayedTraumaRpg, delayedTraumaCaster, delayedTraumaRpg.battle.enemy, mindBreaker);
+    assert.strictEqual(delayedTraumaLeader.hp, 340);
+    BattleRuntime.executeSkill(
+      delayedTraumaRpg,
+      delayedTraumaCaster,
+      delayedTraumaRpg.battle.enemy,
+      delayedTraumaRpg.battle.delayedEffects[0].skill,
+      true
+    );
+    assert.strictEqual(delayedTraumaLeader.hp, 221);
+
+    // Behemoth's stun and Death Roulette both wait for a delayed attack to trigger.
+    const delayedBehemoth = buildWaveUnit('behemoth', ['behemoth'], 0);
+    delayedBehemoth.baseCrit = -100;
+    const delayedBehemothRpg = makeRpg(delayedBehemoth, ['behemoth']);
+    delayedBehemothRpg.battle.enemy = makeUnit({ id: 'behemoth-target', hp: 1, maxHp: 1, buffs: {} });
+    delayedBehemothRpg.hasArtifact = id => id === 'death_roulette';
+    const earthquake = delayedBehemoth.skills.find(skill => skill.name === '어스퀘이크');
+    const originalDelayedTimingRandom = Math.random;
+    Math.random = () => 0;
+    BattleRuntime.executeSkill(delayedBehemothRpg, delayedBehemoth, delayedBehemothRpg.battle.enemy, earthquake);
+    assert.strictEqual(delayedBehemothRpg.battle.enemy.buffs.stun, undefined);
+    assert.strictEqual(delayedBehemoth.isDead, false);
+    BattleRuntime.executeSkill(
+      delayedBehemothRpg,
+      delayedBehemoth,
+      delayedBehemothRpg.battle.enemy,
+      delayedBehemothRpg.battle.delayedEffects[0].skill,
+      true
+    );
+    Math.random = originalDelayedTimingRandom;
+    assert.strictEqual(delayedBehemothRpg.battle.enemy.buffs.stun, 1);
+    assert.strictEqual(delayedBehemothRpg.battle.enemy.hp <= 0, true);
+    assert.strictEqual(delayedBehemoth.isDead, true);
+
+    const multiDelayedBehemoth = buildWaveUnit('behemoth', ['behemoth'], 0);
+    multiDelayedBehemoth.baseCrit = -100;
+    const multiDelayedRpg = makeRpg(multiDelayedBehemoth, ['behemoth']);
+    multiDelayedRpg.battle.enemy = makeUnit({ id: 'multi-behemoth-target', hp: 10000, maxHp: 10000, buffs: {} });
+    multiDelayedRpg.hasArtifact = id => id === 'death_roulette';
+    const multiDelayedSkill = {
+      name: '검증용 다단 지연', type: 'mag', cost: 0, val: 1.0,
+      effects: [{ type: 'multi_delayed_attack', turns: [1, 2] }]
+    };
+    const originalMultiDelayedTimingRandom = Math.random;
+    Math.random = () => 0;
+    BattleRuntime.executeSkill(multiDelayedRpg, multiDelayedBehemoth, multiDelayedRpg.battle.enemy, multiDelayedSkill);
+    assert.strictEqual(multiDelayedRpg.battle.delayedEffects.length, 2);
+    assert.strictEqual(multiDelayedRpg.battle.enemy.buffs.stun, undefined);
+    assert.strictEqual(multiDelayedBehemoth.isDead, false);
+    BattleRuntime.executeSkill(
+      multiDelayedRpg,
+      multiDelayedBehemoth,
+      multiDelayedRpg.battle.enemy,
+      multiDelayedRpg.battle.delayedEffects[0].skill,
+      true
+    );
+    Math.random = originalMultiDelayedTimingRandom;
+    assert.strictEqual(multiDelayedRpg.battle.enemy.buffs.stun, 1);
+    assert.strictEqual(multiDelayedBehemoth.isDead, true);
+
+    BattleRuntime.TurnManager.endPlayerTurn = originalEndPlayerTurnForNewCards;
+
+    // Dream Form penetration is additive with curse: 20% curse + 30% moon + 50% reaper fully removes 100 MDEF.
+    const dreamAdditiveSource = makeUnit({ matk: 100, baseCrit: -100, proto: getCard('trans_lumi'), buffs: {} });
+    const dreamAdditiveTarget = makeUnit({ mdef: 100, buffs: { curse: 1 }, baseCrit: -100 });
+    const dreamAdditiveResult = Logic.calculateDamage(
+      dreamAdditiveSource,
+      dreamAdditiveTarget,
+      getCard('trans_lumi').skills.find(skill => skill.name === '꿈의형태'),
+      [{ name: 'moon_bless' }, { name: 'reaper_realm' }],
+      [],
+      quiet,
+      'default',
+      [],
+      1,
+      []
+    );
+    assert.strictEqual(dreamAdditiveResult.dmg, 520);
 
     // Transcendence Lumi restores 20 MP on normal attacks, capped at max MP.
     const dreamLumi = makeUnit({


### PR DESCRIPTION
## 변경 사항
- 혼돈의 축복 결과를 `올스탯 +N%`으로 표시하고, 루미 질문 모달의 제목과 버튼을 두 줄로 배치했습니다.
- 팔라딘 가드를 제거하고, 아레스·아우로라·점성술사·애쉬·크리스마스 자스민·꿈의형태를 요청 사항에 맞게 조정했습니다.
- 지연 스킬은 예약 시점이 아니라 실제 발동 시점에 베히모스 기절과 데스룰렛 사망 판정을 수행하도록 수정했습니다.
- 서큐버스, 트라우마, 명탐정, 푸른달의사제를 추가했습니다.

## 동작 및 원인
- 기존에는 지연 스킬을 예약할 때 타이밍 의존 효과가 먼저 처리될 수 있었습니다. 실제 해소 경로로 옮겨 다단 지연에도 중복 없이 적용되도록 했습니다.
- 꿈의형태의 달/사신 마법방어 관통은 이미 감소된 방어력 기준으로 다시 계산되어 곱연산처럼 동작하던 문제를 기본 마법방어력 기준의 합연산으로 변경했습니다.

## 검증
- `npm run verify`
