### PR TITLE
fix(card): 아티팩트 리저브 패배 시 비정상 세이브 제거 및 혼돈의 축복 보존 정합성 수정

### DIFF
--- a/PR_DRAFT.md
+++ b/PR_DRAFT.md
@@ -1,39 +1,33 @@
 # Title
-feat(card): 포춘쿠키 LC 파트 3/4 (다중 문제) 구현 및 안정성 개선
+fix(card): 아티팩트 리저브 패배 시 비정상 세이브 제거 및 혼돈의 축복 보존 정합성 수정
 
 ## Summary
 
-포춘쿠키 기능에 TOEIC Part 3(대화) 및 Part 4(담화) 등 다중 문제(Multi-Question)를 지원하도록 기능을 확장하고, 오디오 재생 및 모달 전환 관련 로직의 안정성을 대폭 개선했습니다.
-또한, 포춘쿠키 API의 응답 처리 과정 및 UI 관련 중요한 버그를 수정했습니다.
+아티팩트 리저브 모드(`artifact_reserve`)에서 전투 패배 시 의도치 않게 세이브가 실행되어 아티팩트 사용 횟수와 리셋된 혼돈의 축복 상태가 디스크에 덮어써지던 버그를 수정했습니다.
 
-### 1. 리스닝 데이터 확장 (`listening_data.js`)
-- **Part 3 & 4 데이터 추가**: 총 8세트의 복수 문항 지문 추가 (DAY 10, DAY 16).
-- **상세 데이터 구조**: 실제 시험 환경과 동일하게 구현하기 위해 각 질문(`questionText`, `questionTextKo`)과 보기(`options`, `optionsKo`), 그리고 전체 스크립트(`passage`, `passageKo`)를 모두 포함하도록 스키마를 고도화했습니다.
+### 1. 주요 원인 분석
+- `loseBattle()` 실행 시 메모리(RAM) 상에서 혼돈의 축복을 3회 및 빈 버프 목록으로 리셋한 직후 `consumeArtifactReserveUsesForBattle()`를 호출했습니다.
+- `consumeArtifactReserveUsesForBattle()` 내부에서 무조건 `this.saveGame(false)`를 호출함에 따라:
+  1. **아티팩트 잔여 횟수 소모만 영구 저장**되고, 카드의 사망(`handlePermadeath`)은 저장되지 않는 기형적 비대칭 세이브가 발생했습니다.
+  2. 전투 전 저장해 둔 **혼돈의 축복 당첨 버프(`chaosBuffs`) 및 잔여 횟수(`chaosBlessingUses`)가 리셋된 상태(3회/빈 목록)로 디스크에 덮어쓰기 저장**되었습니다.
+- 이로 인해 다른 모드와 달리 아티팩트 리저브에서만 패배 후 이어하기 시 전투 전 저장했던 축복 및 아티팩트 상태가 소실되는 문제가 있었습니다.
 
-### 2. UI 모달 구조 개편 (`index.html`)
-기존 2단계(문제 풀이 → 운세 결과)로 구성되었던 모달에 **다중 문제 전용 3단계 Phase**를 추가로 구현했습니다.
-- `fortune-multi-hub-phase`: 오디오 재생 및 개별 문제 진입을 담당하는 허브 화면.
-- `fortune-multi-q-phase`: 실제 영어 질문과 4지선다 보기가 렌더링되는 단일 문제 풀이 화면.
-- `fortune-explanation-phase`: 전체 문제 풀이 완료 후 지문, 해석, 정오답을 스크롤로 읽어보는 해설 화면.
-- **초상화 위치 수정**: 불필요한 해설 화면(explanation phase)에서 루미 초상화를 제거하고, 대사를 출력하는 최종 운세 결과 화면(result phase)으로 초상화를 이동했습니다.
+### 2. 변경 내용
+- **`consumeArtifactReserveUsesForBattle(autoSave = true)` 파라미터화**:
+  - `card/rpg_features.js` 및 `card_remaster/rpg_features.js`의 `consumeArtifactReserveUsesForBattle`에 `autoSave` 매개변수를 추가(기본값 `true`).
+  - `loseBattle()`에서는 `this.consumeArtifactReserveUsesForBattle(false)`로 호출하여 패배 시 일체의 디스크 저장이 발생하지 않도록 차단.
+- **모드 간 세이브 정책 정합성 통일**:
+  - 다른 일반/챌린지 모드와 동일하게 패배 시에는 디스크 저장을 하지 않음으로써, 패배 후 재로드 시 전투 전 세이브해 둔 혼돈의 축복 상태(버프 목록 및 잔여 횟수)와 아티팩트 잔여 횟수가 온전히 보존됩니다.
+  - 승리 시(`winBattle`)에는 기존대로 아티팩트 소모와 진행 상황이 정상적으로 저장됩니다.
 
