### PR TITLE
[Draft] feat(card): 엔드리스 퍼펙트플랜 모드 추가

### DIFF
--- a/card/battle_runtime.js
+++ b/card/battle_runtime.js
@@ -82,7 +82,7 @@ function buildBattleEnemy(rpg) {
     let steps = 0;
     if (rpg.state.mode === 'puzzle' || rpg.state.mode === 'artifact_chaos') {
         steps = 2;
-    } else if (['artifact', 'artifact_reserve', 'flood', 'curse'].includes(rpg.state.mode)) {
+    } else if (['artifact', 'artifact_reserve', 'flood', 'curse', 'perfect_plan'].includes(rpg.state.mode)) {
         if (rpg.state.gameType === 'challenge' || rpg.state.gameType === 'endless') {
             steps = 1;
         }
@@ -201,6 +201,13 @@ const BattleRuntime = {
     startBattleInit(rpg) {
         if (rpg.state.mode === 'artifact_reserve' && rpg.state.artifactReserveDraft && rpg.state.artifactReserveDraft.active) {
             return rpg.showAlert("아티팩트 리저브 선택을 먼저 완료해주세요.");
+        }
+
+        if (rpg.state.mode === 'perfect_plan' && rpg.state.perfectPlanDraft && rpg.state.perfectPlanDraft.active) {
+            return rpg.showAlert('퍼펙트플랜 카드 선택을 먼저 완료해주세요.');
+        }
+        if (rpg.state.mode === 'perfect_plan' && (!rpg.state.factoryPool || rpg.state.factoryPool.length === 0)) {
+            return rpg.showAlert('퍼펙트플랜 카드 선택을 먼저 완료해주세요.');
         }
 
         if (rpg.state.mode === 'puzzle') {

--- a/card/index.html
+++ b/card/index.html
@@ -1215,6 +1215,18 @@
                 <button class="menu-btn" onclick="RPG.toMenu()" style="width:200px;">나가기</button>
             </div>
         </div>
+        <div id="screen-perfect-plan-draft" class="screen">
+            <h3 style="margin:5px 0;">퍼펙트플랜 (<span id="perfect-plan-step-text">전설 0/10</span>)</h3>
+            <p id="perfect-plan-help" style="text-align:center; margin-bottom:5px; font-size:0.9rem; color:#ccc;">
+                해금된 전설 카드에서 10장을 선택하세요.
+            </p>
+            <div id="perfect-plan-grid" class="bonus-pool-grid" style="flex:1; overflow-y:auto; padding:5px;"></div>
+            <div style="margin-top:auto; margin-bottom:40px; padding-bottom:10px; display:flex; gap:10px; justify-content:center;">
+                <button class="menu-btn" onclick="RPG.resetPerfectPlanCurrentGrade()" style="width:100px;">초기화</button>
+                <button class="menu-btn" id="btn-perfect-plan-prev" onclick="RPG.goPerfectPlanPrevStep()" style="width:100px;">이전</button>
+                <button class="menu-btn" id="btn-perfect-plan-next" onclick="RPG.confirmPerfectPlanCurrentGrade()" style="width:100px; background:#1b5e20; border-color:#4caf50;">다음</button>
+            </div>
+        </div>
         <div id="screen-draft" class="screen">
             <h3 style="margin:5px 0;">덱 빌딩 (<span id="draft-round-text">선봉</span> 선발)</h3>
             <div style="text-align:center; margin-bottom:2px;">
@@ -3197,11 +3209,12 @@
                     { id: 'draft', name: '드래프트', desc: '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
                     { id: 'factory', name: '팩토리', desc: '시작 시 40장의 카드를 번들 단위로 드래프트하여 덱 풀 구성.\n(성공조건: 24 스테이지 / 패배 시 데이터 삭제)' },
                     { id: 'artifact', name: '아티팩트', desc: '매 보스(창조신) 클리어 시 아티팩트 획득 (최대 4개). 아티팩트 효과로 전투를 유리하게! 강화된 적 출현.\n(성공조건: 30 스테이지)' },
-                    { id: 'artifact_reserve', name: '아티팩트리저브', desc: '아티팩트 세트 선택 4회 반복으로 12개 풀 구성. 각 아티팩트는 2회 사용 가능, 전투 전 최대 4개 수동 활성화. 강화된 적 출현.\n(성공조건: 24 스테이지)' }
+                    { id: 'artifact_reserve', name: '아티팩트리저브', desc: '아티팩트 세트 선택 4회 반복으로 12개 풀 구성. 각 아티팩트는 2회 사용 가능, 전투 전 최대 4개 수동 활성화. 강화된 적 출현.\n(성공조건: 24 스테이지)' },
+                    { id: 'perfect_plan', name: '퍼펙트플랜', desc: '해금된 전설/에픽/레어/노말에서 각 10장씩 골라 40장 전용 풀을 만든 뒤 오리진과 같이 진행. 강화된 적 출현(1.1배).\n(성공조건: 없음 / 무한)' }
                 ];
 
                 if (this.tempGameType === 'endless') {
-                    MODES = MODES.filter(m => ['origin', 'draft', 'chaos', 'artifact', 'artifact_reserve'].includes(m.id));
+                    MODES = MODES.filter(m => ['origin', 'draft', 'chaos', 'artifact', 'artifact_reserve', 'perfect_plan'].includes(m.id));
                     MODES.forEach(m => {
                         if (m.id === 'chaos') m.desc = '매 전투 덱/인벤토리 초기화. 무작위 15장 풀에서 뽑기 진행.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
                         if (m.id === 'draft') m.desc = '뽑기 대신 덱 빌딩(드래프트)으로 3명을 선발하여 전투.\n(성공조건: 없음 / 무한 / 패배 시 데이터 삭제)';
@@ -3216,10 +3229,10 @@
                         });
                     }
                 } else if (this.tempGameType === 'challenge') {
-                    MODES = MODES.filter(m => !['origin', 'archive'].includes(m.id));
+                    MODES = MODES.filter(m => !['origin', 'archive'].includes(m.id) && m.id !== 'perfect_plan');
                 } else {
                     // 신규 아티팩트 변형은 챌린지 전용이며, 리저브만 엔드리스에도 제공한다.
-                    MODES = MODES.filter(m => !['artifact_chaos', 'artifact_reserve'].includes(m.id));
+                    MODES = MODES.filter(m => !['artifact_chaos', 'artifact_reserve'].includes(m.id) && m.id !== 'perfect_plan');
                 }
 
                 MODES.forEach(m => {
@@ -3230,7 +3243,7 @@
                     btn.innerText = m.name;
                     btn.id = `mode-btn-${m.id}`;
 
-                    const isUnlocked = m.id === 'dream_corridor' || this.global.unlocked_modes.includes(m.id);
+                    const isUnlocked = m.id === 'dream_corridor' || m.id === 'perfect_plan' || this.global.unlocked_modes.includes(m.id);
                     if (isUnlocked) {
                         const hardCleared = this.global.hardChallengeCleared && this.global.hardChallengeCleared[m.id];
                         if (this.tempGameType === 'challenge' && hardCleared) {
@@ -3290,7 +3303,7 @@
                         () => {
                             this.initNewGame(this.selectedModeId);
                             modal.classList.remove('active');
-                            if (!['factory', 'artifact_reserve'].includes(this.selectedModeId)) {
+                            if (!['factory', 'artifact_reserve', 'perfect_plan'].includes(this.selectedModeId)) {
                                 this.toMenu();
                             }
                         }
@@ -3301,6 +3314,9 @@
             },
 
             toMenu() {
+                if (this.state.mode === 'perfect_plan' && this.state.perfectPlanDraft && this.state.perfectPlanDraft.active) {
+                    return this.openPerfectPlanDraft();
+                }
                 this.clearToeicLumiQuestionSession({ abort: true, clearCurrentToeic: true });
                 this.showScreen('screen-menu');
                 document.getElementById('ui-tickets').innerText = this.state.tickets;
@@ -3389,8 +3405,8 @@
                 const mode = this.state.mode;
                 let pool;
 
-                if (mode === 'factory' && this.state.factoryPool && this.state.factoryPool.length > 0) {
-                    // 팩토리: 드래프트된 40장 한정
+                if (GameUtils.usesLimitedCardPool(mode) && this.state.factoryPool && this.state.factoryPool.length > 0) {
+                    // 팩토리/퍼펙트플랜: 드래프트된 40장 한정
                     pool = GameUtils.buildCardPool(this.global, {
                         factoryPool: this.state.factoryPool,
                         specialCardSelections: this.state.activeSpecialCardSelections
@@ -3424,7 +3440,7 @@
                     suffering: '고난의 여정', puzzle: '퍼즐', archive: '아카이브',
                     curse: '저주의 증폭', flood: '축복의 범람', chaos: '카오스', artifact_chaos: '아티팩트카오스',
                     draft: '드래프트', factory: '팩토리', artifact: '아티팩트', artifact_reserve: '아티팩트리저브',
-                    overdrive: '오버드라이브', dream_corridor: '꿈의회랑' };
+                    overdrive: '오버드라이브', dream_corridor: '꿈의회랑', perfect_plan: '퍼펙트플랜' };
                 const label = modeLabel[mode] || mode;
                 document.getElementById('card-pool-info').innerText =
                     `현재 모드: ${label} | 풀 카드 수: ${pool.length}장`;
@@ -3608,7 +3624,7 @@
                 let pool = GameUtils.buildCardPool(this.global, {
                     excludeTranscendence: true,
                     excludeEvent: true,
-                    factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
+                    factoryPool: GameUtils.usesLimitedCardPool(this.state.mode) ? this.state.factoryPool : null,
                     activeBonusPoolIds: this.state.activeBonusPoolIds,
                     specialCardSelections: this.state.activeSpecialCardSelections,
                     maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
@@ -3736,7 +3752,7 @@
                 const puzzleConfig = GAME_CONSTANTS.PUZZLE || {};
                 const count = puzzleConfig.PIECE_COUNT || 36;
                 const pool = GameUtils.buildCardPool(this.global, {
-                    factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
+                    factoryPool: GameUtils.usesLimitedCardPool(this.state.mode) ? this.state.factoryPool : null,
                     activeBonusPoolIds: this.state.activeBonusPoolIds,
                     specialCardSelections: this.state.activeSpecialCardSelections
                 });
@@ -3818,7 +3834,7 @@
 
                 // Build Pool
                 let pool = GameUtils.buildCardPool(this.global, {
-                    factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
+                    factoryPool: GameUtils.usesLimitedCardPool(this.state.mode) ? this.state.factoryPool : null,
                     activeBonusPoolIds: this.state.activeBonusPoolIds,
                     specialCardSelections: this.state.activeSpecialCardSelections
                 }).filter(card => card.grade === grade);
@@ -3831,7 +3847,7 @@
                     console.error("Empty pool for grade: " + grade);
                     grade = 'normal';
                     pool = GameUtils.buildCardPool(this.global, {
-                        factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
+                        factoryPool: GameUtils.usesLimitedCardPool(this.state.mode) ? this.state.factoryPool : null,
                         activeBonusPoolIds: this.state.activeBonusPoolIds,
                         specialCardSelections: this.state.activeSpecialCardSelections
                     }).filter(card => card.grade === 'normal');
@@ -4272,6 +4288,165 @@
                 };
 
                 this.renderCardList('collection-grid', pool, (id) => this.showCardInfo(id));
+            },
+
+            // --- Perfect Plan Draft Logic ---
+            openPerfectPlanDraft() {
+                this.showScreen('screen-perfect-plan-draft');
+                this.renderPerfectPlanDraft();
+            },
+
+            renderPerfectPlanDraft() {
+                const draft = this.state.perfectPlanDraft;
+                if (!draft) return;
+                const grades = (typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.PERFECT_PLAN)
+                    ? GAME_CONSTANTS.PERFECT_PLAN.GRADES
+                    : ['legend', 'epic', 'rare', 'normal'];
+                const gradeNames = { legend: '전설', epic: '에픽', rare: '레어', normal: '노말' };
+                const currentGrade = grades[draft.step] || 'legend';
+                const gradeName = gradeNames[currentGrade] || currentGrade;
+                const pool = this.getPerfectPlanGradePool(currentGrade);
+                const required = this.getPerfectPlanRequiredCount(currentGrade);
+
+                const stepText = document.getElementById('perfect-plan-step-text');
+                const helpText = document.getElementById('perfect-plan-help');
+                const grid = document.getElementById('perfect-plan-grid');
+                const prevBtn = document.getElementById('btn-perfect-plan-prev');
+                const nextBtn = document.getElementById('btn-perfect-plan-next');
+
+                if (stepText) {
+                    stepText.innerText = `${gradeName} ${draft.currentGradeSelected.length}/${required}`;
+                }
+                if (helpText) {
+                    if (draft.step === grades.length - 1 && draft.currentGradeSelected.length === required) {
+                        helpText.innerText = '다음을 누르면 모험이 시작됩니다.';
+                    } else {
+                        helpText.innerText = `해금된 ${gradeName} 카드에서 ${required}장을 선택하세요.`;
+                    }
+                }
+                if (prevBtn) {
+                    prevBtn.style.display = draft.step > 0 ? 'inline-block' : 'none';
+                }
+                if (nextBtn) {
+                    nextBtn.innerText = draft.step === grades.length - 1 ? '시작' : '다음';
+                }
+
+                if (!grid) return;
+                grid.innerHTML = '';
+
+                const selectedSet = new Set(draft.currentGradeSelected);
+
+                pool.forEach(card => {
+                    const isChecked = selectedSet.has(card.id);
+                    const item = document.createElement('label');
+                    item.className = `bonus-pool-item${isChecked ? '' : ' is-disabled'}`;
+                    item.innerHTML = `
+                        <div class="bonus-pool-name">${card.name}</div>
+                        <div class="bonus-pool-grade">${card.grade.toUpperCase()} / ${card.role}</div>
+                        <div class="bonus-pool-toggle">
+                            <input type="checkbox" ${isChecked ? 'checked' : ''}>
+                            <span>선택</span>
+                        </div>
+                    `;
+                    item.insertBefore(ImageAssets.createPortrait(card), item.firstChild);
+
+                    const checkbox = item.querySelector('input');
+                    checkbox.addEventListener('change', () => {
+                        this.togglePerfectPlanCard(card.id, checkbox.checked);
+                    });
+
+                    grid.appendChild(item);
+                });
+            },
+
+            togglePerfectPlanCard(cardId, isChecked) {
+                const draft = this.state.perfectPlanDraft;
+                if (!draft) return;
+                const grades = (typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.PERFECT_PLAN)
+                    ? GAME_CONSTANTS.PERFECT_PLAN.GRADES
+                    : ['legend', 'epic', 'rare', 'normal'];
+                const currentGrade = grades[draft.step] || 'legend';
+                const required = this.getPerfectPlanRequiredCount(currentGrade);
+
+                if (isChecked) {
+                    if (draft.currentGradeSelected.length >= required) {
+                        this.showAlert(`이 등급은 ${required}장까지 선택할 수 있습니다.`);
+                        this.renderPerfectPlanDraft();
+                        return;
+                    }
+                    if (!draft.currentGradeSelected.includes(cardId)) {
+                        draft.currentGradeSelected.push(cardId);
+                    }
+                } else {
+                    draft.currentGradeSelected = draft.currentGradeSelected.filter(id => id !== cardId);
+                }
+                this.saveGame(false);
+                this.renderPerfectPlanDraft();
+            },
+
+            resetPerfectPlanCurrentGrade() {
+                const draft = this.state.perfectPlanDraft;
+                if (!draft) return;
+                draft.currentGradeSelected = [];
+                this.saveGame(false);
+                this.renderPerfectPlanDraft();
+            },
+
+            confirmPerfectPlanCurrentGrade() {
+                const draft = this.state.perfectPlanDraft;
+                if (!draft) return;
+                const grades = (typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.PERFECT_PLAN)
+                    ? GAME_CONSTANTS.PERFECT_PLAN.GRADES
+                    : ['legend', 'epic', 'rare', 'normal'];
+                const currentGrade = grades[draft.step] || 'legend';
+                const required = this.getPerfectPlanRequiredCount(currentGrade);
+
+                if (draft.currentGradeSelected.length !== required) {
+                    return this.showAlert(`정확히 ${required}장을 선택해야 합니다. (현재: ${draft.currentGradeSelected.length}장)`);
+                }
+
+                draft.selected.push(...draft.currentGradeSelected);
+                draft.currentGradeSelected = [];
+                draft.step++;
+
+                if (draft.step >= grades.length) {
+                    this.finishPerfectPlanDraft();
+                } else {
+                    this.saveGame(false);
+                    this.renderPerfectPlanDraft();
+                }
+            },
+
+            goPerfectPlanPrevStep() {
+                const draft = this.state.perfectPlanDraft;
+                if (!draft || draft.step <= 0) return;
+                const grades = (typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.PERFECT_PLAN)
+                    ? GAME_CONSTANTS.PERFECT_PLAN.GRADES
+                    : ['legend', 'epic', 'rare', 'normal'];
+
+                draft.step--;
+                const prevGrade = grades[draft.step];
+                const prevRequired = this.getPerfectPlanRequiredCount(prevGrade);
+
+                draft.currentGradeSelected = draft.selected.slice(-prevRequired);
+                draft.selected = draft.selected.slice(0, -prevRequired);
+                this.saveGame(false);
+                this.renderPerfectPlanDraft();
+            },
+
+            finishPerfectPlanDraft() {
+                this.state.perfectPlanDraft.active = false;
+                this.state.factoryPool = [...this.state.perfectPlanDraft.selected];
+                this.state.inventory = [...(this.state.activeTranscendenceCards || [])];
+                this.state.deck = [null, null, null];
+                this.saveGame(false);
+
+                let msg = '퍼펙트플랜 구성이 완료되었습니다!<br>방금 고른 40장의 전용 풀을 바탕으로 모험을 시작합니다.';
+                if (this.state.activeTranscendenceCards && this.state.activeTranscendenceCards.length > 0) {
+                    msg += `<br><br>초월 카드 ${this.state.activeTranscendenceCards.length}장이 인벤토리에 합류했습니다!`;
+                }
+                this.showAlert(msg);
+                this.toMenu();
             },
 
             // --- Draft Logic ---

--- a/card/logic.js
+++ b/card/logic.js
@@ -284,6 +284,13 @@ class SaveDataMigrator {
             currentBundles: []
         }, ['pool', 'currentBundles']);
 
+        state.perfectPlanDraft = SaveDataMigrator.mergeObjectDefaults(state.perfectPlanDraft, {
+            active: false,
+            step: 0,
+            selected: [],
+            currentGradeSelected: []
+        }, ['selected', 'currentGradeSelected']);
+
         if (typeof options.normalizeBonusPoolIds === 'function') {
             state.activeBonusPoolIds = options.normalizeBonusPoolIds(state.activeBonusPoolIds);
         }
@@ -410,6 +417,12 @@ window.GAME_CONSTANTS = {
 
     DRAFT: {
         INITIAL_REROLLS: 3
+    },
+
+    PERFECT_PLAN: {
+        GRADES: ['legend', 'epic', 'rare', 'normal'],
+        PICKS_PER_GRADE: 10,
+        HIDDEN_BOSS_AFTER_STAGE: 12
     },
 
     DREAM_CORRIDOR_MAX_LIVES: 3,
@@ -939,6 +952,18 @@ const GameUtils = {
             const factorySet = new Set(options.factoryPool);
             let pool = allPossible.filter(c => factorySet.has(c.id));
             
+            if (options.specialCardSelections && Object.keys(options.specialCardSelections).length > 0) {
+                const specialById = new Map(this.getSpecialCards().map(card => [card.id, card]));
+                pool = pool.map(card => {
+                    const selectedId = options.specialCardSelections[card.id];
+                    const specialCard = specialById.get(selectedId);
+                    if (specialCard && specialCard.specialBaseId === card.id) {
+                        return specialCard;
+                    }
+                    return card;
+                });
+            }
+
             // Still respect maxGrade if specified (e.g. for great sage blessing)
             if (options.maxGrade) {
                 const gradeOrder = {
@@ -1062,6 +1087,15 @@ const GameUtils = {
         return GAME_CONSTANTS.MODE_CLEAR_STAGES[mode] !== undefined
             ? GAME_CONSTANTS.MODE_CLEAR_STAGES[mode]
             : GAME_CONSTANTS.MODE_CLEAR_STAGES.default;
+    },
+
+    /**
+     * Check if a mode uses a limited 40-card factoryPool.
+     * @param {string} mode
+     * @returns {boolean}
+     */
+    usesLimitedCardPool(mode) {
+        return mode === 'factory' || mode === 'perfect_plan';
     }
 };
 

--- a/card/rpg_features.js
+++ b/card/rpg_features.js
@@ -775,9 +775,12 @@
         ) {
             enemyId = this.getCurrentSpecialSeason().bossId;
         }
+        const hiddenAfter = (this.state.mode === 'perfect_plan')
+            ? ((typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.PERFECT_PLAN) ? GAME_CONSTANTS.PERFECT_PLAN.HIDDEN_BOSS_AFTER_STAGE : 12)
+            : 30;
         if (this.state.mode === 'puzzle' && stageNumber > rotation.length && hiddenBossMap[baseId]) {
             enemyId = hiddenBossMap[baseId];
-        } else if (this.state.gameType === 'endless' && stageNumber > 30 && hiddenBossMap[baseId] && Math.random() < 0.3) {
+        } else if (this.state.gameType === 'endless' && stageNumber > hiddenAfter && hiddenBossMap[baseId] && Math.random() < 0.3) {
             enemyId = hiddenBossMap[baseId];
         }
 
@@ -818,6 +821,30 @@
         return this.getStandardBonusCards()
             .concat(this.getHiddenBonusCards())
             .filter(card => unlocked.has(card.id));
+    },
+
+
+    getPerfectPlanGradePool(grade) {
+        const unlockedBonusIds = new Set(this.global.unlocked_bonus_cards || []);
+        const base = (typeof CARDS !== 'undefined' ? CARDS : []).filter(card =>
+            card.grade === grade
+            && !card.hide_from_gacha
+            && card.unlockSource !== 'bonus'
+            && card.unlockSource !== 'hidden'
+        );
+        const bonus = this.getUnlockedBonusCards().filter(card =>
+            card.grade === grade && unlockedBonusIds.has(card.id)
+        );
+        return this.sortCardDataByGrade([...base, ...bonus]);
+    },
+
+
+    getPerfectPlanRequiredCount(grade) {
+        const available = this.getPerfectPlanGradePool(grade).length;
+        const target = (typeof GAME_CONSTANTS !== 'undefined' && GAME_CONSTANTS.PERFECT_PLAN)
+            ? GAME_CONSTANTS.PERFECT_PLAN.PICKS_PER_GRADE
+            : 10;
+        return Math.min(target, available);
     },
 
 
@@ -1270,7 +1297,7 @@
 
     initNewGame(mode = 'origin') {
         // Origin records are closed when the next run begins; other modes close on defeat.
-        if (this.state.mode === 'origin' && this.state.enemyScale > 0) {
+        if (['origin', 'perfect_plan'].includes(this.state.mode) && this.state.enemyScale > 0) {
             this.saveRecord();
         }
 
@@ -1299,6 +1326,7 @@
             draft: { active: false, round: 0, rerolls: GAME_CONSTANTS.DRAFT.INITIAL_REROLLS, currentOptions: [] },
             factoryDraft: { active: false, round: 1, maxRounds: 10, pool: [], seenCards: [], currentBundles: [] },
             artifactReserveDraft: { active: false, round: 1, maxRounds: 4, pool: [], currentBundles: [] },
+            perfectPlanDraft: { active: false, step: 0, selected: [], currentGradeSelected: [] },
             artifactReservePool: [],
             artifacts: [],
             pendingEnemyId: null,
@@ -1350,6 +1378,15 @@
             this.state.artifactReserveDraft.pool = [];
             this.state.artifactReserveDraft.currentBundles = [];
             this.generateArtifactReserveBundles();
+        }
+
+        if (mode === 'perfect_plan') {
+            this.state.perfectPlanDraft.active = true;
+            this.state.perfectPlanDraft.step = 0;
+            this.state.perfectPlanDraft.selected = [];
+            this.state.perfectPlanDraft.currentGradeSelected = [];
+            this.state.factoryPool = [];
+            this.openPerfectPlanDraft();
         }
 
         // Origin Mode: Add Transcendence Cards directly to Inventory
@@ -1476,7 +1513,7 @@
         let pool = GameUtils.buildCardPool(this.global, {
             excludeTranscendence: true,
             excludeEvent: true,
-            factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
+            factoryPool: GameUtils.usesLimitedCardPool(this.state.mode) ? this.state.factoryPool : null,
             activeBonusPoolIds: this.state.activeBonusPoolIds,
             specialCardSelections: this.state.activeSpecialCardSelections,
             maxGrade: GameUtils.getMaxGradeForMode(this.state.mode)
@@ -1555,7 +1592,7 @@
         let pool = GameUtils.buildCardPool(this.global, {
             includeTranscendence: true,
             activeTranscendenceCards: this.state.activeTranscendenceCards,
-            factoryPool: this.state.mode === 'factory' ? this.state.factoryPool : null,
+            factoryPool: GameUtils.usesLimitedCardPool(this.state.mode) ? this.state.factoryPool : null,
             activeBonusPoolIds: this.state.activeBonusPoolIds,
             specialCardSelections: this.state.activeSpecialCardSelections,
             // [목적] 드래프트 선택지에 획득한 이벤트 카드가 등장하도록 함

--- a/scripts/verify_card_combat_regressions.js
+++ b/scripts/verify_card_combat_regressions.js
@@ -1246,6 +1246,13 @@ function run() {
     assert.strictEqual(buildScaledEnemy('default', 'challenge').maxHp, ENEMIES[0].stats.hp);
     assert.strictEqual(buildScaledEnemy('artifact_chaos', 'challenge').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.2));
     assert.strictEqual(buildScaledEnemy('artifact_reserve', 'endless').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.1));
+    assert.strictEqual(buildScaledEnemy('perfect_plan', 'endless').maxHp, Math.floor(ENEMIES[0].stats.hp * 1.1));
+    assert.strictEqual(buildScaledEnemy('origin', 'endless').maxHp, ENEMIES[0].stats.hp);
+    assert.strictEqual(GameUtils.usesLimitedCardPool('perfect_plan'), true);
+    assert.strictEqual(GameUtils.usesLimitedCardPool('factory'), true);
+    assert.strictEqual(GameUtils.usesLimitedCardPool('origin'), false);
+    const customFactoryPool = GameUtils.buildCardPool({}, { factoryPool: ['marshmallow', 'rumi'] });
+    assert.deepStrictEqual(customFactoryPool.map(c => c.id).sort(), ['marshmallow', 'rumi']);
 
     // The merchant hands 20 maximum and current mana to the next living ally.
     const merchantVictim = buildWaveUnit('grand_merchant', ['grand_merchant', 'marshmallow', 'kobold'], 0);


### PR DESCRIPTION
## 개요
엔드리스 모드에 원하는 덱을 직접 구성하여 등반하는 **퍼펙트플랜 (`perfect_plan`)** 모드를 추가합니다.

## 주요 변경 사항
1. **40장 전용 드래프트 풀 구성**:
   - 모드 진입 시 전설 10장 → 에픽 10장 → 레어 10장 → 노말 10장을 순차적으로 체크하여 총 40장의 전용 가챠 풀(`factoryPool`) 생성
   - 전용 화면(`screen-perfect-plan-draft`)에서 선택 초기화, 이전 단계 복구 기능 제공
2. **초월 카드 룰 (오리진 모드 동일)**:
   - 게임 시작 시 인벤토리에 직접 지급(`inventory.push(...activeTranscendenceCards)`)
   - 전투 종료 후 1회 사용 시 소멸(`cleanupTranscendenceCards`)
3. **난이도 및 스케일링**:
   - 적 스탯 1.1배 초기 배율(`steps = 1`) 적용
   - 히든보스 난입 시점을 13스테이지(`> 12`)부터 30% 확률로 조정
4. **소프트락 및 사이드이펙트 방지**:
   - 드래프트 도중 F5 새로고침 시 `toMenu()`에서 자동으로 드래프트 화면 복귀
   - 미완료 드래프트 상태에서 전투 진입 차단 가드 추가
   - `buildCardPool`의 `factoryPool` 분기에서 `specialCardSelections` 치환 로직 연동
   - `initNewGame`에서 오리진과 동일하게 새 런 시작 시 이전 기록(`saveRecord`) 저장
   - `verify_card_smoke.js` 문자열 무결성 보존

## 검증 내역
- `npm run lint:card`: 통과
- `node scripts/verify_card_smoke.js`: 통과
- `node scripts/verify_card_combat_regressions.js`: 퍼펙트플랜 배율 및 풀 검증 케이스 추가 통과
- `npm run verify`: 전체 테스트 스위트 통과 (유닛/통합 96개 패스, defense-v2 번들 및 뷰포트 패스)
