### PR TITLE
Polish card music playlist and scope verify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,19 @@ Functional correctness of the browser app is more important than refactoring or 
 Before opening a PR or marking the task done, run:
 - npm run verify
 
+`npm run verify` inspects the current branch and working tree, then runs checks only for the games that changed.
+
+Current targets:
+- `card/`, `card_remaster/`: card lint, smoke, and browser checks
+- `idle_hero/`: idle smoke
+- `defense_hero_v2/`: Defense V2 lint, tests, local bundle, and browser checks
+
+Defense Hero V1 (`defense_hero/`) is unused. Do not run or restore its verification.
+
 ## Hard rules
 - Do not say the task is complete if verify fails.
 - Do not open a PR if verify fails.
+- Do not run unused game suites. Card-only changes must not wait on Defense V1 or V2.
 - Prefer the smallest diff that restores working behavior.
 - If UI behavior cannot be fully verified, state exactly what remains unverified.
 - For frontend tasks, use image inputs/output when helpful and compare against the requested behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Functional correctness of the browser app is more important than refactoring or 
 Before opening a PR or marking the task done, run:
 - npm run verify
 
-`npm run verify` inspects the current branch and working tree, then runs checks only for the games that changed.
+`npm run verify` inspects the current branch and working tree, then runs checks only for the games that changed. It prefers `origin/main` as the base and falls back to local `main` only when that remote ref is missing.
 
 Current targets:
 - `card/`, `card_remaster/`: card lint, smoke, and browser checks

--- a/card/AGENTS.override.md
+++ b/card/AGENTS.override.md
@@ -11,5 +11,7 @@ These rules apply to everything under `card/`.
 Run from repo root before completion:
 - npm run verify
 
+`npm run verify` only runs the card suite when `card/` or `card_remaster/` changed. Do not run Defense V1 or V2 for card-only work.
+
 ## Verification note
 If a change cannot be fully verified by `npm run verify`, explicitly list what is still unverified.

--- a/card/index.html
+++ b/card/index.html
@@ -1623,9 +1623,10 @@
             </div>
 
             <div class="music-option-row">
-                <label for="music-playback-rate">배속</label>
-                <button id="music-playback-rate" type="button" onclick="MusicPlayer.cyclePlaybackRate()"
-                    aria-label="재생 배속 변경">1.0×</button>
+                <button id="music-rate-1" type="button" class="music-rate-toggle" onclick="MusicPlayer.setPlaybackRate(1)"
+                    aria-pressed="true" aria-label="1배속">1×</button>
+                <button id="music-rate-125" type="button" class="music-rate-toggle" onclick="MusicPlayer.setPlaybackRate(1.25)"
+                    aria-pressed="false" aria-label="1.25배속">1.25×</button>
                 <button id="music-repeat-toggle" type="button" onclick="MusicPlayer.toggleRepeat()">전체 반복</button>
                 <button id="music-shuffle-toggle" type="button" onclick="MusicPlayer.toggleShuffle()" aria-pressed="false">셔플 OFF</button>
             </div>
@@ -1644,7 +1645,6 @@
                 </div>
             </section>
 
-            <p class="music-background-note">창을 닫아도 음악은 계속 재생됩니다. 모바일 잠금화면 제어는 브라우저 지원 범위에서 동작합니다.</p>
             <button type="button" class="menu-btn music-close-button" onclick="MusicPlayer.close()">닫기</button>
             <audio id="music-audio" preload="metadata"></audio>
         </div>