-### 3. 복수 문제 진행 및 피드백 로직 (`fortune_cookie.js`)
-- `currentMultiSession` 상태 객체를 도입하여 하나의 지문에 딸린 여러 문제의 진행 상황(`qIndex`)과 풀이 이력(`results`)을 안전하게 관리.
-- 문제 풀이 시 즉각적인 피드백(정/오답)을 표시한 뒤, 다음 문제가 있으면 허브로 돌아가 오디오를 재청취할 수 있게 하고, 모든 문제를 풀면 해설 창으로 이동시킵니다.
-- **통합 스크롤 해설**: 한 화면에서 영문 스크립트, 한글 해석, 각 문항별 내 선택 및 정답 여부를 한눈에 확인할 수 있는 전체 스크롤 뷰 구현.
-- **오디오 UX 개선**: 오디오 버튼 클릭 시 무조건 재시작하던 것을 **재생/일시정지 토글** 형태로 변경하여 청취 편의성을 높였습니다.
+### 3. 검증 및 테스트 (`scripts/verify_card_combat_regressions.js`)
+- `consumeArtifactReserveUsesForBattle(false)` 호출 시 `saveGame`이 호출되지 않음을 확인하는 단위 테스트 추가.
+- `consumeArtifactReserveUsesForBattle(true)` 호출 시 `saveGame`이 정상 동작함을 확인하는 단위 테스트 추가.
+- `loseBattle()` 실행 시 `artifact_reserve` 모드에서 세이브가 발생하지 않음을 보증하는 회귀 테스트 추가.
 
-### 4. 안정성 (Robustness) 및 버그 픽스
-- **[핵심 Bug Fix] API Key 연동 수정** (`fortune_cookie.js`): 포춘쿠키가 존재하지 않는 `localStorage` 키(`gemini_api_key`)에서 API 키를 읽다가 `null`을 반환받아 API 호출 자체를 건너뛰던 버그를 수정했습니다. 다른 모든 기능과 동일하게 `Storage.keys.API_KEY`(`cardRpgApiKey`)를 참조하도록 통일했습니다.
-- **Pro 모델 응답 파싱 보완** (`api.js` `generateContent`): `gemini-2.5-pro`(thinkingBudget 방식)를 사용할 때 응답의 `parts`에 `thought: true` 파트가 포함될 수 있어, 기존의 `.filter(part => typeof part.text === 'string')` 조건에 `!part.thought` 조건을 추가하여 사고 과정이 본문에 섞이지 않도록 처리했습니다. (thinkingLevel 방식을 사용하는 다른 Flash 계열 호출부는 해당 없음.)
-- **Phase 중복 렌더링 방지**: 재방문 시 `showFortunePhase()`가 직접 호출될 때 이전 Phase들이 숨김 처리되지 않아 UI가 겹칠 수 있는 취약점을 명시적 `display: none` 선언으로 방어했습니다.
-- **타이머 오동작 방지**: 답안을 선택하고 1.5초 대기 중 모달을 강제로 닫을 경우, 백그라운드 `setTimeout` 콜백이 모달을 다시 여는 버그를 `clearTimeout`으로 수정했습니다.
-- 기존 파트 2 분기 코드 내의 데드코드를 제거하여 유지보수성을 높였습니다.
+## Verification Results
+- `npm run lint:card` 통과
+- `npm run test:card:smoke` 통과
+- `npm run test:card:browser` (Playwright 브라우저 통합 테스트) 통과
+- 전투/모드/세이브 사이드이펙트 없음 확인
 
