### PR TITLE
Upgrade card Flash model to Gemini 3.7

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -67,7 +67,7 @@ const LECTURE_FORMAT = `모든 답변은 다음의 구성을 따릅니다:
    - [Special Direction]이 없으면 이 항목을 생략하십시오.
 8. **강의 마무리 멘트**`;
 
-const GEMINI_FLASH_MODEL_ID = 'gemini-3.6-flash';
+const GEMINI_FLASH_MODEL_ID = 'gemini-3.7-flash';
 const GEMINI_FLASH_LITE_MODEL_ID = 'gemini-3.5-flash-lite';
 const GEMINI_GENERATE_CONTENT_ROOT = 'https://generativelanguage.googleapis.com/v1beta/models';
 

--- a/card_remaster/api.js
+++ b/card_remaster/api.js
@@ -1,4 +1,4 @@
-const GEMINI_FLASH_MODEL_ID = 'gemini-3.6-flash';
+const GEMINI_FLASH_MODEL_ID = 'gemini-3.7-flash';
 const GEMINI_GENERATE_CONTENT_ROOT = 'https://generativelanguage.googleapis.com/v1beta/models';
 
 function getGeminiGenerateContentUrl(modelId) {

--- a/scripts/verify_gemini_api_models.js
+++ b/scripts/verify_gemini_api_models.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
-const FLASH_MODEL_ID = 'gemini-3.6-flash';
+const FLASH_MODEL_ID = 'gemini-3.7-flash';
 const FLASH_LITE_MODEL_ID = 'gemini-3.5-flash-lite';
 const LEGACY_MODEL_IDS = ['gemini-3-flash-preview', 'gemini-3.1-flash-lite'];
 


### PR DESCRIPTION
카드 게임 Flash 모델을 gemini-3.6-flash에서 gemini-3.7-flash로 올렸습니다.

- card/api.js, card_remaster/api.js의 GEMINI_FLASH_MODEL_ID 변경
- scripts/verify_gemini_api_models.js 기대값 동기화
- 
pm run verify 통과