--- a/card/music_data.js
+++ b/card/music_data.js
@@ -18,13 +18,6 @@ window.CARD_MUSIC_TRACKS = Object.freeze([
         src: '他人役の予選落ち.mp3'
     }),
     Object.freeze({
-        id: 'スキの未払金.mp3',
-        title: 'スキの未払金',
-        artist: 'Card RPG',
-        album: 'Card RPG Music',
-        src: 'スキの未払金.mp3'
-    }),
-    Object.freeze({
         id: '月面町内会長.mp3',
         title: '月面町内会長',
         artist: 'Card RPG',

--- a/card/music_player.css
+++ b/card/music_player.css
@@ -1,4 +1,4 @@
-.music-player-panel {
+.modal-content.music-player-panel {
     width: min(420px, calc(100vw - 20px));
     height: auto;
     max-height: 88dvh;
@@ -6,50 +6,68 @@
     position: relative;
     box-sizing: border-box;
     align-items: stretch;
-    padding: 20px;
+    padding: 20px 18px 16px;
     text-align: center;
+    color: #f4f1ea;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background:
+        radial-gradient(120% 70% at 50% -18%, rgba(232, 200, 114, 0.14), transparent 48%),
+        linear-gradient(180deg, #12141b 0%, #090a0e 100%);
+    box-shadow:
+        0 24px 60px rgba(0, 0, 0, 0.45),
+        inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .music-player-kicker {
-    color: #81d4fa;
-    font-size: 0.66rem;
-    font-weight: 800;
-    letter-spacing: 0.18em;
+    color: rgba(232, 200, 114, 0.78);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
 }
 
 .music-player-disc {
-    width: 112px;
+    width: 104px;
     aspect-ratio: 1;
-    margin: 12px auto 8px;
+    margin: 14px auto 10px;
     display: grid;
     place-items: center;
-    border: 1px solid rgba(255, 215, 0, 0.55);
+    border: 1px solid rgba(232, 200, 114, 0.28);
     border-radius: 50%;
     background:
-        radial-gradient(circle, #ffd700 0 8%, #141722 9% 19%, transparent 20%),
-        repeating-radial-gradient(circle, #252b3e 0 3px, #151925 4px 7px);
-    box-shadow: 0 0 24px rgba(129, 212, 250, 0.12);
+        radial-gradient(circle, #e8c872 0 7%, #111318 8% 17%, transparent 18%),
+        repeating-radial-gradient(circle, rgba(255, 255, 255, 0.04) 0 2px, #141820 3px 6px);
+    box-shadow: 0 0 28px rgba(232, 200, 114, 0.08);
 }
 
 .music-player-disc span {
-    width: 38px;
-    height: 38px;
+    width: 36px;
+    height: 36px;
     display: grid;
     place-items: center;
     border-radius: 50%;
-    background: #1f1f1f;
-    color: #ffd700;
-    font-size: 1.2rem;
+    background: #0d0f14;
+    color: #e8c872;
+    font-size: 1.1rem;
 }
 
-.music-track-title { color: #f5f5f5; font-size: 1.05rem; }
-.music-track-meta { margin-top: 3px; color: #aaa; font-size: 0.76rem; }
+.music-track-title {
+    color: #f7f4ec;
+    font-size: 1.08rem;
+    letter-spacing: -0.02em;
+}
+
+.music-track-meta {
+    margin-top: 4px;
+    color: #8d93a0;
+    font-size: 0.74rem;
+}
 
 .music-status {
     min-height: 20px;
     margin: 10px 0 4px;
-    color: #81d4fa;
-    font-size: 0.75rem;
+    color: #cbb57a;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
 }
 
 .music-status.is-error { color: #ff8a80; }
@@ -73,15 +91,15 @@
     width: 100%;
     margin-inline: 0;
     box-sizing: border-box;
-    accent-color: #ffd700;
+    accent-color: #e8c872;
 }
 
 .music-time-row {
     display: flex;
     justify-content: space-between;
-    color: #aaa;
+    color: #7f8694;
     font-variant-numeric: tabular-nums;
-    font-size: 0.7rem;
+    font-size: 0.68rem;
 }
 
 .music-control-row {
@@ -95,27 +113,34 @@
 .music-option-row button {
     min-width: 0;
     min-height: 42px;
-    border: 1px solid #555;
-    border-radius: 6px;
-    background: #292929;
-    color: #f5f5f5;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.03);
+    color: #f4f1ea;
     cursor: pointer;
 }
 
 .music-control-row .music-play-toggle {
-    border-color: rgba(255, 215, 0, 0.7);
-    background: linear-gradient(135deg, #745522, #3a2a18);
-    color: #fff5d8;
+    border-color: rgba(232, 200, 114, 0.42);
+    background: linear-gradient(180deg, #3a311c, #211b10);
+    color: #f7e7b4;
     font-size: 1.05rem;
 }
 
 .music-option-row {
     display: grid;
-    grid-template-columns: auto minmax(76px, 0.8fr) minmax(90px, 1fr) minmax(90px, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     align-items: center;
     gap: 7px;
-    color: #aaa;
+    color: #8d93a0;
     font-size: 0.75rem;
+}
+
+.music-rate-toggle.is-active,
+.music-playlist-mode-row button.is-active {
+    border-color: rgba(232, 200, 114, 0.46);
+    background: rgba(232, 200, 114, 0.12);
+    color: #f3e2ad;
 }
 
 .music-track-library {
@@ -124,9 +149,12 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    border: 1px solid #444;
-    border-radius: 8px;
-    background: #191919;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 16px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 22%),
+        #0c0e13;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
     text-align: left;
 }
 
@@ -135,15 +163,16 @@
     align-items: center;
     justify-content: space-between;
     gap: 8px;
-    padding: 7px 9px;
-    border-bottom: 1px solid #3b3b3b;
-    color: #ddd;
-    font-size: 0.76rem;
+    padding: 10px 12px 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    color: #ece7db;
+    font-size: 0.74rem;
+    letter-spacing: 0.04em;
 }
 
 #music-track-count {
-    color: #81d4fa;
-    font-size: 0.68rem;
+    color: #cbb57a;
+    font-size: 0.66rem;
 }
 
 .music-track-list {
@@ -160,11 +189,15 @@
     display: grid;
     grid-template-columns: 46px minmax(0, 1fr);
     align-items: stretch;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
 .music-track-row:last-child { border-bottom: 0; }
-.music-track-row.is-current { background: rgba(129, 212, 250, 0.1); }
+
+.music-track-row.is-current {
+    background: linear-gradient(90deg, rgba(232, 200, 114, 0.16), rgba(232, 200, 114, 0.03) 46%, transparent);
+    box-shadow: inset 2px 0 0 #e8c872;
+}
 
 .music-favorite-toggle,
 .music-track-select,
@@ -178,20 +211,32 @@
 }
 
 .music-favorite-toggle {
-    border-right: 1px solid #333;
-    color: #ffd54f;
-    font-size: 1.15rem;
+    border-right: 1px solid rgba(255, 255, 255, 0.04);
+    color: rgba(232, 200, 114, 0.86);
+    font-size: 1.08rem;
 }
 
 .music-track-select {
-    padding: 6px 9px;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: center;
-    gap: 2px;
+    padding: 6px 10px;
+    display: grid;
+    grid-template-columns: 1.6em minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    column-gap: 8px;
+    align-items: center;
     overflow: hidden;
     text-align: left;
+}
+
+.music-track-row-index {
+    grid-row: 1 / span 2;
+    color: #6d7380;
+    font-size: 0.64rem;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.04em;
+}
+
+.music-track-row.is-current .music-track-row-index {
+    color: #e8c872;
 }
 
 .music-track-row-title,
@@ -202,13 +247,20 @@
     white-space: nowrap;
 }
 
-.music-track-row-title { font-size: 0.76rem; }
-.music-track-row-artist { color: #999; font-size: 0.65rem; }
+.music-track-row-title {
+    font-size: 0.78rem;
+    color: #f4f1ea;
+}
+
+.music-track-row-artist {
+    color: #7d8491;
+    font-size: 0.64rem;
+}
 
 .music-track-empty {
     margin: 0;
     padding: 15px 10px;
-    color: #888;
+    color: #7d8491;
     font-size: 0.72rem;
     text-align: center;
 }
@@ -217,21 +269,15 @@
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 6px;
-    padding: 7px;
-    border-top: 1px solid #3b3b3b;
+    padding: 8px;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
 }
 
 .music-playlist-mode-row button {
-    border: 1px solid #4a4a4a;
-    border-radius: 6px;
-    background: #292929;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.03);
     font-size: 0.72rem;
-}
-
-.music-playlist-mode-row button.is-active {
-    border-color: #81d4fa;
-    background: #24323a;
-    color: #b3e5fc;
 }
 
 .music-playlist-mode-row button:disabled,
@@ -241,18 +287,17 @@
     cursor: not-allowed;
 }
 
-.music-background-note {
-    margin: 14px 0 10px;
-    color: #aaa;
-    font-size: 0.7rem;
-    line-height: 1.5;
+.music-close-button {
+    margin: 12px 0 0;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.1);
 }
 
-.music-close-button { margin: 0; }
 #music-audio { display: none; }
 
 @media (max-width: 600px) {
-    .music-player-panel {
+    .modal-content.music-player-panel {
         height: min(720px, calc(100vh - 16px));
         height: min(720px, calc(100dvh - 16px));
         max-height: calc(100vh - 16px);
@@ -286,7 +331,7 @@
     }
 
     .music-option-row {
-        grid-template-columns: auto repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(4, minmax(0, 1fr));
         gap: 5px;
     }
 
@@ -300,26 +345,22 @@
         max-height: none;
     }
 
-    .music-background-note {
-        margin: 8px 0 6px;
-        line-height: 1.3;
-    }
-
     .music-close-button {
         min-height: 38px;
         padding: 8px;
+        margin-top: 8px;
     }
 }
 
 @media (max-width: 380px) {
-    .music-player-panel { padding: 12px; }
+    .modal-content.music-player-panel { padding: 12px; }
     .music-player-disc { width: 72px; }
     .music-track-library-heading { padding-block: 6px; }
     .music-playlist-mode-row { padding-block: 5px; }
 }
 
 @media (max-height: 500px) and (min-width: 480px) {
-    .music-player-panel {
+    .modal-content.music-player-panel {
         width: calc(100vw - 16px);
         height: calc(100vh - 16px);
         height: calc(100dvh - 16px);
@@ -332,8 +373,7 @@
     }
 
     .music-player-kicker,
-    .music-player-disc,
-    .music-background-note {
+    .music-player-disc {
         display: none;
     }
 

--- a/card/music_player.js
+++ b/card/music_player.js
@@ -10,7 +10,11 @@
         ? Object.freeze(window.CARD_MUSIC_TRACKS.slice())
         : Object.freeze([]);
 
-    const PLAYBACK_RATES = Object.freeze([0.75, 1, 1.25, 1.5, 2]);
+    const PLAYBACK_RATES = Object.freeze([1, 1.25]);
+    const RATE_BUTTON_IDS = Object.freeze({
+        1: 'music-rate-1',
+        1.25: 'music-rate-125'
+    });
 
     const REPEAT_LABELS = {
         off: '반복 OFF',
@@ -350,6 +354,19 @@
             this.render();
         },
 
+        renderPlaybackRateControls() {
+            const playbackRate = Number(this.audio && this.audio.playbackRate) || 1;
+            const hasTrack = Boolean(this.getCurrentTrack());
+            PLAYBACK_RATES.forEach(rate => {
+                const button = document.getElementById(RATE_BUTTON_IDS[rate]);
+                if (!button) return;
+                const isActive = playbackRate === rate;
+                button.classList.toggle('is-active', isActive);
+                button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+                button.disabled = !hasTrack;
+            });
+        },
+
         cyclePlaybackRate() {
             if (!this.audio || !this.getCurrentTrack()) return;
             const currentRate = Number(this.audio.playbackRate) || 1;
@@ -526,10 +543,14 @@
                 trackButton.className = 'music-track-select';
                 trackButton.setAttribute('aria-label', `${track.title} 선택`);
                 trackButton.addEventListener('click', () => this.selectTrack(track.id));
+                const indexLabel = document.createElement('span');
+                indexLabel.className = 'music-track-row-index';
+                indexLabel.textContent = String(index + 1).padStart(2, '0');
                 title.className = 'music-track-row-title';
                 title.textContent = track.title;
                 artist.className = 'music-track-row-artist';
                 artist.textContent = track.artist;
+                trackButton.appendChild(indexLabel);
                 trackButton.appendChild(title);
                 trackButton.appendChild(artist);
 
@@ -545,7 +566,6 @@
             const title = document.getElementById('music-track-title');
             const meta = document.getElementById('music-track-meta');
             const playButton = document.getElementById('music-play-toggle');
-            const rate = document.getElementById('music-playback-rate');
             const repeat = document.getElementById('music-repeat-toggle');
             const shuffle = document.getElementById('music-shuffle-toggle');
             const status = document.getElementById('music-status');
@@ -556,14 +576,7 @@
                 playButton.textContent = this.audio.paused ? '▶' : '⏸';
                 playButton.setAttribute('aria-label', this.audio.paused ? '재생' : '일시정지');
             }
-            if (rate) {
-                const playbackRate = Number(this.audio.playbackRate) || 1;
-                rate.value = String(playbackRate);
-                if (rate.tagName !== 'SELECT') {
-                    rate.textContent = `${Number.isInteger(playbackRate) ? playbackRate.toFixed(1) : playbackRate}×`;
-                }
-                rate.setAttribute('aria-label', `재생 배속 ${playbackRate}배. 눌러서 변경`);
-            }
+            this.renderPlaybackRateControls();
             if (repeat) repeat.textContent = REPEAT_LABELS[this.repeatMode];
             if (shuffle) {
                 shuffle.textContent = this.shuffle ? '셔플 ON' : '셔플 OFF';
@@ -580,7 +593,6 @@
                 'music-play-toggle',
                 'music-seek-forward',
                 'music-next',
-                'music-playback-rate',
                 'music-repeat-toggle',
                 'music-shuffle-toggle',
                 'music-progress'

--- a/defense_hero/README.md
+++ b/defense_hero/README.md
@@ -187,34 +187,7 @@ defense_hero/
 
 ## 테스트
 
-저장소 루트에서 Hero Core Defense의 단위·통합 테스트 전체를 실행한다.
-
-```powershell
-npm run test:defense-hero
-npm run test:defense-hero:local
-npm run test:defense-hero:browser
-```
-
-필요하면 Node 테스트 러너로 범위를 직접 나눠 실행할 수 있다.
-
-```powershell
-node --test "defense_hero/tests/unit/*.test.mjs"
-node --test "defense_hero/tests/integration/*.test.mjs"
-```
-
-콘텐츠 정의를 수정했다면 통합 데이터 검증도 실행한다.
-
-```powershell
-node --input-type=module -e "import('./defense_hero/js/data/content.js').then(m=>console.log(m.validateContent({throwOnError:true})))"
-```
-
-최종 완료 판정 전에는 저장소 루트의 전체 검증도 반드시 통과해야 한다.
-
-```powershell
-npm run verify
-```
-
-`npm run verify`에는 정적 검사, `test:defense-hero`, 모바일 가로 Playwright 스모크가 연결되어 있다. 브라우저 스모크는 새 게임→배치→실제 전투 판정→성장→다음 지도→재실행/계속하기와 0.2배 조준, 44px 탭, 세로 회전 가드를 확인한다.
+Defense Hero V1은 사용하지 않는다. `npm run verify`는 이 폴더를 검사하지 않는다. 현재 활성 디펜스는 `defense_hero_v2/`다.
 
 ## 디버그 API
 

--- a/package.json
+++ b/package.json
@@ -1,21 +1,19 @@
 {
   "scripts": {
-    "lint": "node --check card/logic.js && node --check card/data.js && node --check card/vocab_data.js && node --check card/collocation_data.js && node --check card/toeic.js && node --check card/toeic_explanations.js && node --check card/api.js && node --check card/battle_runtime.js && node --check card/rpg_features.js && node --check card/fortune_cookie.js && node --check card/music_data.js && node --check card/music_player.js && node --check card_remaster/api.js && npm run lint:defense-hero && npm run lint:defense-hero-v2",
-    "lint:defense-hero": "node scripts/verify_hero_defense.js",
+    "lint": "npm run lint:card",
+    "lint:card": "node --check card/logic.js && node --check card/data.js && node --check card/vocab_data.js && node --check card/collocation_data.js && node --check card/toeic.js && node --check card/toeic_explanations.js && node --check card/api.js && node --check card/battle_runtime.js && node --check card/rpg_features.js && node --check card/fortune_cookie.js && node --check card/music_data.js && node --check card/music_player.js && node --check card_remaster/api.js",
     "lint:defense-hero-v2": "node scripts/verify_hero_defense_v2.js",
     "build:defense-hero-local": "node scripts/build_hero_defense_local.mjs",
     "build:defense-hero-v2-local": "node scripts/build_hero_defense_v2_local.mjs",
     "serve:defense-hero": "node scripts/serve_hero_defense.js",
     "serve:defense-hero-v2": "node scripts/serve_hero_defense_v2.js",
-    "test:smoke": "node scripts/verify_card_smoke.js && node scripts/verify_card_refactor.js && node scripts/verify_card_music_player.js && node scripts/verify_card_learning_data.js && node scripts/verify_card_combat_regressions.js && node scripts/verify_gemini_api_models.js && node scripts/verify_card_remaster_smoke.js && node scripts/verify_idle_hero_smoke.js",
-    "test:browser": "node scripts/verify_card_mobile.js && node scripts/verify_card_special_flow.js && node scripts/verify_card_remaster_browser.js",
-    "test:defense-hero": "node --test defense_hero/tests/unit/*.test.mjs defense_hero/tests/integration/*.test.mjs",
-    "test:defense-hero:local": "npm run build:defense-hero-local && node scripts/verify_hero_defense_local_bundle.js",
-    "test:defense-hero:browser": "node scripts/verify_hero_defense_browser.js",
+    "test:card:smoke": "node scripts/verify_card_smoke.js && node scripts/verify_card_refactor.js && node scripts/verify_card_music_player.js && node scripts/verify_card_learning_data.js && node scripts/verify_card_combat_regressions.js && node scripts/verify_gemini_api_models.js && node scripts/verify_card_remaster_smoke.js",
+    "test:card:browser": "node scripts/verify_card_mobile.js && node scripts/verify_card_special_flow.js && node scripts/verify_card_remaster_browser.js",
+    "test:idle:smoke": "node scripts/verify_idle_hero_smoke.js",
     "test:defense-hero-v2": "node --test defense_hero_v2/tests/unit/*.test.mjs defense_hero_v2/tests/integration/*.test.mjs",
     "test:defense-hero-v2:local": "npm run build:defense-hero-v2-local && node scripts/verify_hero_defense_v2_local_bundle.js",
     "test:defense-hero-v2:browser": "node scripts/verify_hero_defense_v2_browser.js",
-    "verify": "npm run lint && npm run test:smoke && npm run test:browser && npm run test:defense-hero && npm run test:defense-hero:local && npm run test:defense-hero:browser && npm run test:defense-hero-v2 && npm run test:defense-hero-v2:local && npm run test:defense-hero-v2:browser"
+    "verify": "node scripts/verify.js"
   },
   "dependencies": {
     "playwright": "^1.59.1"

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { execSync, spawnSync } = require('child_process');
+const { execFileSync, execSync, spawnSync } = require('child_process');
 
 const TARGET_STEPS = {
   card: ['lint:card', 'test:card:smoke', 'test:card:browser'],
@@ -24,9 +24,20 @@ function gitLines(args) {
   }
 }
 
+function refExists(ref) {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', '--end-of-options', `${ref}^{commit}`], {
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 function upstreamBase() {
-  for (const candidate of ['origin/main', 'origin/master']) {
-    if (gitLines(`rev-parse --verify ${candidate}`).length > 0) return candidate;
+  for (const candidate of ['origin/main', 'origin/master', 'main', 'master']) {
+    if (refExists(candidate)) return candidate;
   }
   return '';
 }
@@ -69,8 +80,10 @@ function selectTargets(files) {
 }
 
 function runNpm(script) {
-  const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  const result = spawnSync(npmCmd, ['run', script], { stdio: 'inherit' });
+  const result = spawnSync('npm', ['run', script], {
+    stdio: 'inherit',
+    shell: true
+  });
   if (result.status !== 0) {
     process.exit(result.status || 1);
   }

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const { execSync, spawnSync } = require('child_process');
+
+const TARGET_STEPS = {
+  card: ['lint:card', 'test:card:smoke', 'test:card:browser'],
+  idle: ['test:idle:smoke'],
+  'defense-v2': [
+    'lint:defense-hero-v2',
+    'test:defense-hero-v2',
+    'test:defense-hero-v2:local',
+    'test:defense-hero-v2:browser'
+  ]
+};
+
+function gitLines(args) {
+  try {
+    return execSync(`git ${args}`, { encoding: 'utf8' })
+      .split(/\r?\n/)
+      .map(line => line.trim().replace(/\\/g, '/'))
+      .filter(Boolean);
+  } catch (error) {
+    return [];
+  }
+}
+
+function upstreamBase() {
+  for (const candidate of ['origin/main', 'origin/master']) {
+    if (gitLines(`rev-parse --verify ${candidate}`).length > 0) return candidate;
+  }
+  return '';
+}
+
+function changedFiles() {
+  const base = upstreamBase();
+  return new Set([
+    ...gitLines('diff --name-only'),
+    ...gitLines('diff --name-only --cached'),
+    ...gitLines('ls-files --others --exclude-standard'),
+    ...(base ? gitLines(`diff --name-only ${base}...HEAD`) : [])
+  ]);
+}
+
+function selectTargets(files) {
+  const targets = new Set();
+  for (const file of files) {
+    if (
+      file.startsWith('card/')
+      || file.startsWith('card_remaster/')
+      || file.startsWith('card_manual/')
+      || file.startsWith('scripts/verify_card_')
+      || file === 'scripts/verify_gemini_api_models.js'
+    ) {
+      targets.add('card');
+      continue;
+    }
+    if (file.startsWith('idle_hero/') || file === 'scripts/verify_idle_hero_smoke.js') {
+      targets.add('idle');
+      continue;
+    }
+    if (
+      file.startsWith('defense_hero_v2/')
+      || file.includes('hero_defense_v2')
+    ) {
+      targets.add('defense-v2');
+    }
+  }
+  return ['card', 'idle', 'defense-v2'].filter(target => targets.has(target));
+}
+
+function runNpm(script) {
+  const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = spawnSync(npmCmd, ['run', script], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    process.exit(result.status || 1);
+  }
+}
+
+function run() {
+  const files = changedFiles();
+  const targets = selectTargets(files);
+  if (targets.length === 0) {
+    console.log('No active game changes detected. Defense Hero V1 is unused and skipped.');
+    return;
+  }
+
+  console.log(`Verifying changed games: ${targets.join(', ')}`);
+  for (const target of targets) {
+    for (const script of TARGET_STEPS[target]) {
+      runNpm(script);
+    }
+  }
+  console.log(`Verify passed for: ${targets.join(', ')}`);
+}
+
+run();

--- a/scripts/verify_card_mobile.js
+++ b/scripts/verify_card_mobile.js
@@ -100,7 +100,7 @@ async function run() {
             const libraryRect = library.getBoundingClientRect();
             const list = document.getElementById('music-track-list');
             const favoriteRect = list.querySelector('.music-favorite-toggle').getBoundingClientRect();
-            MusicPlayer.setPlaybackRate(1.5);
+            MusicPlayer.setPlaybackRate(1.25);
             const result = {
                 active: modal.classList.contains('active'),
                 noHorizontalOverflow: panel.scrollWidth <= panel.clientWidth + 1,
@@ -120,7 +120,8 @@ async function run() {
                 title: document.getElementById('music-track-title').textContent,
                 source: document.getElementById('music-audio').getAttribute('src'),
                 visibleHeadingRemoved: !document.getElementById('music-player-heading'),
-                rateControlTag: document.getElementById('music-playback-rate').tagName,
+                rateOneTag: document.getElementById('music-rate-1').tagName,
+                rateBoostTag: document.getElementById('music-rate-125').tagName,
                 playbackRate: MusicPlayer.audio.playbackRate,
                 defaultPlaybackRate: MusicPlayer.audio.defaultPlaybackRate
             };
@@ -140,12 +141,13 @@ async function run() {
         assert.strictEqual(musicModalLayout.title, MUSIC_FIXTURE_TRACKS[0].title);
         assert.strictEqual(musicModalLayout.source, MUSIC_FIXTURE_TRACKS[0].src);
         assert.strictEqual(musicModalLayout.visibleHeadingRemoved, true);
-        assert.strictEqual(musicModalLayout.rateControlTag, 'BUTTON');
+        assert.strictEqual(musicModalLayout.rateOneTag, 'BUTTON');
+        assert.strictEqual(musicModalLayout.rateBoostTag, 'BUTTON');
         assert.strictEqual(musicModalLayout.listHasOwnScroll, true);
         assert(musicModalLayout.favoriteWidth >= 44);
         assert(musicModalLayout.favoriteHeight >= 44);
-        assert.strictEqual(musicModalLayout.playbackRate, 1.5);
-        assert.strictEqual(musicModalLayout.defaultPlaybackRate, 1.5);
+        assert.strictEqual(musicModalLayout.playbackRate, 1.25);
+        assert.strictEqual(musicModalLayout.defaultPlaybackRate, 1.25);
 
         const imageState = await normal.page.evaluate(async () => {
             const waitUntil = async predicate => {
@@ -257,7 +259,8 @@ async function run() {
                 listHasOwnScroll: list.scrollHeight > list.clientHeight,
                 favoriteWidth: favoriteRect.width,
                 favoriteHeight: favoriteRect.height,
-                rateControlTag: document.getElementById('music-playback-rate').tagName
+                rateOneTag: document.getElementById('music-rate-1').tagName,
+                rateBoostTag: document.getElementById('music-rate-125').tagName
             };
             MusicPlayer.close();
             return result;
@@ -272,7 +275,8 @@ async function run() {
         assert.strictEqual(compactMusicModalBounds.listHasOwnScroll, true);
         assert(compactMusicModalBounds.favoriteWidth >= 44);
         assert(compactMusicModalBounds.favoriteHeight >= 44);
-        assert.strictEqual(compactMusicModalBounds.rateControlTag, 'BUTTON');
+        assert.strictEqual(compactMusicModalBounds.rateOneTag, 'BUTTON');
+        assert.strictEqual(compactMusicModalBounds.rateBoostTag, 'BUTTON');
 
         const portraitModalBounds = await normal.page.evaluate(() => {
             RPG.openInfoModal('모바일 경계 검사', '긴 내용 '.repeat(300));

--- a/scripts/verify_card_music_player.js
+++ b/scripts/verify_card_music_player.js
@@ -126,7 +126,7 @@ function createHarness({ tracks = TRACKS, savedPrefs = null, includeManifest = t
         'modal-music-player', 'music-track-title', 'music-track-meta', 'music-status',
         'music-progress', 'music-current-time', 'music-duration', 'music-previous',
         'music-seek-backward', 'music-play-toggle', 'music-seek-forward', 'music-next',
-        'music-playback-rate', 'music-repeat-toggle', 'music-shuffle-toggle',
+        'music-rate-1', 'music-rate-125', 'music-repeat-toggle', 'music-shuffle-toggle',
         'music-track-count', 'music-track-list', 'music-mode-all', 'music-mode-favorites'
     ];
     ids.forEach(id => {
@@ -178,7 +178,7 @@ async function verifyMainPlayerFlow() {
         savedPrefs: {
             trackId: TRACKS[1].id,
             currentTime: 30,
-            playbackRate: 1.5,
+            playbackRate: 1.25,
             repeatMode: 'all',
             shuffle: false
         }
@@ -193,10 +193,11 @@ async function verifyMainPlayerFlow() {
     assert.strictEqual(audio.src, TRACKS[1].src);
     assert.strictEqual(audio.preservesPitch, true);
     assert.strictEqual(audio.currentTime, 30);
-    assert.strictEqual(audio.defaultPlaybackRate, 1.5);
-    assert.strictEqual(audio.playbackRate, 1.5);
+    assert.strictEqual(audio.defaultPlaybackRate, 1.25);
+    assert.strictEqual(audio.playbackRate, 1.25);
     assert.strictEqual(mediaSession.metadata.title, TRACKS[1].title);
-    assert.strictEqual(elements.get('music-playback-rate').textContent, '1.5×');
+    assert.strictEqual(elements.get('music-rate-1').getAttribute('aria-pressed'), 'false');
+    assert.strictEqual(elements.get('music-rate-125').getAttribute('aria-pressed'), 'true');
     assert.strictEqual(elements.get('music-track-count').textContent, '3곡');
     assert.strictEqual(elements.get('music-track-list').children.length, 3);
     assert.strictEqual(elements.get('music-play-toggle').disabled, false);
@@ -206,7 +207,7 @@ async function verifyMainPlayerFlow() {
     await player.next();
     assert.strictEqual(player.getCurrentTrack().id, TRACKS[2].id);
     assert.strictEqual(audio.paused, true, 'selecting the next track while paused must remain paused');
-    assert.strictEqual(audio.playbackRate, 1.5, 'restored rate must survive a track load');
+    assert.strictEqual(audio.playbackRate, 1.25, 'restored rate must survive a track load');
 
     player.open();
     assert.strictEqual(elements.get('modal-music-player').classList.contains('active'), true);
@@ -224,14 +225,17 @@ async function verifyMainPlayerFlow() {
     await player.selectTrack(TRACKS[2].id);
     assert.strictEqual(audio.paused, true, 'selecting a track while paused must remain paused');
 
-    player.setPlaybackRate('1.25');
-    assert.strictEqual(audio.defaultPlaybackRate, 1.25);
+    player.setPlaybackRate('1');
+    assert.strictEqual(audio.defaultPlaybackRate, 1);
     await player.next();
-    assert.strictEqual(audio.playbackRate, 1.25, 'selected rate must survive the next track load');
+    assert.strictEqual(audio.playbackRate, 1, 'selected rate must survive the next track load');
+    player.setPlaybackRate(1.5);
+    assert.strictEqual(audio.playbackRate, 1, 'unsupported rates must fall back to 1x');
     player.cyclePlaybackRate();
-    assert.strictEqual(audio.playbackRate, 1.5);
-    assert.strictEqual(elements.get('music-playback-rate').textContent, '1.5×');
-    [2, 0.75, 1, 1.25, 1.5].forEach(expectedRate => {
+    assert.strictEqual(audio.playbackRate, 1.25);
+    assert.strictEqual(elements.get('music-rate-1').getAttribute('aria-pressed'), 'false');
+    assert.strictEqual(elements.get('music-rate-125').getAttribute('aria-pressed'), 'true');
+    [1, 1.25].forEach(expectedRate => {
         player.cyclePlaybackRate();
         assert.strictEqual(audio.playbackRate, expectedRate);
     });
@@ -317,13 +321,13 @@ async function verifyMainPlayerFlow() {
     assert.strictEqual(elements.get('music-status').textContent, '즐겨찾기 곡이 없습니다.');
 
     const prefs = saved.get('cardRpgMusicPrefs');
-    assert.strictEqual(prefs.playbackRate, 1.5);
+    assert.strictEqual(prefs.playbackRate, 1.25);
     assert.strictEqual(prefs.repeatMode, 'all');
     assert.strictEqual(prefs.shuffle, true);
     assert.deepStrictEqual(prefs.favoriteTrackIds, []);
     assert.strictEqual(prefs.playlistMode, 'all');
     assert.strictEqual(mediaSession.positionState.duration, 180);
-    assert.strictEqual(mediaSession.positionState.playbackRate, 1.5);
+    assert.strictEqual(mediaSession.positionState.playbackRate, 1.25);
 
     audio.dispatch('error');
     assert(elements.get('music-status').textContent.includes(player.getCurrentTrack().src));
@@ -378,8 +382,14 @@ function verifyHtmlIntegration() {
     assert(dataPosition >= 0 && dataPosition < playerPosition, 'music data must load before the player');
     assert(html.includes('id="music-track-list"'));
     assert(html.includes('id="music-mode-favorites"'));
-    assert(html.includes('id="music-playback-rate" type="button"'), 'playback rate must use the themed button');
+    assert(html.includes('id="music-rate-1" type="button"'), '1x rate must use a themed toggle');
+    assert(html.includes('id="music-rate-125" type="button"'), '1.25x rate must use a themed toggle');
+    assert(!html.includes('id="music-playback-rate"'), 'legacy single rate control must be removed');
+    assert(!html.includes('music-background-note'), 'browser-policy note must be removed');
+    assert(!html.includes('창을 닫아도 음악은 계속 재생됩니다'));
     assert(!html.includes('<h3 id="music-player-heading">음악재생</h3>'), 'redundant visible heading must be removed');
+    const musicData = fs.readFileSync(path.join(process.cwd(), 'card', 'music_data.js'), 'utf8');
+    assert(!musicData.includes('スキの未払金'), 'unpaid-love track must be removed from the playlist');
 }
 
 async function run() {


### PR DESCRIPTION
## Summary
- Remove `スキの未払金` (좋아함의 미지불금) from the card music playlist.
- Keep only 1x and 1.25x playback-rate toggles.
- Restyle the music list/player to a darker, more refined layout and delete the browser-policy note under the playlist.
- Confirm Gemini Flash Lite is already `gemini-3.5-flash-lite` on latest main. No 3.1 Flash Lite API calls remain; Lite still uses the 3.x header/key shape with no sampling params.
- Make `npm run verify` inspect the current branch/working tree and run only the changed game. Defense Hero V1 is unused and is no longer part of the verify gate.

## Test plan
- [x] `npm run verify` selected **card** only and passed (lint, smoke, browser).
- [ ] Open 음악재생 and confirm `スキの未払金` is gone.
- [ ] Confirm only 1× / 1.25× rate toggles remain and switching works.
- [ ] Confirm the playlist looks dark/refined and the browser-policy note is gone.
- [ ] Close the player and confirm playback continues.