### PR TITLE
feat(card): deck confirm visibility, compact bonus editor, unify mode desc tone, sync artifact_chaos 1.2x battle scaling

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -80,9 +80,9 @@ function buildBattleEnemy(rpg) {
     const cycle = Math.floor(rpg.state.enemyScale / cycleLength);
     let scale = 1.0 + (cycle * GAME_CONSTANTS.ENEMY_SCALING.CYCLE_BONUS);
     let steps = 0;
-    if (rpg.state.mode === 'puzzle') {
+    if (rpg.state.mode === 'puzzle' || rpg.state.mode === 'artifact_chaos') {
         steps = 2;
-    } else if (['artifact', 'artifact_chaos', 'artifact_reserve', 'flood', 'curse'].includes(rpg.state.mode)) {
+    } else if (['artifact', 'artifact_reserve', 'flood', 'curse'].includes(rpg.state.mode)) {
         if (rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') {
             steps = 1;
         }

--- a/card/index.html
+++ b/card/index.html
@@ -1203,7 +1203,7 @@
             </div>
             <div id="collection-grid" class="card-grid"></div>
         </div>
-        <div id="screen-deck" class="screen">
+        <div id="screen-deck" class="screen" style="padding-bottom: env(safe-area-inset-bottom, 8px);">
             <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:4px;">
                 <h3 style="margin:4px 0;">덱 구성</h3>
                 <button onclick="RPG.toMenu()"
@@ -1217,7 +1217,7 @@
             <div style="flex:1; overflow-y:auto; border-top:1px solid #333;">
                 <div id="deck-card-list" class="card-grid" style="padding-bottom:15px;"></div>
             </div>
-            <button class="menu-btn" onclick="RPG.confirmDeck()" style="margin-top:6px; margin-bottom: 20px; padding:12px;">확인</button>
+            <button class="menu-btn" onclick="RPG.confirmDeck()" style="flex-shrink:0; margin-top:6px; margin-bottom:0; padding:12px;">확인</button>
         </div>
         <div id="screen-chaos-roulette" class="screen">
             <div
@@ -1326,7 +1326,7 @@
             <button id="btn-bonus-pool-editor" class="menu-btn" onclick="RPG.openBonusPoolEditor()"
                 style="padding:12px; border-color:#4fc3f7; color:#4fc3f7; margin-bottom:8px;">
                 덱 편집<br>
-                <span style="font-size:0.8rem; color:#b3e5fc;">기본 카드는 항상 포함 / 보너스 카드만 ON/OFF</span>
+                <span style="font-size:0.8rem; color:#b3e5fc;">보너스 카드 ON/OFF</span>
             </button>
             <button id="btn-special-card-editor" class="menu-btn" onclick="RPG.openSpecialCardEditor()"
                 style="display:none; padding:12px; border-color:#ffca28; color:#ffe082; margin-bottom:8px;">
@@ -1348,16 +1348,16 @@
     <div id="modal-bonus-pool-editor" class="modal">
         <div class="modal-content" style="height:auto; min-height:320px; width: 360px;">
             <h3>보너스 카드 덱 편집</h3>
-            <p style="font-size:0.85rem; color:#aaa; margin:0 0 6px 0;">
-                기본 카드는 항상 포함됩니다. 체크된 보너스 카드는 이번 런의 랜덤 풀에서 비활성화됩니다. (최대 15장)
-            </p>
             <p id="bonus-pool-editor-summary" style="font-size:0.8rem; color:#81d4fa; margin:0 0 8px 0;">세팅 1 · 활성 0 / 0 (최대 15)</p>
             <div id="bonus-pool-preset-list" class="bonus-preset-row"></div>
             <p id="bonus-pool-preset-status" style="font-size:0.78rem; color:#b3e5fc; margin:0 0 8px 0;">다음 런 적용 세팅: 1</p>
             <div id="bonus-pool-editor-list" class="modal-scroll"></div>
-            <button class="menu-btn" onclick="RPG.resetBonusPoolSelection()"
-                style="margin-bottom:8px; border-color:#ef5350; color:#ef5350;">선택초기화</button>
-            <button onclick="RPG.closeBonusPoolEditor()" style="width:100%; padding:10px;">닫기</button>
+            <div style="display:flex; gap:8px; margin-top:6px;">
+                <button class="menu-btn" onclick="RPG.resetBonusPoolSelection()"
+                    style="flex:1; margin-bottom:0; border-color:#ef5350; color:#ef5350;">선택초기화</button>
+                <button class="menu-btn" onclick="RPG.closeBonusPoolEditor()"
+                    style="flex:1; margin-bottom:0;">닫기</button>
+            </div>
         </div>
     </div>
 
@@ -3126,20 +3126,20 @@
                 }
 
                 let MODES = [
-                    { id: 'origin', name: '오리진', desc: '기본 모드입니다.\n(성공조건: 없음 / 무한)' },
-                    { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
-                    { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
+                    { id: 'origin', name: '오리진', desc: '기본 모드.\n(성공조건: 없음 / 무한)' },
+                    { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장.\n(성공조건: 18 스테이지)' },
+                    { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장.\n(성공조건: 18 스테이지)' },
                     { id: 'suffering', name: '고난의 여정', desc: '초기 10장, 클리어 보상 없음, 축복 카드 +2장.\n(성공조건: 24 스테이지)' },
-                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 확보해 진행. 사용한 카드는 소멸, 강화된 적 출현.\n(성공조건: 12 스테이지)' },
+                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 확보해 진행. 사용한 카드는 소멸, 크게 강화된 적 출현.\n(성공조건: 12 스테이지)' },
                     { id: 'archive', name: '아카이브', desc: '매 스테이지 종료 후 문법 퀴즈. 정답률 80% 이상 필요.\n(성공조건: 18 스테이지)' },
                     { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'chaos', name: '카오스', desc: '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'artifact_chaos', name: '아티팩트카오스', desc: '카오스모드와 동일하지만, 매 스테이지마다 랜덤 아티팩트 4개를 추가로 받습니다.\n메뉴에서 활성 아티팩트를 확인할 수 있고, 셔플 시 아티팩트도 초기화됩니다. 강화된 적 출현.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+                    { id: 'artifact_chaos', name: '아티팩트카오스', desc: '카오스 기반 + 매 스테이지 랜덤 아티팩트 4개 추가 획득. 셔플 시 아티팩트도 초기화. 크게 강화된 적 출현.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
                     { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'factory', name: '팩토리', desc: '시작 시 40장의 카드를 번들 단위로 드래프트하여 덱 풀을 구성.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 30 스테이지)' },
-                    { id: 'artifact_reserve', name: '아티팩트리저브', desc: '아티팩트 세트 선택을 4회 반복해 12개 풀을 구성. 각 아티팩트는 2회 사용 가능하며 전투 전 최대 4개를 수동 활성화합니다. 강화된 적 출현.\n(성공조건: 24 스테이지)' }
+                    { id: 'factory', name: '팩토리', desc: '시작 시 40장의 카드를 번들 단위로 드래프트하여 덱 풀 구성.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+                    { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개). 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 30 스테이지)' },
+                    { id: 'artifact_reserve', name: '아티팩트리저브', desc: '아티팩트 세트 선택 4회 반복으로 12개 풀 구성. 각 아티팩트는 2회 사용 가능, 전투 전 최대 4개 수동 활성화. 강화된 적 출현.\n(성공조건: 24 스테이지)' }
                 ];
 
                 if (this.tempGameType === 'endless') {
@@ -3147,14 +3147,14 @@
                     MODES.forEach(m => {
                         if (m.id === 'chaos') m.desc = '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
                         if (m.id === 'draft') m.desc = '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
-                        if (m.id === 'artifact') m.desc = '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 없음 / 무한)';
-                        if (m.id === 'artifact_reserve') m.desc = '아티팩트 세트 선택을 4회 반복해 12개 풀을 구성. 각 아티팩트는 2회 사용 가능하며 전투 전 최대 4개를 수동 활성화합니다. 강화된 적 출현.\n(성공조건: 없음 / 무한)';
+                        if (m.id === 'artifact') m.desc = '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개). 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 없음 / 무한)';
+                        if (m.id === 'artifact_reserve') m.desc = '아티팩트 세트 선택 4회 반복으로 12개 풀 구성. 각 아티팩트는 2회 사용 가능, 전투 전 최대 4개 수동 활성화. 강화된 적 출현.\n(성공조건: 없음 / 무한)';
                     });
                     if (this.global.hiddenStudyReady) {
                         MODES.push({
                             id: 'dream_corridor',
                             name: '꿈의회랑',
-                            desc: '학습용 히든 엔드리스 모드. 전투 종료 후 퀴즈가 자동 진행되며, 오답은 3회까지 유예됩니다. (3회 오답 시 런 실패 / 오답 즉시 저장)\n(실전마법연습 3회로 출현)'
+                            desc: '학습용 히든 엔드리스 모드. 전투 종료 후 퀴즈 자동 진행, 오답 3회까지 유예. (3회 오답 시 런 실패 / 오답 즉시 저장)\n(실전마법연습 3회로 출현)'
                         });
                     }
                 } else if (this.tempGameType === 'challenge') {
@@ -3188,9 +3188,9 @@
                         
                         if (this.tempGameType === 'challenge') {
                             let steps = 0;
-                            if (m.id === 'puzzle') {
+                            if (m.id === 'puzzle' || m.id === 'artifact_chaos') {
                                 steps = 2;
-                            } else if (['artifact', 'artifact_chaos', 'artifact_reserve', 'flood', 'curse'].includes(m.id)) {
+                            } else if (['artifact', 'artifact_reserve', 'flood', 'curse'].includes(m.id)) {
                                 steps = 1;
                             }
                             if (this.hardModeActive) {
@@ -3205,7 +3205,7 @@
                             
                             if (enhanceText) {
                                 if (descText.includes("강화된 적 출현")) {
-                                    descText = descText.replace(/강화된 적 출현\.?/g, enhanceText);
+                                    descText = descText.replace(/(크게 |대폭 |최고로 )?강화된 적 출현\.?/g, enhanceText);
                                 } else {
                                     descText = descText.replace(/\n\(성공조건:/, `\n(${enhanceText})\n(성공조건:`);
                                 }

--- a/card_remaster/battle_runtime.js
+++ b/card_remaster/battle_runtime.js
@@ -93,9 +93,9 @@ function buildBattleEnemy(rpg) {
     const cycle = Math.floor(rpg.state.enemyScale / cycleLength);
     let scale = 1.0 + (cycle * GAME_CONSTANTS.ENEMY_SCALING.CYCLE_BONUS);
     let steps = 0;
-    if (rpg.state.mode === 'puzzle') {
+    if (rpg.state.mode === 'puzzle' || rpg.state.mode === 'artifact_chaos') {
         steps = 2;
-    } else if (['artifact', 'artifact_chaos', 'artifact_reserve', 'flood', 'curse'].includes(rpg.state.mode)) {
+    } else if (['artifact', 'artifact_reserve', 'flood', 'curse'].includes(rpg.state.mode)) {
         if (rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') {
             steps = 1;
         }

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -3161,20 +3161,20 @@
                 }
 
                 let MODES = [
-                    { id: 'origin', name: '오리진', desc: '기본 모드입니다.\n(성공조건: 없음 / 무한)' },
-                    { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
-                    { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장합니다.\n(성공조건: 18 스테이지)' },
+                    { id: 'origin', name: '오리진', desc: '기본 모드.\n(성공조건: 없음 / 무한)' },
+                    { id: 'restriction', name: '제약의 시련', desc: '뽑기/축복에서 레어 등급 이하만 등장.\n(성공조건: 18 스테이지)' },
+                    { id: 'balance', name: '균형의 도전', desc: '뽑기/축복에서 에픽 등급 이하만 등장.\n(성공조건: 18 스테이지)' },
                     { id: 'suffering', name: '고난의 여정', desc: '초기 10장, 클리어 보상 없음, 축복 카드 +2장.\n(성공조건: 24 스테이지)' },
-                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 확보해 진행. 사용한 카드는 소멸, 강화된 적 출현.\n(성공조건: 12 스테이지)' },
+                    { id: 'puzzle', name: '퍼즐', desc: '시작 퀴즈로 정해진 카드 36장을 확보해 진행. 사용한 카드는 소멸, 크게 강화된 적 출현.\n(성공조건: 12 스테이지)' },
                     { id: 'archive', name: '아카이브', desc: '매 스테이지 종료 후 문법 퀴즈. 정답률 80% 이상 필요.\n(성공조건: 18 스테이지)' },
                     { id: 'curse', name: '저주의 증폭', desc: '디버프의 스탯 감소 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'flood', name: '축복의 범람', desc: '필드 버프의 강화 효과 2배. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
                     { id: 'chaos', name: '카오스', desc: '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'artifact_chaos', name: '아티팩트카오스', desc: '카오스모드와 동일하지만, 매 스테이지마다 랜덤 아티팩트 4개를 추가로 받습니다.\n메뉴에서 활성 아티팩트를 확인할 수 있고, 셔플 시 아티팩트도 초기화됩니다. 강화된 적 출현.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+                    { id: 'artifact_chaos', name: '아티팩트카오스', desc: '카오스 기반 + 매 스테이지 랜덤 아티팩트 4개 추가 획득. 셔플 시 아티팩트도 초기화. 크게 강화된 적 출현.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
                     { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'factory', name: '팩토리', desc: '시작 시 40장의 카드를 번들 단위로 드래프트하여 덱 풀을 구성.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
-                    { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 30 스테이지)' },
-                    { id: 'artifact_reserve', name: '아티팩트리저브', desc: '아티팩트 세트 선택을 4회 반복해 12개 풀을 구성. 각 아티팩트는 2회 사용 가능하며 전투 전 최대 4개를 수동 활성화합니다. 강화된 적 출현.\n(성공조건: 24 스테이지)' }
+                    { id: 'factory', name: '팩토리', desc: '시작 시 40장의 카드를 번들 단위로 드래프트하여 덱 풀 구성.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
+                    { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개). 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 30 스테이지)' },
+                    { id: 'artifact_reserve', name: '아티팩트리저브', desc: '아티팩트 세트 선택 4회 반복으로 12개 풀 구성. 각 아티팩트는 2회 사용 가능, 전투 전 최대 4개 수동 활성화. 강화된 적 출현.\n(성공조건: 24 스테이지)' }
                 ];
 
                 if (this.tempGameType === 'endless') {
@@ -3182,14 +3182,14 @@
                     MODES.forEach(m => {
                         if (m.id === 'chaos') m.desc = '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
                         if (m.id === 'draft') m.desc = '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
-                        if (m.id === 'artifact') m.desc = '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개).\n고유한 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 없음 / 무한)';
-                        if (m.id === 'artifact_reserve') m.desc = '아티팩트 세트 선택을 4회 반복해 12개 풀을 구성. 각 아티팩트는 2회 사용 가능하며 전투 전 최대 4개를 수동 활성화합니다. 강화된 적 출현.\n(성공조건: 없음 / 무한)';
+                        if (m.id === 'artifact') m.desc = '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개). 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 없음 / 무한)';
+                        if (m.id === 'artifact_reserve') m.desc = '아티팩트 세트 선택 4회 반복으로 12개 풀 구성. 각 아티팩트는 2회 사용 가능, 전투 전 최대 4개 수동 활성화. 강화된 적 출현.\n(성공조건: 없음 / 무한)';
                     });
                     if (this.global.hiddenStudyReady) {
                         MODES.push({
                             id: 'dream_corridor',
                             name: '꿈의회랑',
-                            desc: '학습용 히든 엔드리스 모드. 전투 종료 후 퀴즈가 자동 진행되며, 오답은 3회까지 유예됩니다. (3회 오답 시 런 실패 / 오답 즉시 저장)\n(실전마법연습 3회로 출현)'
+                            desc: '학습용 히든 엔드리스 모드. 전투 종료 후 퀴즈 자동 진행, 오답 3회까지 유예. (3회 오답 시 런 실패 / 오답 즉시 저장)\n(실전마법연습 3회로 출현)'
                         });
                     }
                 } else if (this.tempGameType === 'challenge') {
@@ -3223,9 +3223,9 @@
 
                         if (this.tempGameType === 'challenge') {
                             let steps = 0;
-                            if (m.id === 'puzzle') {
+                            if (m.id === 'puzzle' || m.id === 'artifact_chaos') {
                                 steps = 2;
-                            } else if (['artifact', 'artifact_chaos', 'artifact_reserve', 'flood', 'curse'].includes(m.id)) {
+                            } else if (['artifact', 'artifact_reserve', 'flood', 'curse'].includes(m.id)) {
                                 steps = 1;
                             }
                             if (this.hardModeActive) {
@@ -3240,7 +3240,7 @@
 
                             if (enhanceText) {
                                 if (descText.includes("강화된 적 출현")) {
-                                    descText = descText.replace(/강화된 적 출현\.?/g, enhanceText);
+                                    descText = descText.replace(/(크게 |대폭 |최고로 )?강화된 적 출현\.?/g, enhanceText);
                                 } else {
                                     descText = descText.replace(/\n\(성공조건:/, `\n(${enhanceText})\n(성공조건:`);
                                 }

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -1217,7 +1217,7 @@ function run() {
       getCurrentStageEnemyData: () => ENEMIES[0]
     });
     assert.strictEqual(buildScaledEnemy('default', 'challenge').maxHp, ENEMIES[0].stats.hp);
-    assert.strictEqual(buildScaledEnemy('artifact_chaos', 'challenge').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.1));
+    assert.strictEqual(buildScaledEnemy('artifact_chaos', 'challenge').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.2));
     assert.strictEqual(buildScaledEnemy('artifact_reserve', 'endless').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.1));
 
     // The merchant hands 20 maximum and current mana to the next living ally.


### PR DESCRIPTION
## Summary

1. **덱 구성 확인 버튼 모바일 잘림 방지**
   - `margin-bottom: 0` + `flex-shrink: 0` 적용으로 화면 압축 시에도 확인 버튼이 100% 온전히 표시되도록 보장
   - `#screen-deck`에 `padding-bottom: env(safe-area-inset-bottom, 8px)`를 적용하여 안드로이드 하단 내비게이션 바/제스처 영역 안전 확보

2. **보너스 카드 덱 편집 UI 여백 최적화**
   - 설명 문구("기본 카드는 항상 포함됩니다...") 제거하여 카드 목록 노출 영역 확보
   - 게임 종류 선택 버튼의 서브 텍스트를 "보너스 카드 ON/OFF"로 간결화
   - [선택초기화] / [닫기] 버튼을 `menu-btn` 스타일로 통일하고 가로 1줄(좌: 선택초기화, 우: 닫기)로 배치

3. **게임 모드 설명 문체 통일**
   - 모든 모드의 `desc`를 일관되고 간결한 문체로 정리

4. **아티팩트카오스 적 강화 단계 및 실제 전투 스케일링 1:1 동기화**
   - UI 설명: 일반은 **"크게 강화된 적"**, 하드모드는 **"최고로 강화된 적"**으로 매핑 (정규식 치환 보완)
   - `battle_runtime.js` 전투 로직: `artifact_chaos`의 적 스케일링 단계를 `steps = 2`(기본 1.2배, 하드모드 1.4배)로 퍼즐 모드와 동일하게 일치시킴

## Verification
- `verify_card_smoke.js`: PASS
- `verify_card_combat_regressions.js`: PASS (artifact_chaos 1.2x 검증 반영)
- `verify_card_learning_data.js`: PASS
- `verify_card_music_player.js`: PASS
- `verify_card_refactor.js`: PASS
- `verify_gemini_api_models.js`: PASS
