### PR TITLE
[Fix] 드래프트 완료 시 덱 화면 미갱신(이전 덱 잔존) 버그 수정

### DIFF
--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1577,7 +1577,7 @@
         if (this.state.deck.indexOf(null) === -1) {
             this.showAlert("덱 구성 완료!");
             this.state.draft.active = false;
-            this.showScreen('screen-deck');
+            this.openDeck();
         } else {
             this.startDraft();
         }

--- a/card_remaster/rpg_features.js
+++ b/card_remaster/rpg_features.js
@@ -1577,7 +1577,7 @@
         if (this.state.deck.indexOf(null) === -1) {
             this.showAlert("덱 구성 완료!");
             this.state.draft.active = false;
-            this.showScreen('screen-deck');
+            this.openDeck();
         } else {
             this.startDraft();
         }


### PR DESCRIPTION
## 💡 개요 (Summary)
드래프트 모드에서 3장의 카드를 모두 선발하여 덱 빌딩을 완료했을 때, 덱 구성 화면(`#screen-deck`)에 방금 선택한 카드가 아닌 **이전 라운드/이전에 열람했던 덱 구성의 DOM이 그대로 노출되던 버그**를 수정했습니다.

---

## 🔍 원인 분석 (Root Cause)
- `selectDraftCard(id)`에서 3번째 카드 선택 완료 시, 덱 슬롯 및 카드 리스트 DOM을 갱신하는 `this.openDeck()` 대신 단순 화면 전환용 함수인 `this.showScreen('screen-deck')`을 호출하고 있었습니다.
- `this.showScreen()`은 CSS 클래스(`active`)만 토글할 뿐 `updateDeckSlots()`나 `renderCardList()`를 호출하지 않아, 이전 판에 렌더링되었던 덱 HTML이 그대로 남아있게 되었습니다.

---

## 🛠 변경 사항 (Changes)
- `card/rpg_features.js` 및 `card_remaster/rpg_features.js` 내 `selectDraftCard` 메서드 수정:
  - 드래프트 완료 시 `this.showScreen('screen-deck')` 호출을 `this.openDeck()`으로 변경하여 DOM 슬롯 및 인벤토리 목록이 즉시 새로고침되도록 수정.

```diff
         if (this.state.deck.indexOf(null) === -1) {
             this.showAlert("덱 구성 완료!");
             this.state.draft.active = false;
-            this.showScreen('screen-deck');
+            this.openDeck();
         } else {
```

---

## ✅ 검증 (Verification)
- 드래프트 1회차 완료 -> 전투 진행 및 승리 -> 드래프트 2회차 진행 시, 새로 뽑은 3장의 카드가 덱 슬롯 및 덱 구성 화면에 정상적으로 반영되는 것을 확인.
