### PR TITLE
Increase Dream Corridor mission unlock rates

### DIFF
--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -294,12 +294,12 @@
 
 
     getSpecialMissionUnlockChance(stageNumber) {
-        if (stageNumber >= 36) return 0.35;
-        if (stageNumber >= 30) return 0.30;
-        if (stageNumber >= 24) return 0.25;
-        if (stageNumber >= 18) return 0.20;
-        if (stageNumber >= 12) return 0.15;
-        if (stageNumber >= 6) return 0.10;
+        if (stageNumber >= 36) return 0.40;
+        if (stageNumber >= 30) return 0.35;
+        if (stageNumber >= 24) return 0.30;
+        if (stageNumber >= 18) return 0.25;
+        if (stageNumber >= 12) return 0.20;
+        if (stageNumber >= 6) return 0.15;
         return 0;
     },
 

--- a/scripts/verify_card_special_flow.js
+++ b/scripts/verify_card_special_flow.js
@@ -71,6 +71,22 @@ async function run() {
 
     const originalRandom = Math.random;
     const season = RPG.getCurrentSpecialSeason();
+    [
+      [5, 0],
+      [6, 0.15],
+      [12, 0.20],
+      [18, 0.25],
+      [24, 0.30],
+      [30, 0.35],
+      [36, 0.40],
+      [42, 0.40]
+    ].forEach(([stage, expectedChance]) => {
+      assert(
+        RPG.getSpecialMissionUnlockChance(stage) === expectedChance,
+        'special_unlock_chance',
+        `stage ${stage}: ${RPG.getSpecialMissionUnlockChance(stage)}`
+      );
+    });
     Math.random = () => 0;
     const unlockMsg = RPG.tryUnlockSpecialMissionFromDreamCorridor(6);
     Math.random = originalRandom;


### PR DESCRIPTION
## What changed

- Raise the first Dream Corridor special-mission unlock chance at stage 6 from 10% to 15%.
- Continue increasing the chance by 5 percentage points per Creator God cycle: 20%, 25%, 30%, 35%, then 40% from stage 36 onward.
- Add browser-flow regression coverage for every probability boundary and the stage-6 unlock message.

## Why

The initial special-mission unlock chance was lower than the requested progression. Updating every threshold together preserves the existing six-stage cadence while shifting the full probability curve upward by five percentage points.

## Impact

Dream Corridor runs get a better chance to unlock the seasonal special mission, starting at 15% and capping at 40%.

## Validation

- `node scripts/verify_card_special_flow.js`
- `npm run verify`