### PR TITLE
Fix Chaos Shuffle button text and layout in main lobby

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1078,14 +1078,14 @@
                 <button class="menu-btn" onclick="RPG.startDraft()" style="border-color:#00e676; color:#00e676;">덱 빌딩
                     (드래프트)</button>
             </div>
-            <div id="menu-chaos-area" style="display:none; gap:5px; margin-bottom:10px;">
+            <div id="menu-chaos-area" style="display:none; flex-direction:column; gap:5px; margin-bottom:10px;">
                 <button id="btn-menu-artifact-check" class="menu-btn" onclick="RPG.openArtifactCheck()"
-                    style="display:none; flex:1; border-color:#ffd700; color:#ffd700;">
+                    style="display:none; border-color:#ffd700; color:#ffd700;">
                     아티팩트 확인
                 </button>
                 <button class="menu-btn" onclick="RPG.reshuffleChaosPool()"
-                    style="flex:1; border-color:#ff5252; color:#ff5252;">
-                    카오스 셔플 (티켓 1장)
+                    style="border-color:#ff5252; color:#ff5252;">
+                    카오스 셔플
                 </button>
             </div>
             <button class="menu-btn" onclick="RPG.openDeck()">덱 구성</button>


### PR DESCRIPTION
Updates the Chaos Shuffle menu area in `card/index.html` to remove the "(티켓 1장)" suffix from the button text and switches the flex container to `flex-direction: column` (and removes `flex: 1` from the artifact button) to match the standard 1-row layout of other menu buttons.

---
*PR created automatically by Jules for task [18239063143170382660](https://jules.google.com/task/18239063143170382660) started by @romarin0325-cell*