### PR TITLE
[Fix] 전투 헤더 아티팩트 확인 위치 정돈(턴 우측) 및 필드 버프 우측 정렬 통일

### DIFF
--- a/card/index.html
+++ b/card/index.html
@@ -235,10 +235,21 @@
         .battle-header {
             display: flex;
             justify-content: space-between;
-            padding: 5px;
+            align-items: center;
+            padding: 5px 8px;
             background: #222;
             border-radius: 5px;
             font-size: 0.8rem;
+            min-height: 30px;
+            box-sizing: border-box;
+            gap: 8px;
+        }
+
+        .battle-header-left {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            flex-shrink: 0;
         }
 
         .battle-artifact-btn {
@@ -250,16 +261,21 @@
             color: #ffd700;
             font-size: 0.7rem;
             cursor: pointer;
+            white-space: nowrap;
         }
 
         .field-buffs {
             height: 20px;
+            line-height: 20px;
             font-size: 0.7rem;
             color: #81d4fa;
-            text-align: center;
+            text-align: right;
             overflow: hidden;
             white-space: nowrap;
+            text-overflow: ellipsis;
             cursor: pointer;
+            flex: 1;
+            min-width: 0;
         }
 
         .visual-stage {
@@ -1269,9 +1285,12 @@
             <div id="transcendence-grid" class="card-grid"></div>
         </div>
         <div id="screen-battle" class="screen">
-            <div class="battle-header"><span>Turn: <span id="bt-turn">1</span></span>
-                <button id="btn-battle-artifact-check" class="battle-artifact-btn"
-                    onclick="RPG.openArtifactCheck()">아티팩트 확인</button>
+            <div class="battle-header">
+                <div class="battle-header-left">
+                    <span>Turn: <span id="bt-turn">1</span></span>
+                    <button id="btn-battle-artifact-check" class="battle-artifact-btn"
+                        onclick="RPG.openArtifactCheck()">아티팩트 확인</button>
+                </div>
                 <div id="field-buff-box" class="field-buffs" onclick="RPG.showFieldBuffInfo()"></div>
             </div>
             <div class="visual-stage">
@@ -3344,7 +3363,8 @@
             showBattleScreen() {
                 this.showScreen('screen-battle');
                 const artifactBtn = document.getElementById('btn-battle-artifact-check');
-                if (artifactBtn) artifactBtn.style.display = this.state.mode === 'artifact_chaos' ? 'block' : 'none';
+                const isArtifactMode = ['artifact', 'artifact_chaos', 'artifact_reserve'].includes(this.state.mode);
+                if (artifactBtn) artifactBtn.style.display = isArtifactMode ? 'inline-block' : 'none';
             },
             clearBattleLog() { document.getElementById('battle-log').innerHTML = ""; },
             renderBattleView() { this.renderBattlefield(); },
@@ -5285,6 +5305,25 @@
                 const title = document.getElementById('artifact-check-title');
 
                 if (this.state.mode === 'artifact_reserve') {
+                    const inBattle = this.battle && !this.battle.isFinished;
+                    if (inBattle) {
+                        if (title) title.innerText = '현재 활성 아티팩트';
+                        if (owned.length === 0) {
+                            list.innerHTML = '<div style="color:#aaa; text-align:center;">활성화된 아티팩트가 없습니다.</div>';
+                        } else {
+                            list.innerHTML = owned.map(id => {
+                                const art = GameUtils.getArtifactById(id);
+                                if (!art) return '';
+                                return `<div style="margin-bottom:8px; padding:8px; background:#333; border-radius:5px; border-left: 3px solid #ffd700;">
+                                    <b style="color:#ffd700;">${art.name}</b><br>
+                                    <span style="color:#ccc;">${art.desc}</span>
+                                </div>`;
+                            }).join('');
+                        }
+                        document.getElementById('modal-artifact-check').classList.add('active');
+                        return;
+                    }
+
                     const reservePool = this.state.artifactReservePool || [];
                     const activeCount = owned.length;
                     if (title) title.innerText = `아티팩트 풀 (${activeCount}/${GAME_CONSTANTS.MAX_ARTIFACTS} 활성)`;

--- a/card_remaster/index.html
+++ b/card_remaster/index.html
@@ -234,10 +234,14 @@
         .battle-header {
             display: flex;
             justify-content: space-between;
-            padding: 5px;
+            align-items: center;
+            padding: 5px 8px;
             background: #222;
             border-radius: 5px;
             font-size: 0.8rem;
+            min-height: 30px;
+            box-sizing: border-box;
+            gap: 8px;
         }
 
         .battle-artifact-btn {
@@ -249,16 +253,21 @@
             color: #ffd700;
             font-size: 0.7rem;
             cursor: pointer;
+            white-space: nowrap;
         }
 
         .field-buffs {
             height: 20px;
+            line-height: 20px;
             font-size: 0.7rem;
             color: #81d4fa;
-            text-align: center;
+            text-align: right;
             overflow: hidden;
             white-space: nowrap;
+            text-overflow: ellipsis;
             cursor: pointer;
+            flex: 1;
+            min-width: 0;
         }
 
         .visual-stage {
@@ -1256,9 +1265,9 @@
                     <span id="battle-stage-text">Stage 1</span>
                     <strong>Turn <span id="bt-turn">1</span></strong>
                     <span id="battle-mode-text">오리진</span>
+                    <button id="btn-battle-artifact-check" class="battle-artifact-btn"
+                        onclick="RPG.openArtifactCheck()">아티팩트 확인</button>
                 </div>
-                <button id="btn-battle-artifact-check" class="battle-artifact-btn"
-                    onclick="RPG.openArtifactCheck()">아티팩트 확인</button>
                 <div id="field-buff-box" class="field-buffs" onclick="RPG.showFieldBuffInfo()"></div>
                 <div id="battle-party-rail" class="battle-party-rail">
                     <div id="battle-party-slot-0" class="battle-party-slot image-fallback" data-fallback="-"><img id="battle-party-img-0" alt=""><span>선봉</span></div>
@@ -3359,7 +3368,8 @@
             showBattleScreen() {
                 this.showScreen('screen-battle');
                 const artifactBtn = document.getElementById('btn-battle-artifact-check');
-                if (artifactBtn) artifactBtn.style.display = this.state.mode === 'artifact_chaos' ? 'block' : 'none';
+                const isArtifactMode = ['artifact', 'artifact_chaos', 'artifact_reserve'].includes(this.state.mode);
+                if (artifactBtn) artifactBtn.style.display = isArtifactMode ? 'inline-block' : 'none';
             },
             clearBattleLog() { document.getElementById('battle-log').innerHTML = ""; },
             renderBattleView() { this.renderBattlefield(); },
@@ -5348,6 +5358,25 @@
                 const title = document.getElementById('artifact-check-title');
 
                 if (this.state.mode === 'artifact_reserve') {
+                    const inBattle = this.battle && !this.battle.isFinished;
+                    if (inBattle) {
+                        if (title) title.innerText = '현재 활성 아티팩트';
+                        if (owned.length === 0) {
+                            list.innerHTML = '<div style="color:#aaa; text-align:center;">활성화된 아티팩트가 없습니다.</div>';
+                        } else {
+                            list.innerHTML = owned.map(id => {
+                                const art = GameUtils.getArtifactById(id);
+                                if (!art) return '';
+                                return `<div style="margin-bottom:8px; padding:8px; background:#333; border-radius:5px; border-left: 3px solid #ffd700;">
+                                    <b style="color:#ffd700;">${art.name}</b><br>
+                                    <span style="color:#ccc;">${art.desc}</span>
+                                </div>`;
+                            }).join('');
+                        }
+                        document.getElementById('modal-artifact-check').classList.add('active');
+                        return;
+                    }
+
                     const reservePool = this.state.artifactReservePool || [];
                     const activeCount = owned.length;
                     if (title) title.innerText = `아티팩트 풀 (${activeCount}/${GAME_CONSTANTS.MAX_ARTIFACTS} 활성)`;


### PR DESCRIPTION
## 💡 개요 (Summary)
전투 화면 상단 헤더(`.battle-header`)에서 아티팩트 확인 버튼과 필드 버프의 위치를 정돈하여, 모드별 위치 흔들림(Layout Shift) 및 비일관성을 해결했습니다.

---

## 🔍 변경 전 문제점 (Problem)
1. **아티팩트 확인 버튼의 비일관성:** `artifact_chaos` 모드에서만 전투 중 확인 버튼이 노출되고, `artifact` 및 `artifact_reserve` 모드에서는 전투 중 아티팩트 확인이 불가능했음.
2. **필드 버프 변화에 따른 흔들림(Layout Shift):** 기존에 아티팩트 확인 버튼이 중앙에 위치하여, 우측 필드 버프의 개수가 변할 때마다 버튼 위치가 좌우로 밀려나는 현상 발생.
3. **모드 간 필드 버프 위치 혼란:** 아티팩트 버튼 유무에 따라 필드 버프 위치가 중앙/우측으로 바뀌어 시각적 일관성 저하.

---

## 🛠 주요 변경 사항 (Changes)
1. **전투 헤더 2분할 고정 레이아웃 적용:**
   - **좌측 (`.battle-header-left` / `.battle-meta-row`):** `Turn` 표시 바로 우측에 `[아티팩트 확인]` 버튼을 배치하여 좌측 그룹으로 고정.
   - **우측 (`#field-buff-box`):** 필드 버프를 항상 우측 끝 정렬로 고정하고, `text-overflow: ellipsis` 및 `flex: 1`을 적용하여 텍스트가 길어져도 버튼을 침범하거나 줄바꿈되지 않도록 처리.
2. **모든 아티팩트 모드에서 전투 중 아티팩트 확인 지원:**
   - `showBattleScreen()`에서 `artifact`, `artifact_chaos`, `artifact_reserve` 3개 모드 모두 전투 중 아티팩트 확인 버튼이 노출되도록 통일.
3. **`artifact_reserve` 전투 중 안전 처리 (Read-Only):**
   - 전투 진행 중(`this.battle && !this.battle.isFinished`)일 때 아티팩트 확인 모달을 열면, 수동 토글 대신 현재 전투에 적용된 활성 아티팩트 목록만 읽기 전용으로 안전하게 표시.

---

## ✅ 검증 (Verification)
- 일반 모드: 좌측 `Turn`, 우측 `[필드 버프]` 정상 표시 확인.
- 아티팩트 관련 모드(`artifact`, `artifact_chaos`, `artifact_reserve`): 좌측 `Turn` 옆에 `[아티팩트 확인]` 버튼 노출, 우측 끝에 `[필드 버프]` 고정 정렬 확인.
- 필드 버프 추가/삭제 시에도 좌측 `Turn` 및 `[아티팩트 확인]` 위치가 전혀 흔들리지 않고 유지됨 확인.
- `artifact_reserve` 전투 중 모달 열람 시 활성 아티팩트 목록이 읽기 전용으로 정상 표시됨 확인.
