### PR TITLE
Restore horizontal artifact chaos lobby actions

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -1078,13 +1078,13 @@
                 <button class="menu-btn" onclick="RPG.startDraft()" style="border-color:#00e676; color:#00e676;">덱 빌딩
                     (드래프트)</button>
             </div>
-            <div id="menu-chaos-area" style="display:none; flex-direction:column; gap:5px; margin-bottom:10px;">
+            <div id="menu-chaos-area" style="display:none; gap:5px; margin-bottom:10px;">
                 <button id="btn-menu-artifact-check" class="menu-btn" onclick="RPG.openArtifactCheck()"
-                    style="display:none; border-color:#ffd700; color:#ffd700;">
+                    style="display:none; flex:1; border-color:#ffd700; color:#ffd700;">
                     아티팩트 확인
                 </button>
                 <button class="menu-btn" onclick="RPG.reshuffleChaosPool()"
-                    style="border-color:#ff5252; color:#ff5252;">
+                    style="flex:1; border-color:#ff5252; color:#ff5252;">
                     카오스 셔플
                 </button>
             </div>

--- a/scripts/verify_card_mobile.js
+++ b/scripts/verify_card_mobile.js
@@ -210,6 +210,36 @@ async function run() {
         assert.strictEqual(landscapeState.lastButtonVisible, true);
 
         await normal.page.setViewportSize({ width: 390, height: 844 });
+        const artifactChaosMenuLayout = await normal.page.evaluate(() => {
+            RPG.initNewGame('artifact_chaos');
+            RPG.toMenu();
+
+            const area = document.getElementById('menu-chaos-area');
+            const artifactButton = document.getElementById('btn-menu-artifact-check');
+            const shuffleButton = area.querySelector('button[onclick="RPG.reshuffleChaosPool()"]');
+            const areaStyle = getComputedStyle(area);
+            const artifactRect = artifactButton.getBoundingClientRect();
+            const shuffleRect = shuffleButton.getBoundingClientRect();
+
+            return {
+                areaDisplay: areaStyle.display,
+                flexDirection: areaStyle.flexDirection,
+                artifactVisible: getComputedStyle(artifactButton).display !== 'none',
+                artifactLeft: artifactRect.left,
+                artifactRight: artifactRect.right,
+                artifactWidth: artifactRect.width,
+                shuffleLeft: shuffleRect.left,
+                shuffleWidth: shuffleRect.width
+            };
+        });
+        assert.strictEqual(artifactChaosMenuLayout.areaDisplay, 'flex');
+        assert.strictEqual(artifactChaosMenuLayout.flexDirection, 'row');
+        assert.strictEqual(artifactChaosMenuLayout.artifactVisible, true);
+        assert(artifactChaosMenuLayout.artifactRight <= artifactChaosMenuLayout.shuffleLeft);
+        assert(Math.abs(
+            artifactChaosMenuLayout.artifactWidth - artifactChaosMenuLayout.shuffleWidth
+        ) <= 1);
+
         const corruptSaveState = await normal.page.evaluate(() => {
             const raw = '{broken-json';
             RPG.toTitle();


### PR DESCRIPTION
## What changed

- Lay out `아티팩트 확인` on the left and `카오스 셔플` on the right in the Artifact Chaos lobby.
- Give both actions equal flex width to match the normal/challenge gacha row.
- Add a 390px mobile browser regression check for row direction, visibility, ordering, and equal widths.

## Why

The Chaos lobby container forced `flex-direction: column`, so its two primary actions appeared as two stacked rows instead of matching the established horizontal gacha action layout.

## Impact

Artifact Chaos players now see the two related lobby actions side by side with equal prominence, while other modes keep their existing behavior.

## Validation

- `npm run verify`
- In-app browser check at 390×844: both buttons share the same row and measure 184.5px each.