### PR TITLE
[Feat] 실전마법연습 파트 5 복습 해설 화면 루미 질문하기 API 연동 지원

### DIFF
--- a/card/api.js
+++ b/card/api.js
@@ -688,11 +688,13 @@ function buildToeicReviewSource(toeicSession, explanationText) {
     if (!toeicSession || !toeicSession.set) return null;
 
     const set = toeicSession.set;
-    const partLabel = set.type === 'part6'
-        ? '파트 6'
-        : set.type === 'part7'
-            ? '파트 7'
-            : '문제';
+    const partLabel = set.type === 'part5'
+        ? '파트 5'
+        : set.type === 'part6'
+            ? '파트 6'
+            : set.type === 'part7'
+                ? '파트 7'
+                : '문제';
 
     return {
         setId: set.id,
@@ -768,7 +770,7 @@ const LumiQuestionRuntime = {
     },
 
     shouldShowToeicQuestionButton(set) {
-        return !!set && (set.type === 'part6' || set.type === 'part7');
+        return !!set && ['part5', 'part6', 'part7'].includes(set.type);
     },
 
     ensureGeneralSession(sessionStore) {

--- a/card_remaster/api.js
+++ b/card_remaster/api.js
@@ -685,11 +685,13 @@ function buildToeicReviewSource(toeicSession, explanationText) {
     if (!toeicSession || !toeicSession.set) return null;
 
     const set = toeicSession.set;
-    const partLabel = set.type === 'part6'
-        ? '파트 6'
-        : set.type === 'part7'
-            ? '파트 7'
-            : '문제';
+    const partLabel = set.type === 'part5'
+        ? '파트 5'
+        : set.type === 'part6'
+            ? '파트 6'
+            : set.type === 'part7'
+                ? '파트 7'
+                : '문제';
 
     return {
         setId: set.id,
@@ -765,7 +767,7 @@ const LumiQuestionRuntime = {
     },
 
     shouldShowToeicQuestionButton(set) {
-        return !!set && (set.type === 'part6' || set.type === 'part7');
+        return !!set && ['part5', 'part6', 'part7'].includes(set.type);
     },
 
     ensureGeneralSession(sessionStore) {


### PR DESCRIPTION
## 💡 개요 (Summary)
실전마법연습(TOEIC) 종료 후 복습 및 해설 화면에서 기존에 파트 6 및 파트 7에만 제공되던 **루미 AI 질문하기(Gemini API 연동) 기능**을 **파트 5**에서도 동일하게 이용할 수 있도록 확장했습니다.

---

## 🔍 변경 전 문제점 (Problem)
- 파트 5 세트(단문 빈칸 채우기) 학습 종료 후 복습 허브에서 `해설`을 열람할 때, `LumiQuestionRuntime.shouldShowToeicQuestionButton(set)`에서 파트 6/7만 허용하도록 하드코딩되어 있어 `[질문하기]` 버튼이 숨겨져 있었습니다.
- 이로 인해 파트 5의 문법 해설이나 선지 차이, 오답 원인 등에 대해 루미에게 실시간으로 질문할 수 없었습니다.

---

## 🛠 주요 변경 사항 (Changes)
1. **파트 5 질문 버튼 활성화 (`shouldShowToeicQuestionButton`):**
   - `card/api.js` 및 `card_remaster/api.js`에서 파트 5(`part5`)도 질문 버튼 노출 대상에 포함.
2. **파트 5 컨텍스트 라벨 매핑 보정 (`buildToeicReviewSource`):**
   - 세트 정보 생성 시 파트 5의 라벨을 `파트 5`로 명시하여, AI가 파트 5 문법 퀴즈 컨텍스트를 정확하게 인지하도록 개선.

```diff
-    shouldShowToeicQuestionButton(set) {
-        return !!set && (set.type === 'part6' || set.type === 'part7');
-    },
+    shouldShowToeicQuestionButton(set) {
+        return !!set && ['part5', 'part6', 'part7'].includes(set.type);
+    },
```

---

## ✅ 검증 (Verification)
- 파트 5 세트(1강 등) 학습 완료 후 `복습 및 해설 보기` -> `해설` 진입 시 `[질문하기]` 버튼이 정상 노출됨을 확인.
- `[질문하기]` 클릭 시 파트 5 문항, 선지, 정답, 유저 답안, 해설 텍스트가 정상적으로 프롬프트 컨텍스트에 주입되어 AI 대화가 원활히 작동함을 확인.
- 질문 모달 종료 후 복습 허브로 정상 복귀 및 데이트 이벤트 연동이 정상 유지됨을 확인.