-## Testing
-- `npm run verify` 통과 (Card smoke verification + lint checks)
-- 다중 문제 진행, 오디오 재생/일시정지, 타이머 강제 종료 로직 수동 검증 완료.
-- API 키 로드 및 운세 응답 생성 수동 검증 완료.
-
-## Notes
-- 당일 이미 포춘쿠키를 사용한 상태에서 다시 진입할 경우, 해설이나 문제를 다시 보여주지 않고 즉시 운세 결과로 직행하는 기존의 기획 의도는 그대로 보존되었습니다.

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -1167,7 +1167,7 @@
     },
 
 
-    consumeArtifactReserveUsesForBattle() {
+    consumeArtifactReserveUsesForBattle(autoSave = true) {
         if (this.state.mode !== 'artifact_reserve') return [];
 
         const entries = this.state.artifactReservePool || [];
@@ -1181,7 +1181,9 @@
             entry.remainingUses--;
         });
         this.state.artifacts = [];
-        this.saveGame(false);
+        if (autoSave && typeof this.saveGame === 'function') {
+            this.saveGame(false);
+        }
         return activeIds;
     },
 
@@ -1934,7 +1936,7 @@
         this.state.chaosBuffs = [];
         this.state.activeChaosBlessing = [];
         this.state.activeSageBlessing = [];
-        this.consumeArtifactReserveUsesForBattle();
+        this.consumeArtifactReserveUsesForBattle(false);
 
         let deadMsg = this.handlePermadeath(this.battle.players);
         if (this.state.mode === 'dream_corridor') {

--- a/card_remaster/rpg_features.js
+++ b/card_remaster/rpg_features.js
@@ -1167,7 +1167,7 @@
     },
 
 
-    consumeArtifactReserveUsesForBattle() {
+    consumeArtifactReserveUsesForBattle(autoSave = true) {
         if (this.state.mode !== 'artifact_reserve') return [];
 
         const entries = this.state.artifactReservePool || [];
@@ -1181,7 +1181,9 @@
             entry.remainingUses--;
         });
         this.state.artifacts = [];
-        this.saveGame(false);
+        if (autoSave && typeof this.saveGame === 'function') {
+            this.saveGame(false);
+        }
         return activeIds;
     },
 
@@ -1936,7 +1938,7 @@
         this.state.chaosBuffs = [];
         this.state.activeChaosBlessing = [];
         this.state.activeSageBlessing = [];
-        this.consumeArtifactReserveUsesForBattle();
+        this.consumeArtifactReserveUsesForBattle(false);
 
         let deadMsg = this.handlePermadeath(this.battle.players);
         if (this.state.mode === 'dream_corridor') {

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -456,6 +456,33 @@ function run() {
     reserveHost.state.artifactReservePool[0].remainingUses = 0;
     assert.strictEqual(reserveHost.toggleArtifactReserveArtifact(reserveIds[0]), false);
 
+    // Verify autoSave control in consumeArtifactReserveUsesForBattle
+    let saveGameCallCount = 0;
+    reserveHost.saveGame = () => { saveGameCallCount++; };
+    reserveHost.state.artifactReservePool[1].remainingUses = 2;
+    reserveHost.state.artifacts = [reserveIds[1]];
+    assert.deepStrictEqual(reserveHost.consumeArtifactReserveUsesForBattle(false), [reserveIds[1]]);
+    assert.strictEqual(reserveHost.state.artifactReservePool[1].remainingUses, 1);
+    assert.strictEqual(saveGameCallCount, 0, 'consumeArtifactReserveUsesForBattle(false) must not call saveGame');
+
+    reserveHost.state.artifacts = [reserveIds[1]];
+    assert.deepStrictEqual(reserveHost.consumeArtifactReserveUsesForBattle(true), [reserveIds[1]]);
+    assert.strictEqual(reserveHost.state.artifactReservePool[1].remainingUses, 0);
+    assert.strictEqual(saveGameCallCount, 1, 'consumeArtifactReserveUsesForBattle(true) must call saveGame');
+
+    // Verify loseBattle does NOT save game in artifact_reserve mode
+    saveGameCallCount = 0;
+    reserveHost.battle = { isFinished: false, players: [] };
+    reserveHost.cleanupTranscendenceCards = () => '';
+    reserveHost.handlePermadeath = () => '';
+    reserveHost.openInfoModal = quiet;
+    reserveHost.state.chaosBlessingUses = 2;
+    reserveHost.state.chaosBuffs = [{ id: 'test', multiplier: 0.2 }];
+    reserveHost.loseBattle();
+    assert.strictEqual(saveGameCallCount, 0, 'loseBattle in artifact_reserve must not call saveGame on defeat');
+    assert.strictEqual(reserveHost.state.chaosBlessingUses, GAME_CONSTANTS.DEFAULT_BLESSING_USES);
+    assert.strictEqual(reserveHost.state.chaosBuffs.length, 0);
+
     const artifactChaosHost = {
       global: { unlocked_divine_artifacts: ['divine_flora'], unlocked_bonus_cards: [] },
       state: {


### PR DESCRIPTION
# Title
fix(card): 아티팩트 리저브 패배 시 비정상 세이브 제거 및 혼돈의 축복 보존 정합성 수정

## Summary

아티팩트 리저브 모드(`artifact_reserve`)에서 전투 패배 시 의도치 않게 세이브가 실행되어 아티팩트 사용 횟수와 리셋된 혼돈의 축복 상태가 디스크에 덮어써지던 버그를 수정했습니다.

### 1. 주요 원인 분석
- `loseBattle()` 실행 시 메모리(RAM) 상에서 혼돈의 축복을 3회 및 빈 버프 목록으로 리셋한 직후 `consumeArtifactReserveUsesForBattle()`를 호출했습니다.
- `consumeArtifactReserveUsesForBattle()` 내부에서 무조건 `this.saveGame(false)`를 호출함에 따라:
  1. **아티팩트 잔여 횟수 소모만 영구 저장**되고, 카드의 사망(`handlePermadeath`)은 저장되지 않는 기형적 비대칭 세이브가 발생했습니다.
  2. 전투 전 저장해 둔 **혼돈의 축복 당첨 버프(`chaosBuffs`) 및 잔여 횟수(`chaosBlessingUses`)가 리셋된 상태(3회/빈 목록)로 디스크에 덮어쓰기 저장**되었습니다.
- 이로 인해 다른 모드와 달리 아티팩트 리저브에서만 패배 후 이어하기 시 전투 전 저장했던 축복 및 아티팩트 상태가 소실되는 문제가 있었습니다.

### 2. 변경 내용
- **`consumeArtifactReserveUsesForBattle(autoSave = true)` 파라미터화**:
  - `card/rpg_features.js` 및 `card_remaster/rpg_features.js`의 `consumeArtifactReserveUsesForBattle`에 `autoSave` 매개변수를 추가(기본값 `true`).
  - `loseBattle()`에서는 `this.consumeArtifactReserveUsesForBattle(false)`로 호출하여 패배 시 일체의 디스크 저장이 발생하지 않도록 차단.
- **모드 간 세이브 정책 정합성 통일**:
  - 다른 일반/챌린지 모드와 동일하게 패배 시에는 디스크 저장을 하지 않음으로써, 패배 후 재로드 시 전투 전 세이브해 둔 혼돈의 축복 상태(버프 목록 및 잔여 횟수)와 아티팩트 잔여 횟수가 온전히 보존됩니다.
  - 승리 시(`winBattle`)에는 기존대로 아티팩트 소모와 진행 상황이 정상적으로 저장됩니다.

### 3. 검증 및 테스트 (`scripts/verify_card_combat_regressions.js`)
- `consumeArtifactReserveUsesForBattle(false)` 호출 시 `saveGame`이 호출되지 않음을 확인하는 단위 테스트 추가.
- `consumeArtifactReserveUsesForBattle(true)` 호출 시 `saveGame`이 정상 동작함을 확인하는 단위 테스트 추가.
- `loseBattle()` 실행 시 `artifact_reserve` 모드에서 세이브가 발생하지 않음을 보증하는 회귀 테스트 추가.

## Verification Results
- `npm run lint:card` 통과
- `npm run test:card:smoke` 통과
- `npm run test:card:browser` (Playwright 브라우저 통합 테스트) 통과
- 전투/모드/세이브 사이드이펙트 없음 확인

